### PR TITLE
Build recurring discovery foundation

### DIFF
--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -130,7 +130,16 @@ jobs:
             --config config/recurring-searches.example.json \
             --started-at 2026-07-20T06:00:00Z \
             --output /tmp/generated-cycle.json
-          diff -u discovery_cycles/generated/ERL-RECURRING-DISCOVERY-BASELINE-001--20260720-060000.json /tmp/generated-cycle.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          expected = json.loads(Path("discovery_cycles/generated/ERL-RECURRING-DISCOVERY-BASELINE-001--20260720-060000.json").read_text(encoding="utf-8"))
+          generated = json.loads(Path("/tmp/generated-cycle.json").read_text(encoding="utf-8"))
+          if generated != expected:
+              raise SystemExit("Generated discovery-cycle content does not match the committed deterministic fixture.")
+          print("Generated discovery-cycle content matches the committed fixture.")
+          PY
 
       - name: Run combined activation validation
         run: python scripts/run_activation_validation.py

--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -121,5 +121,16 @@ jobs:
       - name: Validate portable evidence intake
         run: python scripts/validate_portable_evidence_intake.py
 
+      - name: Validate recurring discovery foundation
+        run: python scripts/validate_recurring_discovery.py
+
+      - name: Regenerate deterministic discovery-cycle example
+        run: |
+          python scripts/generate_discovery_cycle.py \
+            --config config/recurring-searches.example.json \
+            --started-at 2026-07-20T06:00:00Z \
+            --output /tmp/generated-cycle.json
+          diff -u discovery_cycles/generated/ERL-RECURRING-DISCOVERY-BASELINE-001--20260720-060000.json /tmp/generated-cycle.json
+
       - name: Run combined activation validation
         run: python scripts/run_activation_validation.py

--- a/config/recurring-searches.example.json
+++ b/config/recurring-searches.example.json
@@ -1,0 +1,65 @@
+{
+  "config_id": "ERL-RECURRING-DISCOVERY-BASELINE-001",
+  "enabled": true,
+  "cadence": {
+    "frequency": "daily",
+    "interval": 1,
+    "timezone": "America/Chicago"
+  },
+  "scope": {
+    "topics": [
+      "executive rhetoric",
+      "federal enforcement",
+      "constitutional and civil-rights accountability"
+    ],
+    "time_window": "rolling-14-days-with-historical-links",
+    "jurisdictions": ["United States federal"],
+    "actors": ["President", "Attorney General", "DHS Secretary", "FBI Director"],
+    "agencies": ["Department of Justice", "Federal Bureau of Investigation", "Department of Homeland Security", "Immigration and Customs Enforcement"]
+  },
+  "source_classes": [
+    "primary-legal-record",
+    "official-government",
+    "court-record",
+    "legislative-oversight",
+    "local-reporting",
+    "national-reporting",
+    "advocacy-record"
+  ],
+  "searches": [
+    {
+      "search_id": "captured-topic-refresh",
+      "query_template": "Refresh existing ledger topics for new official actions, corrections, litigation, oversight, and measurable outcomes.",
+      "discovery_class": "captured-topic-refresh",
+      "priority": "critical",
+      "enabled": true
+    },
+    {
+      "search_id": "new-federal-enforcement-incidents",
+      "query_template": "Find newly reported federal enforcement incidents involving use of force, detention, constitutional claims, or changes to investigative responsibility.",
+      "discovery_class": "new-incident",
+      "priority": "high",
+      "enabled": true
+    },
+    {
+      "search_id": "accountability-chain-contradictions",
+      "query_template": "Find contradictions between public statements, internal guidance, agency practice, court records, congressional oversight, and later policy implementation.",
+      "discovery_class": "contradiction-discovery",
+      "priority": "high",
+      "enabled": true
+    },
+    {
+      "search_id": "historical-accountability-controls",
+      "query_template": "Find historical controls and precedents for comparable enforcement, civil-rights investigation, agency self-investigation, and executive intervention.",
+      "discovery_class": "control-discovery",
+      "priority": "medium",
+      "enabled": true
+    }
+  ],
+  "review_boundary": {
+    "automation_may_propose": true,
+    "automation_may_publish": false,
+    "required_review_states": ["candidate-generated", "source-posture-reviewed", "ledger-review-required"]
+  },
+  "notes": "Automation creates discovery candidates only. It may not convert reporting into established fact or promote candidates into reviewed ledger receipts."
+}

--- a/discovery_cycles/generated/ERL-RECURRING-DISCOVERY-BASELINE-001--20260720-060000.json
+++ b/discovery_cycles/generated/ERL-RECURRING-DISCOVERY-BASELINE-001--20260720-060000.json
@@ -1,0 +1,71 @@
+{
+  "cycle_id": "ERL-RECURRING-DISCOVERY-BASELINE-001--20260720-060000",
+  "cycle_status": "planned",
+  "started_at": "2026-07-20T06:00:00Z",
+  "scope": {
+    "topics": [
+      "executive rhetoric",
+      "federal enforcement",
+      "constitutional and civil-rights accountability"
+    ],
+    "time_window": "rolling-14-days-with-historical-links",
+    "jurisdictions": ["United States federal"],
+    "actors": ["President", "Attorney General", "DHS Secretary", "FBI Director"],
+    "agencies": ["Department of Justice", "Federal Bureau of Investigation", "Department of Homeland Security", "Immigration and Customs Enforcement"]
+  },
+  "discovery_classes": [
+    "captured-topic-refresh",
+    "contradiction-discovery",
+    "control-discovery",
+    "new-incident"
+  ],
+  "source_classes": [
+    "primary-legal-record",
+    "official-government",
+    "court-record",
+    "legislative-oversight",
+    "local-reporting",
+    "national-reporting",
+    "advocacy-record"
+  ],
+  "queries": [
+    {
+      "query_id": "captured-topic-refresh",
+      "query_text": "Refresh existing ledger topics for new official actions, corrections, litigation, oversight, and measurable outcomes.",
+      "discovery_class": "captured-topic-refresh",
+      "status": "planned"
+    },
+    {
+      "query_id": "new-federal-enforcement-incidents",
+      "query_text": "Find newly reported federal enforcement incidents involving use of force, detention, constitutional claims, or changes to investigative responsibility.",
+      "discovery_class": "new-incident",
+      "status": "planned"
+    },
+    {
+      "query_id": "accountability-chain-contradictions",
+      "query_text": "Find contradictions between public statements, internal guidance, agency practice, court records, congressional oversight, and later policy implementation.",
+      "discovery_class": "contradiction-discovery",
+      "status": "planned"
+    },
+    {
+      "query_id": "historical-accountability-controls",
+      "query_text": "Find historical controls and precedents for comparable enforcement, civil-rights investigation, agency self-investigation, and executive intervention.",
+      "discovery_class": "control-discovery",
+      "status": "planned"
+    }
+  ],
+  "candidate_outputs": {
+    "new_topics": [],
+    "source_receipts": [],
+    "adjacency_links": [],
+    "control_candidates": [],
+    "contradictions": [],
+    "outcome_updates": []
+  },
+  "review_boundary": {
+    "automation_may_propose": true,
+    "automation_may_publish": false,
+    "required_review_states": ["candidate-generated", "source-posture-reviewed", "ledger-review-required"]
+  },
+  "notes": "Generated from recurring-search configuration. Planned queries are candidates only and require governed review before publication or ledger promotion."
+}

--- a/schemas/recurring-search-config.schema.json
+++ b/schemas/recurring-search-config.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger/schemas/recurring-search-config.schema.json",
+  "title": "Recurring Political Reality Search Configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["config_id", "enabled", "cadence", "scope", "source_classes", "searches", "review_boundary"],
+  "properties": {
+    "config_id": {"type": "string", "minLength": 1},
+    "enabled": {"type": "boolean"},
+    "cadence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["frequency", "interval"],
+      "properties": {
+        "frequency": {"type": "string", "enum": ["hourly", "daily", "weekly", "monthly", "manual"]},
+        "interval": {"type": "integer", "minimum": 1},
+        "timezone": {"type": "string", "minLength": 1}
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["topics", "time_window", "jurisdictions"],
+      "properties": {
+        "topics": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "time_window": {"type": "string", "minLength": 1},
+        "jurisdictions": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "actors": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "agencies": {"type": "array", "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "source_classes": {
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "primary-legal-record", "official-government", "court-record", "legislative-oversight",
+          "original-media", "local-reporting", "national-reporting", "international-reporting",
+          "partisan-or-ideological-reporting", "advocacy-record", "academic-or-expert",
+          "affected-person-or-witness", "historical-archive"
+        ]
+      }
+    },
+    "searches": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["search_id", "query_template", "discovery_class", "priority"],
+        "properties": {
+          "search_id": {"type": "string", "minLength": 1},
+          "query_template": {"type": "string", "minLength": 1},
+          "discovery_class": {
+            "type": "string",
+            "enum": ["captured-topic-refresh", "adjacent-incident", "new-incident", "historical-backfill", "control-discovery", "contradiction-discovery", "outcome-refresh"]
+          },
+          "priority": {"type": "string", "enum": ["critical", "high", "medium", "low"]},
+          "enabled": {"type": "boolean", "default": true}
+        }
+      }
+    },
+    "review_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automation_may_propose", "automation_may_publish", "required_review_states"],
+      "properties": {
+        "automation_may_propose": {"type": "boolean", "const": true},
+        "automation_may_publish": {"type": "boolean", "const": false},
+        "required_review_states": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "notes": {"type": "string"}
+  }
+}

--- a/scripts/generate_discovery_cycle.py
+++ b/scripts/generate_discovery_cycle.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Generate a governed discovery-cycle manifest from recurring-search configuration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = ROOT / "config" / "recurring-searches.example.json"
+DEFAULT_OUTPUT_DIR = ROOT / "discovery_cycles" / "generated"
+
+
+def load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Missing input file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def utc_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def build_cycle(config: dict, started_at: str) -> dict:
+    enabled_searches = [item for item in config["searches"] if item.get("enabled", True)]
+    if not enabled_searches:
+        raise SystemExit("Configuration contains no enabled searches.")
+
+    cycle_suffix = started_at.replace("-", "").replace(":", "").replace("T", "-").replace("Z", "")
+    queries = [
+        {
+            "query_id": item["search_id"],
+            "query_text": item["query_template"],
+            "discovery_class": item["discovery_class"],
+            "status": "planned",
+        }
+        for item in enabled_searches
+    ]
+
+    return {
+        "cycle_id": f"{config['config_id']}--{cycle_suffix}",
+        "cycle_status": "planned",
+        "started_at": started_at,
+        "scope": config["scope"],
+        "discovery_classes": sorted({item["discovery_class"] for item in enabled_searches}),
+        "source_classes": config["source_classes"],
+        "queries": queries,
+        "candidate_outputs": {
+            "new_topics": [],
+            "source_receipts": [],
+            "adjacency_links": [],
+            "control_candidates": [],
+            "contradictions": [],
+            "outcome_updates": [],
+        },
+        "review_boundary": config["review_boundary"],
+        "notes": "Generated from recurring-search configuration. Planned queries are candidates only and require governed review before publication or ledger promotion.",
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--started-at", help="RFC3339 timestamp; defaults to current UTC time")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_json(args.config.resolve())
+    started_at = args.started_at or utc_timestamp()
+    cycle = build_cycle(config, started_at)
+
+    output = args.output
+    if output is None:
+        DEFAULT_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+        output = DEFAULT_OUTPUT_DIR / f"{cycle['cycle_id']}.json"
+    else:
+        output = output.resolve()
+        output.parent.mkdir(parents=True, exist_ok=True)
+
+    output.write_text(json.dumps(cycle, indent=2) + "\n", encoding="utf-8")
+    print(f"Generated {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_recurring_discovery.py
+++ b/scripts/validate_recurring_discovery.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Validate recurring-search configurations and generated discovery-cycle manifests."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    from jsonschema import Draft202012Validator
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("Missing dependency: jsonschema") from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_SCHEMA = ROOT / "schemas" / "recurring-search-config.schema.json"
+CYCLE_SCHEMA = ROOT / "schemas" / "discovery-cycle.schema.json"
+CONFIG_DIR = ROOT / "config"
+CYCLE_DIR = ROOT / "discovery_cycles" / "generated"
+
+
+def load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def validate_file(path: Path, schema: dict) -> list[str]:
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(load_json(path)), key=lambda error: list(error.path))
+    return [
+        f"{path}: {'.'.join(str(part) for part in error.path) or '<root>'}: {error.message}"
+        for error in errors
+    ]
+
+
+def main() -> int:
+    config_schema = load_json(CONFIG_SCHEMA)
+    cycle_schema = load_json(CYCLE_SCHEMA)
+    config_files = sorted(CONFIG_DIR.glob("recurring-searches*.json"))
+    cycle_files = sorted(CYCLE_DIR.glob("*.json"))
+
+    if not config_files:
+        print("No recurring-search configuration files found.", file=sys.stderr)
+        return 1
+    if not cycle_files:
+        print("No generated discovery-cycle manifests found.", file=sys.stderr)
+        return 1
+
+    failures: list[str] = []
+    for path in config_files:
+        failures.extend(validate_file(path, config_schema))
+    for path in cycle_files:
+        failures.extend(validate_file(path, cycle_schema))
+
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+
+    print(f"Validated {len(config_files)} recurring-search configuration file(s).")
+    print(f"Validated {len(cycle_files)} discovery-cycle manifest file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- adds a strict recurring-search configuration schema;
- adds a governed example search configuration;
- adds an executable discovery-cycle manifest generator;
- adds recurring-discovery validation;
- adds a deterministic generated cycle fixture;
- integrates validation and reproducibility checks into GitHub Actions.

## Governance boundary

Automation may plan searches and generate candidate-cycle manifests. It may not publish findings, convert reports into established fact, or promote candidates into reviewed ledger receipts.

## Issue

Advances Issue #6, first implementation tranche.