### PR TITLE
Automate destination acknowledgment verification

### DIFF
--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -76,6 +76,10 @@ jobs:
         run: python scripts/generate_compendium_and_deliveries.py --generated-at 2026-07-20T06:00:00Z
       - name: Validate reviewed-only publication and delivery boundaries
         run: python scripts/validate_compendium_and_deliveries.py
+      - name: Generate pending propagation verification
+        run: python scripts/verify_destination_acknowledgments.py --generated-at 2026-07-20T06:00:00Z
+      - name: Validate destination propagation contracts
+        run: python scripts/validate_destination_propagation.py
       - name: Regenerate deterministic discovery-cycle example
         run: |
           python scripts/generate_discovery_cycle.py --config config/recurring-searches.example.json --started-at 2026-07-20T06:00:00Z --output /tmp/generated-cycle.json

--- a/.github/workflows/verify-destination-propagation.yml
+++ b/.github/workflows/verify-destination-propagation.yml
@@ -1,0 +1,55 @@
+name: Verify Destination Propagation
+
+on:
+  schedule:
+    - cron: "47 13 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: destination-propagation-verification
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validator
+        run: python -m pip install --upgrade jsonschema referencing
+      - name: Verify destination-owned acknowledgments
+        run: python scripts/verify_destination_acknowledgments.py
+      - name: Validate propagation manifest
+        run: python scripts/validate_destination_propagation.py
+      - name: Create or update propagation verification PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="automation/destination-propagation-verification"
+          git config user.name "stegverse-propagation-bot"
+          git config user.email "stegverse-propagation-bot@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add propagation/verification.json
+          if git diff --cached --quiet; then
+            echo "No propagation status change."
+            exit 0
+          fi
+          git commit -m "chore: refresh destination propagation verification"
+          git push --force-with-lease origin "$BRANCH"
+          BODY="Destination status is derived only from destination-owned acknowledgment receipts bound to the current compendium hash. Source automation cannot self-acknowledge delivery or close Issue #6."
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" --title "Refresh destination propagation verification" --body "$BODY"
+          else
+            gh pr create --base main --head "$BRANCH" --title "Refresh destination propagation verification" --body "$BODY"
+          fi

--- a/config/destination-adapters.json
+++ b/config/destination-adapters.json
@@ -1,0 +1,15 @@
+{
+  "source_repository": "StegVerse-Labs/Executive_Rhetoric_Ledger",
+  "source_path": "publication/compendium.json",
+  "destinations": [
+    {"repository": "StegVerse-Labs/Site", "target_path": "public/data/executive-rhetoric-ledger/compendium.json", "acknowledgment_path": "receipts/executive-rhetoric-ledger-ack.json"},
+    {"repository": "GCAT-BCAT-Engine/Publisher", "target_path": "publication_inputs/executive-rhetoric-ledger/compendium.json", "acknowledgment_path": "receipts/executive-rhetoric-ledger-ack.json"},
+    {"repository": "StegVerse-Labs/admissibility-wiki", "target_path": "data/executive-rhetoric-ledger/compendium.json", "acknowledgment_path": "receipts/executive-rhetoric-ledger-ack.json"},
+    {"repository": "StegVerse-Labs/stegguardian-wiki", "target_path": "data/executive-rhetoric-ledger/compendium.json", "acknowledgment_path": "receipts/executive-rhetoric-ledger-ack.json"}
+  ],
+  "authority": {
+    "source_may_prepare": true,
+    "destination_must_acknowledge": true,
+    "source_may_self_acknowledge": false
+  }
+}

--- a/schemas/destination-acknowledgment.schema.json
+++ b/schemas/destination-acknowledgment.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger/schemas/destination-acknowledgment.schema.json",
+  "title": "Destination-Owned Publication Acknowledgment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["acknowledgment_id", "destination_repository", "destination_commit", "source_publication", "target_path", "validation", "status", "authority"],
+  "properties": {
+    "acknowledgment_id": {"type": "string", "minLength": 1},
+    "destination_repository": {"type": "string", "minLength": 1},
+    "destination_commit": {"type": "string", "pattern": "^[a-f0-9]{40}$"},
+    "source_publication": {
+      "type": "object", "additionalProperties": false,
+      "required": ["repository", "path", "sha256"],
+      "properties": {
+        "repository": {"const": "StegVerse-Labs/Executive_Rhetoric_Ledger"},
+        "path": {"const": "publication/compendium.json"},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      }
+    },
+    "target_path": {"type": "string", "minLength": 1},
+    "validation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["validated_at", "validator", "content_hash_matches", "destination_checks_passed"],
+      "properties": {
+        "validated_at": {"type": "string", "format": "date-time"},
+        "validator": {"type": "string", "minLength": 1},
+        "content_hash_matches": {"const": true},
+        "destination_checks_passed": {"const": true}
+      }
+    },
+    "status": {"const": "acknowledged"},
+    "authority": {
+      "type": "object", "additionalProperties": false,
+      "required": ["owned_by_destination", "source_may_self_acknowledge"],
+      "properties": {
+        "owned_by_destination": {"const": true},
+        "source_may_self_acknowledge": {"const": false}
+      }
+    }
+  }
+}

--- a/schemas/propagation-verification.schema.json
+++ b/schemas/propagation-verification.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger/schemas/propagation-verification.schema.json",
+  "title": "Propagation Verification Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["manifest_id", "generated_at", "source_sha256", "required_destinations", "destination_status", "complete", "authority"],
+  "properties": {
+    "manifest_id": {"type": "string", "minLength": 1},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "source_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "required_destinations": {"type": "array", "minItems": 4, "uniqueItems": true, "items": {"type": "string"}},
+    "destination_status": {
+      "type": "array", "minItems": 4,
+      "items": {
+        "type": "object", "additionalProperties": false,
+        "required": ["repository", "status", "acknowledgment_path"],
+        "properties": {
+          "repository": {"type": "string"},
+          "status": {"enum": ["pending", "acknowledged", "failed", "deprecated"]},
+          "acknowledgment_path": {"type": ["string", "null"]},
+          "destination_commit": {"type": ["string", "null"]},
+          "reason": {"type": ["string", "null"]}
+        }
+      }
+    },
+    "complete": {"type": "boolean"},
+    "authority": {
+      "type": "object", "additionalProperties": false,
+      "required": ["may_verify", "may_fabricate_acknowledgment", "may_close_issue"],
+      "properties": {
+        "may_verify": {"const": true},
+        "may_fabricate_acknowledgment": {"const": false},
+        "may_close_issue": {"const": false}
+      }
+    }
+  }
+}

--- a/scripts/validate_destination_propagation.py
+++ b/scripts/validate_destination_propagation.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Validate destination adapter, acknowledgment, and propagation authority boundaries."""
+import json
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+config = json.loads((ROOT / "config/destination-adapters.json").read_text(encoding="utf-8"))
+repositories = [item["repository"] for item in config["destinations"]]
+required = {
+    "StegVerse-Labs/Site",
+    "GCAT-BCAT-Engine/Publisher",
+    "StegVerse-Labs/admissibility-wiki",
+    "StegVerse-Labs/stegguardian-wiki",
+}
+if set(repositories) != required or len(repositories) != len(set(repositories)):
+    raise SystemExit("Destination adapter registry must contain each required destination exactly once.")
+if config["authority"] != {"source_may_prepare": True, "destination_must_acknowledge": True, "source_may_self_acknowledge": False}:
+    raise SystemExit("Destination adapter authority boundary is invalid.")
+
+for schema_name in ["destination-acknowledgment.schema.json", "propagation-verification.schema.json"]:
+    schema = json.loads((ROOT / "schemas" / schema_name).read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+
+manifest_path = ROOT / "propagation" / "verification.json"
+if manifest_path.exists():
+    schema = json.loads((ROOT / "schemas/propagation-verification.schema.json").read_text(encoding="utf-8"))
+    document = json.loads(manifest_path.read_text(encoding="utf-8"))
+    errors = list(Draft202012Validator(schema).iter_errors(document))
+    if errors:
+        raise SystemExit("Propagation verification manifest failed schema validation.")
+    if document["authority"]["may_fabricate_acknowledgment"] or document["authority"]["may_close_issue"]:
+        raise SystemExit("Propagation verifier exceeded its authority.")
+
+print("Validated destination propagation contracts and authority boundaries.")

--- a/scripts/verify_destination_acknowledgments.py
+++ b/scripts/verify_destination_acknowledgments.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Verify destination-owned acknowledgment receipts without self-acknowledgment."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def fetch_json(url: str) -> dict | None:
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError):
+        return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--generated-at")
+    parser.add_argument("--output", default="propagation/verification.json")
+    args = parser.parse_args()
+
+    config = load_json(ROOT / "config/destination-adapters.json")
+    source_bytes = (ROOT / config["source_path"]).read_bytes()
+    source_hash = hashlib.sha256(source_bytes).hexdigest()
+    generated_at = args.generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    statuses = []
+    for destination in config["destinations"]:
+        repository = destination["repository"]
+        ack_path = destination["acknowledgment_path"]
+        url = f"https://raw.githubusercontent.com/{repository}/main/{ack_path}"
+        receipt = fetch_json(url)
+        status = "pending"
+        commit = None
+        reason = "destination acknowledgment not found"
+        if receipt:
+            authority = receipt.get("authority", {})
+            source = receipt.get("source_publication", {})
+            validation = receipt.get("validation", {})
+            valid = (
+                receipt.get("destination_repository") == repository
+                and receipt.get("status") == "acknowledged"
+                and source.get("repository") == config["source_repository"]
+                and source.get("path") == config["source_path"]
+                and source.get("sha256") == source_hash
+                and receipt.get("target_path") == destination["target_path"]
+                and validation.get("content_hash_matches") is True
+                and validation.get("destination_checks_passed") is True
+                and authority.get("owned_by_destination") is True
+                and authority.get("source_may_self_acknowledge") is False
+            )
+            if valid:
+                status = "acknowledged"
+                commit = receipt.get("destination_commit")
+                reason = None
+            else:
+                status = "failed"
+                reason = "destination receipt exists but failed binding or authority checks"
+        statuses.append({
+            "repository": repository,
+            "status": status,
+            "acknowledgment_path": ack_path if receipt else None,
+            "destination_commit": commit,
+            "reason": reason,
+        })
+
+    complete = all(item["status"] in {"acknowledged", "deprecated"} for item in statuses)
+    document = {
+        "manifest_id": f"PROP-{source_hash[:20].upper()}",
+        "generated_at": generated_at,
+        "source_sha256": source_hash,
+        "required_destinations": [item["repository"] for item in config["destinations"]],
+        "destination_status": statuses,
+        "complete": complete,
+        "authority": {"may_verify": True, "may_fabricate_acknowledgment": False, "may_close_issue": False},
+    }
+    output = ROOT / args.output
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(output.relative_to(ROOT))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- defines destination-owned acknowledgment and propagation-verification schemas;
- registers the four required destination adapters;
- verifies destination receipts against the current reviewed compendium SHA-256;
- prevents source-side self-acknowledgment and automatic Issue #6 closure;
- adds scheduled propagation verification and automatic status-PR refresh;
- integrates propagation contracts into complete CI validation.

## Authority boundary

The source repository may verify destination evidence. It may not fabricate delivery, acknowledgment, destination validation, or completion authority.

Advances Issue #6 toward destination integration and closure.