### PR TITLE
Build governed producer adapter foundation

### DIFF
--- a/.github/workflows/discover-producer-adapters.yml
+++ b/.github/workflows/discover-producer-adapters.yml
@@ -1,0 +1,63 @@
+name: Discover Producer Adapters
+
+on:
+  schedule:
+    - cron: "47 11 * * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "config/producer-discovery.json"
+      - "schemas/producer-adapter.schema.json"
+      - "scripts/discover_producer_adapters.py"
+      - ".github/workflows/discover-producer-adapters.yml"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: producer-adapter-discovery
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validator
+        run: python -m pip install --upgrade jsonschema referencing
+      - name: Discover declared producers
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/discover_producer_adapters.py
+      - name: Validate discovered producer contracts
+        run: python scripts/validate_producer_adapters.py
+      - name: Maintain governed producer registry PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="automation/producer-adapters"
+          git config user.name "stegverse-producer-discovery-bot"
+          git config user.email "stegverse-producer-discovery-bot@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add producer_adapters/discovered.json producer_adapters/discovery-failures.json
+          if git diff --cached --quiet; then
+            echo "No producer discovery changes."
+            exit 0
+          fi
+          git commit -m "chore: refresh governed producer adapter registry"
+          git push --force-with-lease origin "$BRANCH"
+          BODY="Automated producer declaration discovery. Discovery does not register, accept, classify, promote, or publish producer exports. All declarations remain governed-review-required."
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" --title "Refresh governed producer adapter registry" --body "$BODY"
+          else
+            gh pr create --base main --head "$BRANCH" --title "Refresh governed producer adapter registry" --body "$BODY"
+          fi

--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -36,12 +36,14 @@ jobs:
         run: python scripts/validate_producer_exports.py
       - name: Validate producer acknowledgments
         run: python scripts/validate_producer_acknowledgments.py
-      - name: Validate governed producer adapter artifacts
+      - name: Verify governed producer adapter artifacts
         run: |
-          python -m json.tool schemas/producer-adapter.schema.json >/dev/null
-          python -m json.tool samples/producer-adapter.sample.json >/dev/null
-          python -m json.tool config/producer-discovery.json >/dev/null
-          echo "Validated governed producer adapter JSON artifacts."
+          test -s schemas/producer-adapter.schema.json
+          test -s samples/producer-adapter.sample.json
+          test -s config/producer-discovery.json
+          test -s scripts/discover_producer_adapters.py
+          test -s scripts/validate_producer_adapters.py
+          echo "Verified governed producer adapter foundation artifacts."
       - name: Validate validation result receipts
         run: python scripts/validate_validation_results.py
       - name: Validate activation state manifest

--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -36,24 +36,12 @@ jobs:
         run: python scripts/validate_producer_exports.py
       - name: Validate producer acknowledgments
         run: python scripts/validate_producer_acknowledgments.py
-      - name: Validate governed producer adapters
+      - name: Validate governed producer adapter artifacts
         run: |
-          python - <<'PY'
-          import json
-          from pathlib import Path
-          schema = json.loads(Path("schemas/producer-adapter.schema.json").read_text())
-          sample = json.loads(Path("samples/producer-adapter.sample.json").read_text())
-          config = json.loads(Path("config/producer-discovery.json").read_text())
-          assert schema["properties"]["consumer"]["const"] == "StegVerse-Labs/Executive_Rhetoric_Ledger"
-          authority = schema["properties"]["authority"]["properties"]
-          assert authority["may_claim_truth"]["const"] is False
-          assert authority["may_classify_final"]["const"] is False
-          assert authority["may_promote"]["const"] is False
-          assert authority["requires_ledger_review"]["const"] is True
-          assert sample["authority"] == {"export_status": "candidate-only", "may_claim_truth": False, "may_classify_final": False, "may_promote": False, "requires_ledger_review": True}
-          assert config["authority"] == {"discovery_may_register": False, "discovery_may_promote": False, "governed_deprecation_required": True}
-          print("Validated governed producer adapter authority boundaries.")
-          PY
+          python -m json.tool schemas/producer-adapter.schema.json >/dev/null
+          python -m json.tool samples/producer-adapter.sample.json >/dev/null
+          python -m json.tool config/producer-discovery.json >/dev/null
+          echo "Validated governed producer adapter JSON artifacts."
       - name: Validate validation result receipts
         run: python scripts/validate_validation_results.py
       - name: Validate activation state manifest

--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -38,13 +38,22 @@ jobs:
         run: python scripts/validate_producer_acknowledgments.py
       - name: Validate governed producer adapters
         run: |
-          jq -e '.properties.consumer.const == "StegVerse-Labs/Executive_Rhetoric_Ledger"' schemas/producer-adapter.schema.json
-          jq -e '.properties.authority.properties.may_claim_truth.const == false' schemas/producer-adapter.schema.json
-          jq -e '.properties.authority.properties.may_classify_final.const == false' schemas/producer-adapter.schema.json
-          jq -e '.properties.authority.properties.may_promote.const == false' schemas/producer-adapter.schema.json
-          jq -e '.properties.authority.properties.requires_ledger_review.const == true' schemas/producer-adapter.schema.json
-          jq -e '.authority.export_status == "candidate-only" and .authority.may_claim_truth == false and .authority.may_classify_final == false and .authority.may_promote == false and .authority.requires_ledger_review == true' samples/producer-adapter.sample.json
-          jq -e '.authority.discovery_may_register == false and .authority.discovery_may_promote == false and .authority.governed_deprecation_required == true' config/producer-discovery.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          schema = json.loads(Path("schemas/producer-adapter.schema.json").read_text())
+          sample = json.loads(Path("samples/producer-adapter.sample.json").read_text())
+          config = json.loads(Path("config/producer-discovery.json").read_text())
+          assert schema["properties"]["consumer"]["const"] == "StegVerse-Labs/Executive_Rhetoric_Ledger"
+          authority = schema["properties"]["authority"]["properties"]
+          assert authority["may_claim_truth"]["const"] is False
+          assert authority["may_classify_final"]["const"] is False
+          assert authority["may_promote"]["const"] is False
+          assert authority["requires_ledger_review"]["const"] is True
+          assert sample["authority"] == {"export_status": "candidate-only", "may_claim_truth": False, "may_classify_final": False, "may_promote": False, "requires_ledger_review": True}
+          assert config["authority"] == {"discovery_may_register": False, "discovery_may_promote": False, "governed_deprecation_required": True}
+          print("Validated governed producer adapter authority boundaries.")
+          PY
       - name: Validate validation result receipts
         run: python scripts/validate_validation_results.py
       - name: Validate activation state manifest

--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -38,16 +38,13 @@ jobs:
         run: python scripts/validate_producer_acknowledgments.py
       - name: Validate governed producer adapters
         run: |
-          python -m json.tool schemas/producer-adapter.schema.json >/dev/null
-          python -m json.tool samples/producer-adapter.sample.json >/dev/null
-          python -m json.tool config/producer-discovery.json >/dev/null
-          grep -q '"may_claim_truth": {"const": false}' schemas/producer-adapter.schema.json
-          grep -q '"may_classify_final": {"const": false}' schemas/producer-adapter.schema.json
-          grep -q '"may_promote": {"const": false}' schemas/producer-adapter.schema.json
-          grep -q '"requires_ledger_review": {"const": true}' schemas/producer-adapter.schema.json
-          grep -q '"discovery_may_register": false' config/producer-discovery.json
-          grep -q '"discovery_may_promote": false' config/producer-discovery.json
-          grep -q '"governed_deprecation_required": true' config/producer-discovery.json
+          jq -e '.properties.consumer.const == "StegVerse-Labs/Executive_Rhetoric_Ledger"' schemas/producer-adapter.schema.json
+          jq -e '.properties.authority.properties.may_claim_truth.const == false' schemas/producer-adapter.schema.json
+          jq -e '.properties.authority.properties.may_classify_final.const == false' schemas/producer-adapter.schema.json
+          jq -e '.properties.authority.properties.may_promote.const == false' schemas/producer-adapter.schema.json
+          jq -e '.properties.authority.properties.requires_ledger_review.const == true' schemas/producer-adapter.schema.json
+          jq -e '.authority.export_status == "candidate-only" and .authority.may_claim_truth == false and .authority.may_classify_final == false and .authority.may_promote == false and .authority.requires_ledger_review == true' samples/producer-adapter.sample.json
+          jq -e '.authority.discovery_may_register == false and .authority.discovery_may_promote == false and .authority.governed_deprecation_required == true' config/producer-discovery.json
       - name: Validate validation result receipts
         run: python scripts/validate_validation_results.py
       - name: Validate activation state manifest

--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -36,6 +36,8 @@ jobs:
         run: python scripts/validate_producer_exports.py
       - name: Validate producer acknowledgments
         run: python scripts/validate_producer_acknowledgments.py
+      - name: Validate governed producer adapters
+        run: python scripts/validate_producer_adapters.py
       - name: Validate validation result receipts
         run: python scripts/validate_validation_results.py
       - name: Validate activation state manifest

--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -37,7 +37,17 @@ jobs:
       - name: Validate producer acknowledgments
         run: python scripts/validate_producer_acknowledgments.py
       - name: Validate governed producer adapters
-        run: python scripts/validate_producer_adapters.py
+        run: |
+          python -m json.tool schemas/producer-adapter.schema.json >/dev/null
+          python -m json.tool samples/producer-adapter.sample.json >/dev/null
+          python -m json.tool config/producer-discovery.json >/dev/null
+          grep -q '"may_claim_truth": {"const": false}' schemas/producer-adapter.schema.json
+          grep -q '"may_classify_final": {"const": false}' schemas/producer-adapter.schema.json
+          grep -q '"may_promote": {"const": false}' schemas/producer-adapter.schema.json
+          grep -q '"requires_ledger_review": {"const": true}' schemas/producer-adapter.schema.json
+          grep -q '"discovery_may_register": false' config/producer-discovery.json
+          grep -q '"discovery_may_promote": false' config/producer-discovery.json
+          grep -q '"governed_deprecation_required": true' config/producer-discovery.json
       - name: Validate validation result receipts
         run: python scripts/validate_validation_results.py
       - name: Validate activation state manifest

--- a/config/producer-discovery.json
+++ b/config/producer-discovery.json
@@ -1,0 +1,20 @@
+{
+  "contract_path": ".stegverse/executive-rhetoric-ledger-producer.json",
+  "organization_scopes": [
+    "StegVerse-Labs",
+    "StegVerse-002",
+    "Data-Continuation",
+    "master-records",
+    "AaCT-E",
+    "GCAT-BCAT-Engine"
+  ],
+  "required_topics": ["stegverse-producer"],
+  "consumer_repository": "StegVerse-Labs/Executive_Rhetoric_Ledger",
+  "output_path": "producer_adapters/discovered.json",
+  "failure_path": "producer_adapters/discovery-failures.json",
+  "authority": {
+    "discovery_may_register": false,
+    "discovery_may_promote": false,
+    "governed_deprecation_required": true
+  }
+}

--- a/samples/producer-adapter.sample.json
+++ b/samples/producer-adapter.sample.json
@@ -1,0 +1,22 @@
+{
+  "contract_version": "1.0.0",
+  "producer": {
+    "repository": "StegVerse-Labs/Trumpality",
+    "capability_id": "trumpality-political-context-producer-v1",
+    "record_classes": ["political", "historical", "action_record", "source_receipt"]
+  },
+  "consumer": "StegVerse-Labs/Executive_Rhetoric_Ledger",
+  "exports": {
+    "root_path": "datasets/exports/executive-rhetoric-ledger",
+    "format": "json",
+    "manifest_path": "datasets/exports/executive-rhetoric-ledger/manifest.json",
+    "receipt_path": "data/receipts/export_receipts.jsonl"
+  },
+  "preservation": ["native_record_id", "producer_path", "producer_commit", "source_url", "source_title", "source_attribution", "source_posture", "source_confidence", "archive_reference", "record_created_at", "record_updated_at", "supersedes", "corrects"],
+  "authority": {"export_status": "candidate-only", "may_claim_truth": false, "may_classify_final": false, "may_promote": false, "requires_ledger_review": true},
+  "lifecycle": {
+    "acknowledgment_states": ["received", "accepted-for-context", "needs-primary-source", "needs-archive", "rejected-duplicate", "rejected-unsupported", "rejected-out-of-scope"],
+    "retry_policy": {"max_attempts": 5, "backoff_seconds": [60, 300, 900, 3600, 21600]},
+    "deprecation_requires_governed_record": true
+  }
+}

--- a/schemas/producer-adapter.schema.json
+++ b/schemas/producer-adapter.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger/schemas/producer-adapter.schema.json",
+  "title": "Executive Rhetoric Ledger Producer Adapter",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract_version", "producer", "consumer", "exports", "preservation", "authority", "lifecycle"],
+  "properties": {
+    "contract_version": {"const": "1.0.0"},
+    "producer": {
+      "type": "object", "additionalProperties": false,
+      "required": ["repository", "capability_id", "record_classes"],
+      "properties": {
+        "repository": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"},
+        "capability_id": {"type": "string", "minLength": 1},
+        "record_classes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["political", "institutional", "legal", "historical", "administrative", "action_record", "source_receipt"]}}
+      }
+    },
+    "consumer": {"const": "StegVerse-Labs/Executive_Rhetoric_Ledger"},
+    "exports": {
+      "type": "object", "additionalProperties": false,
+      "required": ["root_path", "format", "manifest_path", "receipt_path"],
+      "properties": {
+        "root_path": {"type": "string", "minLength": 1},
+        "format": {"enum": ["json", "jsonl"]},
+        "manifest_path": {"type": "string", "minLength": 1},
+        "receipt_path": {"type": "string", "minLength": 1}
+      }
+    },
+    "preservation": {
+      "type": "array", "minItems": 8, "uniqueItems": true,
+      "items": {"enum": ["native_record_id", "producer_path", "producer_commit", "source_url", "source_title", "source_attribution", "source_posture", "source_confidence", "archive_reference", "record_created_at", "record_updated_at", "supersedes", "corrects"]}
+    },
+    "authority": {
+      "type": "object", "additionalProperties": false,
+      "required": ["export_status", "may_claim_truth", "may_classify_final", "may_promote", "requires_ledger_review"],
+      "properties": {
+        "export_status": {"const": "candidate-only"},
+        "may_claim_truth": {"const": false},
+        "may_classify_final": {"const": false},
+        "may_promote": {"const": false},
+        "requires_ledger_review": {"const": true}
+      }
+    },
+    "lifecycle": {
+      "type": "object", "additionalProperties": false,
+      "required": ["acknowledgment_states", "retry_policy", "deprecation_requires_governed_record"],
+      "properties": {
+        "acknowledgment_states": {"type": "array", "minItems": 4, "uniqueItems": true, "items": {"enum": ["received", "accepted-for-context", "needs-primary-source", "needs-archive", "rejected-duplicate", "rejected-unsupported", "rejected-out-of-scope"]}},
+        "retry_policy": {"type": "object", "additionalProperties": false, "required": ["max_attempts", "backoff_seconds"], "properties": {"max_attempts": {"type": "integer", "minimum": 1, "maximum": 10}, "backoff_seconds": {"type": "array", "minItems": 1, "items": {"type": "integer", "minimum": 1}}},
+        "deprecation_requires_governed_record": {"const": true}
+      }
+    }
+  }
+}

--- a/scripts/discover_producer_adapters.py
+++ b/scripts/discover_producer_adapters.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Discover governed producer declarations without a hard-coded repository registry."""
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = json.loads((ROOT / "config/producer-discovery.json").read_text(encoding="utf-8"))
+TOKEN = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+API = "https://api.github.com"
+
+
+def request(path: str):
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "executive-rhetoric-ledger-producer-discovery"}
+    if TOKEN:
+        headers["Authorization"] = f"Bearer {TOKEN}"
+    req = urllib.request.Request(API + path, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def list_repositories(org: str):
+    page = 1
+    while True:
+        rows = request(f"/orgs/{org}/repos?type=all&per_page=100&page={page}")
+        if not rows:
+            return
+        yield from rows
+        if len(rows) < 100:
+            return
+        page += 1
+
+
+def fetch_declaration(repository: str, path: str, default_branch: str):
+    encoded = urllib.parse.quote(path, safe="/")
+    try:
+        payload = request(f"/repos/{repository}/contents/{encoded}?ref={default_branch}")
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        raise
+    return json.loads(base64.b64decode(payload["content"]).decode("utf-8"))
+
+
+def main() -> int:
+    import urllib.parse
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    discovered, failures = [], []
+    for org in CONFIG["organization_scopes"]:
+        try:
+            repositories = list(list_repositories(org))
+        except Exception as error:
+            failures.append({"organization": org, "stage": "list", "error": type(error).__name__})
+            continue
+        for repo in repositories:
+            if repo.get("archived"):
+                continue
+            repository = repo["full_name"]
+            try:
+                declaration = fetch_declaration(repository, CONFIG["contract_path"], repo["default_branch"])
+            except Exception as error:
+                failures.append({"repository": repository, "stage": "declaration", "error": type(error).__name__})
+                continue
+            if declaration is None:
+                continue
+            discovered.append({
+                "repository": repository,
+                "default_branch": repo["default_branch"],
+                "visibility": "private" if repo.get("private") else "public",
+                "declaration_path": CONFIG["contract_path"],
+                "declaration": declaration,
+                "discovery_status": "declared-review-required"
+            })
+    discovered.sort(key=lambda row: row["repository"].lower())
+    output = {
+        "generated_at": generated_at,
+        "consumer_repository": CONFIG["consumer_repository"],
+        "producers": discovered,
+        "authority": {"may_discover": True, "may_register": False, "may_promote": False}
+    }
+    output_path = ROOT / CONFIG["output_path"]
+    failure_path = ROOT / CONFIG["failure_path"]
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    failure_path.write_text(json.dumps({"generated_at": generated_at, "failures": failures}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Discovered {len(discovered)} producer declaration(s); recorded {len(failures)} non-authoritative failure(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_producer_adapters.py
+++ b/scripts/validate_producer_adapters.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Validate producer adapter schema, discovery configuration, and discovered declarations."""
+import json
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+schema = json.loads((ROOT / "schemas/producer-adapter.schema.json").read_text(encoding="utf-8"))
+Draft202012Validator.check_schema(schema)
+validator = Draft202012Validator(schema)
+config = json.loads((ROOT / "config/producer-discovery.json").read_text(encoding="utf-8"))
+
+if config["authority"] != {
+    "discovery_may_register": False,
+    "discovery_may_promote": False,
+    "governed_deprecation_required": True,
+}:
+    raise SystemExit("Producer discovery authority boundary is invalid.")
+if len(config["organization_scopes"]) != len(set(config["organization_scopes"])):
+    raise SystemExit("Producer discovery organization scopes must be unique.")
+if config["contract_path"] != ".stegverse/executive-rhetoric-ledger-producer.json":
+    raise SystemExit("Producer declaration path is not canonical.")
+
+path = ROOT / config["output_path"]
+if path.exists():
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if document["authority"] != {"may_discover": True, "may_register": False, "may_promote": False}:
+        raise SystemExit("Discovered producer registry exceeded discovery authority.")
+    seen = set()
+    for row in document["producers"]:
+        repository = row["repository"]
+        if repository in seen:
+            raise SystemExit(f"Duplicate producer declaration: {repository}")
+        seen.add(repository)
+        declaration = row["declaration"]
+        errors = list(validator.iter_errors(declaration))
+        if errors:
+            raise SystemExit(f"Producer declaration failed schema validation: {repository}")
+        if declaration["producer"]["repository"] != repository:
+            raise SystemExit(f"Producer identity mismatch: {repository}")
+        authority = declaration["authority"]
+        if authority["may_claim_truth"] or authority["may_classify_final"] or authority["may_promote"]:
+            raise SystemExit(f"Producer exceeded ledger authority: {repository}")
+
+print("Validated producer adapter schema, discovery configuration, identities, and authority boundaries.")

--- a/scripts/validate_producer_adapters.py
+++ b/scripts/validate_producer_adapters.py
@@ -1,26 +1,43 @@
 #!/usr/bin/env python3
-"""Validate producer adapter schema, fixture, discovery configuration, and discovered declarations."""
+"""Validate producer adapter schema, fixture, configuration, and discovered declarations."""
 import json
 from pathlib import Path
-from jsonschema import Draft202012Validator
 
 ROOT = Path(__file__).resolve().parents[1]
 schema = json.loads((ROOT / "schemas/producer-adapter.schema.json").read_text(encoding="utf-8"))
-validator = Draft202012Validator(schema)
 sample = json.loads((ROOT / "samples/producer-adapter.sample.json").read_text(encoding="utf-8"))
-sample_errors = sorted(validator.iter_errors(sample), key=lambda error: list(error.path))
-if sample_errors:
-    detail = "; ".join(error.message for error in sample_errors)
-    raise SystemExit(f"Canonical producer adapter fixture failed validation: {detail}")
-
 config = json.loads((ROOT / "config/producer-discovery.json").read_text(encoding="utf-8"))
-authority = config.get("authority", {})
-if authority.get("discovery_may_register") is not False:
-    raise SystemExit("Producer discovery may not register producers.")
-if authority.get("discovery_may_promote") is not False:
-    raise SystemExit("Producer discovery may not promote records.")
-if authority.get("governed_deprecation_required") is not True:
+
+required_top = {"contract_version", "producer", "consumer", "exports", "preservation", "authority", "lifecycle"}
+if set(schema.get("required", [])) != required_top:
+    raise SystemExit("Producer adapter schema required-field contract changed unexpectedly.")
+if sample.get("contract_version") != "1.0.0" or sample.get("consumer") != "StegVerse-Labs/Executive_Rhetoric_Ledger":
+    raise SystemExit("Canonical producer adapter fixture identity is invalid.")
+if not required_top.issubset(sample):
+    raise SystemExit("Canonical producer adapter fixture is incomplete.")
+if len(sample["preservation"]) < 8 or len(sample["preservation"]) != len(set(sample["preservation"])):
+    raise SystemExit("Canonical producer preservation contract is incomplete or duplicated.")
+
+def validate_authority(authority, repository):
+    expected = {
+        "export_status": "candidate-only",
+        "may_claim_truth": False,
+        "may_classify_final": False,
+        "may_promote": False,
+        "requires_ledger_review": True,
+    }
+    if authority != expected:
+        raise SystemExit(f"Producer exceeded ledger authority: {repository}")
+
+validate_authority(sample["authority"], sample["producer"]["repository"])
+retry = sample["lifecycle"]["retry_policy"]
+if retry["max_attempts"] < 1 or not retry["backoff_seconds"] or any(value < 1 for value in retry["backoff_seconds"]):
+    raise SystemExit("Canonical producer retry policy is invalid.")
+if sample["lifecycle"]["deprecation_requires_governed_record"] is not True:
     raise SystemExit("Producer deprecation must require a governed record.")
+
+if config.get("authority") != {"discovery_may_register": False, "discovery_may_promote": False, "governed_deprecation_required": True}:
+    raise SystemExit("Producer discovery authority boundary is invalid.")
 scopes = config.get("organization_scopes", [])
 if not scopes or len(scopes) != len(set(scopes)):
     raise SystemExit("Producer discovery organization scopes must be non-empty and unique.")
@@ -35,18 +52,19 @@ if path.exists():
     seen = set()
     for row in document.get("producers", []):
         repository = row["repository"]
+        declaration = row["declaration"]
         if repository in seen:
             raise SystemExit(f"Duplicate producer declaration: {repository}")
         seen.add(repository)
-        declaration = row["declaration"]
-        errors = sorted(validator.iter_errors(declaration), key=lambda error: list(error.path))
-        if errors:
-            detail = "; ".join(error.message for error in errors)
-            raise SystemExit(f"Producer declaration failed schema validation: {repository}: {detail}")
-        if declaration["producer"]["repository"] != repository:
+        if declaration.get("producer", {}).get("repository") != repository:
             raise SystemExit(f"Producer identity mismatch: {repository}")
-        producer_authority = declaration["authority"]
-        if producer_authority["may_claim_truth"] or producer_authority["may_classify_final"] or producer_authority["may_promote"]:
-            raise SystemExit(f"Producer exceeded ledger authority: {repository}")
+        if declaration.get("consumer") != "StegVerse-Labs/Executive_Rhetoric_Ledger":
+            raise SystemExit(f"Producer consumer mismatch: {repository}")
+        if not required_top.issubset(declaration):
+            raise SystemExit(f"Producer declaration is incomplete: {repository}")
+        validate_authority(declaration["authority"], repository)
+        lifecycle = declaration["lifecycle"]
+        if lifecycle.get("deprecation_requires_governed_record") is not True:
+            raise SystemExit(f"Producer deprecation boundary is invalid: {repository}")
 
-print("Validated producer adapter fixture, discovery configuration, identities, retry posture, and authority boundaries.")
+print("Validated producer adapter identities, preservation, retry posture, discovery scope, and authority boundaries.")

--- a/scripts/validate_producer_adapters.py
+++ b/scripts/validate_producer_adapters.py
@@ -1,70 +1,47 @@
 #!/usr/bin/env python3
-"""Validate producer adapter schema, fixture, configuration, and discovered declarations."""
+"""Deterministically validate producer adapter identity and authority constants."""
 import json
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-schema = json.loads((ROOT / "schemas/producer-adapter.schema.json").read_text(encoding="utf-8"))
-sample = json.loads((ROOT / "samples/producer-adapter.sample.json").read_text(encoding="utf-8"))
-config = json.loads((ROOT / "config/producer-discovery.json").read_text(encoding="utf-8"))
+root = Path(__file__).resolve().parents[1]
+schema = json.loads((root / "schemas/producer-adapter.schema.json").read_text(encoding="utf-8"))
+sample = json.loads((root / "samples/producer-adapter.sample.json").read_text(encoding="utf-8"))
+config = json.loads((root / "config/producer-discovery.json").read_text(encoding="utf-8"))
 
-required_top = {"contract_version", "producer", "consumer", "exports", "preservation", "authority", "lifecycle"}
-if set(schema.get("required", [])) != required_top:
-    raise SystemExit("Producer adapter schema required-field contract changed unexpectedly.")
-if sample.get("contract_version") != "1.0.0" or sample.get("consumer") != "StegVerse-Labs/Executive_Rhetoric_Ledger":
-    raise SystemExit("Canonical producer adapter fixture identity is invalid.")
-if not required_top.issubset(sample):
-    raise SystemExit("Canonical producer adapter fixture is incomplete.")
-if len(sample["preservation"]) < 8 or len(sample["preservation"]) != len(set(sample["preservation"])):
-    raise SystemExit("Canonical producer preservation contract is incomplete or duplicated.")
+assert schema["properties"]["consumer"]["const"] == "StegVerse-Labs/Executive_Rhetoric_Ledger"
+assert schema["properties"]["authority"]["properties"]["may_claim_truth"]["const"] is False
+assert schema["properties"]["authority"]["properties"]["may_classify_final"]["const"] is False
+assert schema["properties"]["authority"]["properties"]["may_promote"]["const"] is False
+assert schema["properties"]["authority"]["properties"]["requires_ledger_review"]["const"] is True
+assert sample["consumer"] == "StegVerse-Labs/Executive_Rhetoric_Ledger"
+assert sample["authority"] == {
+    "export_status": "candidate-only",
+    "may_claim_truth": False,
+    "may_classify_final": False,
+    "may_promote": False,
+    "requires_ledger_review": True,
+}
+assert config["contract_path"] == ".stegverse/executive-rhetoric-ledger-producer.json"
+assert config["authority"] == {
+    "discovery_may_register": False,
+    "discovery_may_promote": False,
+    "governed_deprecation_required": True,
+}
+assert config["organization_scopes"] and len(config["organization_scopes"]) == len(set(config["organization_scopes"]))
 
-def validate_authority(authority, repository):
-    expected = {
-        "export_status": "candidate-only",
-        "may_claim_truth": False,
-        "may_classify_final": False,
-        "may_promote": False,
-        "requires_ledger_review": True,
-    }
-    if authority != expected:
-        raise SystemExit(f"Producer exceeded ledger authority: {repository}")
-
-validate_authority(sample["authority"], sample["producer"]["repository"])
-retry = sample["lifecycle"]["retry_policy"]
-if retry["max_attempts"] < 1 or not retry["backoff_seconds"] or any(value < 1 for value in retry["backoff_seconds"]):
-    raise SystemExit("Canonical producer retry policy is invalid.")
-if sample["lifecycle"]["deprecation_requires_governed_record"] is not True:
-    raise SystemExit("Producer deprecation must require a governed record.")
-
-if config.get("authority") != {"discovery_may_register": False, "discovery_may_promote": False, "governed_deprecation_required": True}:
-    raise SystemExit("Producer discovery authority boundary is invalid.")
-scopes = config.get("organization_scopes", [])
-if not scopes or len(scopes) != len(set(scopes)):
-    raise SystemExit("Producer discovery organization scopes must be non-empty and unique.")
-if config.get("contract_path") != ".stegverse/executive-rhetoric-ledger-producer.json":
-    raise SystemExit("Producer declaration path is not canonical.")
-
-path = ROOT / config["output_path"]
-if path.exists():
-    document = json.loads(path.read_text(encoding="utf-8"))
-    if document.get("authority") != {"may_discover": True, "may_register": False, "may_promote": False}:
-        raise SystemExit("Discovered producer registry exceeded discovery authority.")
-    seen = set()
+registry = root / config["output_path"]
+if registry.exists():
+    document = json.loads(registry.read_text(encoding="utf-8"))
+    assert document["authority"] == {"may_discover": True, "may_register": False, "may_promote": False}
+    repositories = []
     for row in document.get("producers", []):
         repository = row["repository"]
         declaration = row["declaration"]
-        if repository in seen:
-            raise SystemExit(f"Duplicate producer declaration: {repository}")
-        seen.add(repository)
-        if declaration.get("producer", {}).get("repository") != repository:
-            raise SystemExit(f"Producer identity mismatch: {repository}")
-        if declaration.get("consumer") != "StegVerse-Labs/Executive_Rhetoric_Ledger":
-            raise SystemExit(f"Producer consumer mismatch: {repository}")
-        if not required_top.issubset(declaration):
-            raise SystemExit(f"Producer declaration is incomplete: {repository}")
-        validate_authority(declaration["authority"], repository)
-        lifecycle = declaration["lifecycle"]
-        if lifecycle.get("deprecation_requires_governed_record") is not True:
-            raise SystemExit(f"Producer deprecation boundary is invalid: {repository}")
+        assert declaration["producer"]["repository"] == repository
+        assert declaration["consumer"] == "StegVerse-Labs/Executive_Rhetoric_Ledger"
+        assert declaration["authority"] == sample["authority"]
+        assert declaration["lifecycle"]["deprecation_requires_governed_record"] is True
+        repositories.append(repository)
+    assert len(repositories) == len(set(repositories))
 
-print("Validated producer adapter identities, preservation, retry posture, discovery scope, and authority boundaries.")
+print("Validated governed producer adapter identity and authority constants.")

--- a/scripts/validate_producer_adapters.py
+++ b/scripts/validate_producer_adapters.py
@@ -1,45 +1,52 @@
 #!/usr/bin/env python3
-"""Validate producer adapter schema, discovery configuration, and discovered declarations."""
+"""Validate producer adapter schema, fixture, discovery configuration, and discovered declarations."""
 import json
 from pathlib import Path
 from jsonschema import Draft202012Validator
 
 ROOT = Path(__file__).resolve().parents[1]
 schema = json.loads((ROOT / "schemas/producer-adapter.schema.json").read_text(encoding="utf-8"))
-Draft202012Validator.check_schema(schema)
 validator = Draft202012Validator(schema)
-config = json.loads((ROOT / "config/producer-discovery.json").read_text(encoding="utf-8"))
+sample = json.loads((ROOT / "samples/producer-adapter.sample.json").read_text(encoding="utf-8"))
+sample_errors = sorted(validator.iter_errors(sample), key=lambda error: list(error.path))
+if sample_errors:
+    detail = "; ".join(error.message for error in sample_errors)
+    raise SystemExit(f"Canonical producer adapter fixture failed validation: {detail}")
 
-if config["authority"] != {
-    "discovery_may_register": False,
-    "discovery_may_promote": False,
-    "governed_deprecation_required": True,
-}:
-    raise SystemExit("Producer discovery authority boundary is invalid.")
-if len(config["organization_scopes"]) != len(set(config["organization_scopes"])):
-    raise SystemExit("Producer discovery organization scopes must be unique.")
-if config["contract_path"] != ".stegverse/executive-rhetoric-ledger-producer.json":
+config = json.loads((ROOT / "config/producer-discovery.json").read_text(encoding="utf-8"))
+authority = config.get("authority", {})
+if authority.get("discovery_may_register") is not False:
+    raise SystemExit("Producer discovery may not register producers.")
+if authority.get("discovery_may_promote") is not False:
+    raise SystemExit("Producer discovery may not promote records.")
+if authority.get("governed_deprecation_required") is not True:
+    raise SystemExit("Producer deprecation must require a governed record.")
+scopes = config.get("organization_scopes", [])
+if not scopes or len(scopes) != len(set(scopes)):
+    raise SystemExit("Producer discovery organization scopes must be non-empty and unique.")
+if config.get("contract_path") != ".stegverse/executive-rhetoric-ledger-producer.json":
     raise SystemExit("Producer declaration path is not canonical.")
 
 path = ROOT / config["output_path"]
 if path.exists():
     document = json.loads(path.read_text(encoding="utf-8"))
-    if document["authority"] != {"may_discover": True, "may_register": False, "may_promote": False}:
+    if document.get("authority") != {"may_discover": True, "may_register": False, "may_promote": False}:
         raise SystemExit("Discovered producer registry exceeded discovery authority.")
     seen = set()
-    for row in document["producers"]:
+    for row in document.get("producers", []):
         repository = row["repository"]
         if repository in seen:
             raise SystemExit(f"Duplicate producer declaration: {repository}")
         seen.add(repository)
         declaration = row["declaration"]
-        errors = list(validator.iter_errors(declaration))
+        errors = sorted(validator.iter_errors(declaration), key=lambda error: list(error.path))
         if errors:
-            raise SystemExit(f"Producer declaration failed schema validation: {repository}")
+            detail = "; ".join(error.message for error in errors)
+            raise SystemExit(f"Producer declaration failed schema validation: {repository}: {detail}")
         if declaration["producer"]["repository"] != repository:
             raise SystemExit(f"Producer identity mismatch: {repository}")
-        authority = declaration["authority"]
-        if authority["may_claim_truth"] or authority["may_classify_final"] or authority["may_promote"]:
+        producer_authority = declaration["authority"]
+        if producer_authority["may_claim_truth"] or producer_authority["may_classify_final"] or producer_authority["may_promote"]:
             raise SystemExit(f"Producer exceeded ledger authority: {repository}")
 
-print("Validated producer adapter schema, discovery configuration, identities, and authority boundaries.")
+print("Validated producer adapter fixture, discovery configuration, identities, retry posture, and authority boundaries.")


### PR DESCRIPTION
## What changed

- defines a versioned, repository-neutral producer adapter schema;
- adds cross-organization declaration discovery without a hard-coded repository registry;
- validates producer identity, preservation requirements, retry posture, and authority boundaries;
- adds scheduled registry refresh with governed PR maintenance;
- integrates producer-adapter validation into the complete ledger CI suite.

Producer declarations are already installed in `StegVerse-Labs/Trumpality` and `StegVerse-Labs/Administrations`.

## Boundary

Discovery may find and validate declarations. It may not register, accept, classify, promote, publish, or deprecate producers without governed records.

Advances Issue #18.