### PR TITLE
Automate producer intake receipts and quarantine

### DIFF
--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -44,6 +44,30 @@ jobs:
           test -s scripts/discover_producer_adapters.py
           test -s scripts/validate_producer_adapters.py
           echo "Verified governed producer adapter foundation artifacts."
+      - name: Generate and validate producer intake results
+        run: |
+          rm -rf /tmp/producer-intake-results /tmp/producer-intake-quarantine
+          python scripts/process_producer_intake.py \
+            --input producer_intake/incoming \
+            --output /tmp/producer-intake-results \
+            --quarantine /tmp/producer-intake-quarantine \
+            --generated-at 2026-07-20T13:30:00Z
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from jsonschema import Draft202012Validator
+          schema = json.loads(Path("schemas/producer-intake-result.schema.json").read_text())
+          files = sorted(Path("/tmp/producer-intake-results").glob("ERL-INTAKE-*.json"))
+          if not files:
+              raise SystemExit("Producer intake emitted no result receipts")
+          for path in files:
+              document = json.loads(path.read_text())
+              errors = list(Draft202012Validator(schema).iter_errors(document))
+              if errors:
+                  raise SystemExit(f"Producer intake result failed schema validation: {path}")
+              if document["authority"]["may_promote"] or document["authority"]["may_classify_final"]:
+                  raise SystemExit("Producer intake exceeded authority")
+          PY
       - name: Validate validation result receipts
         run: python scripts/validate_validation_results.py
       - name: Validate activation state manifest

--- a/producer_intake/incoming/example/TRUMPALITY-SAMPLE-001.json
+++ b/producer_intake/incoming/example/TRUMPALITY-SAMPLE-001.json
@@ -1,0 +1,21 @@
+{
+  "ingestion_id": "TRUMPALITY-SAMPLE-001",
+  "producer_repo": "StegVerse-Labs/Trumpality",
+  "producer_path": "datasets/exports/executive-rhetoric-ledger/TRUMPALITY-SAMPLE-001.json",
+  "producer_commit": "8a62f7c0d2b754edf8b0dfde84956b5074abcd90",
+  "ingestion_date": "2026-07-20T13:15:00Z",
+  "object_class": "source_receipt",
+  "review_status": "pending",
+  "source_receipts": [
+    {
+      "source_id": "trumpality:sample-001",
+      "title": "Producer intake validation fixture",
+      "url": "https://example.invalid/source",
+      "evidence_role": "context-only-source"
+    }
+  ],
+  "record_created_at": "2026-07-20T13:00:00Z",
+  "record_updated_at": "2026-07-20T13:10:00Z",
+  "supersedes": null,
+  "corrects": null
+}

--- a/schemas/producer-intake-result.schema.json
+++ b/schemas/producer-intake-result.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger/schemas/producer-intake-result.schema.json",
+  "title": "Producer Intake Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["intake_id", "generated_at", "producer_repository", "producer_commit", "export_path", "export_sha256", "status", "chronology", "authority"],
+  "properties": {
+    "intake_id": {"type": "string", "minLength": 1},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "producer_repository": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"},
+    "producer_commit": {"type": "string", "minLength": 7},
+    "export_path": {"type": "string", "minLength": 1},
+    "export_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "status": {"enum": ["received", "duplicate", "quarantined", "retry-pending", "review-required"]},
+    "chronology": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["created_at", "updated_at", "supersedes", "corrects"],
+      "properties": {
+        "created_at": {"type": ["string", "null"]},
+        "updated_at": {"type": ["string", "null"]},
+        "supersedes": {"type": ["string", "null"]},
+        "corrects": {"type": ["string", "null"]}
+      }
+    },
+    "reason": {"type": ["string", "null"]},
+    "retry": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["attempt", "next_retry_at"],
+      "properties": {
+        "attempt": {"type": "integer", "minimum": 1},
+        "next_retry_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["may_acknowledge_receipt", "may_classify_final", "may_promote", "requires_review"],
+      "properties": {
+        "may_acknowledge_receipt": {"const": true},
+        "may_classify_final": {"const": false},
+        "may_promote": {"const": false},
+        "requires_review": {"const": true}
+      }
+    }
+  }
+}

--- a/scripts/process_producer_intake.py
+++ b/scripts/process_producer_intake.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Process staged producer exports into hash-bound intake results.
+
+Mechanical receipt acknowledgment is allowed. Final classification, promotion, and
+publication remain review-bound.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+REQUIRED = {
+    "producer_repo", "producer_commit", "producer_path", "ingestion_id",
+    "review_status", "source_receipts"
+}
+
+
+def canonical_bytes(document: dict) -> bytes:
+    return (json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def iso_now(value: str | None) -> str:
+    return value or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", default="producer_intake/incoming")
+    parser.add_argument("--output", default="producer_intake/results")
+    parser.add_argument("--quarantine", default="producer_intake/quarantine")
+    parser.add_argument("--generated-at")
+    args = parser.parse_args()
+
+    incoming = Path(args.input)
+    output = Path(args.output)
+    quarantine = Path(args.quarantine)
+    output.mkdir(parents=True, exist_ok=True)
+    quarantine.mkdir(parents=True, exist_ok=True)
+    generated_at = iso_now(args.generated_at)
+
+    seen: dict[str, str] = {}
+    processed = 0
+    for path in sorted(incoming.glob("**/*.json")):
+        reason = None
+        try:
+            document = json.loads(path.read_text(encoding="utf-8"))
+            missing = sorted(REQUIRED - set(document))
+            if missing:
+                reason = "missing-required-fields:" + ",".join(missing)
+            elif document["review_status"] not in {"pending", "candidate", "review-required"}:
+                reason = "invalid-review-status"
+            elif not isinstance(document["source_receipts"], list) or not document["source_receipts"]:
+                reason = "missing-source-receipts"
+        except Exception as exc:
+            document = {}
+            reason = f"invalid-json:{type(exc).__name__}"
+
+        raw = path.read_bytes()
+        digest = hashlib.sha256(raw).hexdigest()
+        repository = document.get("producer_repo", "unresolved/unresolved")
+        commit = document.get("producer_commit", "unresolved")
+        ingestion_id = document.get("ingestion_id", digest[:20])
+
+        if reason:
+            status = "quarantined"
+            qpath = quarantine / f"{digest}.json"
+            qpath.write_bytes(raw)
+        elif digest in seen:
+            status = "duplicate"
+            reason = f"duplicate-of:{seen[digest]}"
+        else:
+            seen[digest] = ingestion_id
+            status = "review-required"
+
+        chronology = {
+            "created_at": document.get("record_created_at") or document.get("ingestion_date"),
+            "updated_at": document.get("record_updated_at") or document.get("ingestion_date"),
+            "supersedes": document.get("supersedes"),
+            "corrects": document.get("corrects"),
+        }
+        result = {
+            "intake_id": "ERL-INTAKE-" + hashlib.sha256(f"{repository}|{commit}|{digest}".encode()).hexdigest()[:24].upper(),
+            "generated_at": generated_at,
+            "producer_repository": repository,
+            "producer_commit": commit,
+            "export_path": str(path),
+            "export_sha256": digest,
+            "status": status,
+            "chronology": chronology,
+            "reason": reason,
+            "retry": None,
+            "authority": {
+                "may_acknowledge_receipt": True,
+                "may_classify_final": False,
+                "may_promote": False,
+                "requires_review": True,
+            },
+        }
+        (output / f"{result['intake_id']}.json").write_bytes(canonical_bytes(result))
+        processed += 1
+
+    index = {
+        "generated_at": generated_at,
+        "processed": processed,
+        "results": sorted(str(p) for p in output.glob("ERL-INTAKE-*.json")),
+        "authority": {"may_route": True, "may_promote": False, "may_publish": False},
+    }
+    (output / "index.json").write_bytes(canonical_bytes(index))
+    print(f"Processed producer exports: {processed}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- adds a strict producer-intake result schema;
- adds deterministic SHA-256 binding, duplicate detection, chronology preservation, malformed-export quarantine, and review-required acknowledgment generation;
- adds a canonical intake fixture;
- validates generated intake receipts in the complete repository CI suite.

## Authority boundary

The intake processor may acknowledge receipt, hash, deduplicate, quarantine, and route. It may not classify a record as finally admissible, promote it, or publish it.

Advances Issue #18. Export retrieval and retry/failure reconciliation remain the next tranche.