### PR TITLE
Automate live producer retrieval and reconciliation

### DIFF
--- a/.github/workflows/reconcile-producer-exports.yml
+++ b/.github/workflows/reconcile-producer-exports.yml
@@ -1,0 +1,81 @@
+name: Reconcile Producer Exports
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "schemas/producer-health.schema.json"
+      - "scripts/reconcile_producer_exports.py"
+      - "scripts/process_producer_intake.py"
+      - ".github/workflows/reconcile-producer-exports.yml"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: producer-export-reconciliation
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validator
+        run: python -m pip install --upgrade jsonschema referencing
+      - name: Discover current producer declarations
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/discover_producer_adapters.py
+      - name: Retrieve manifests and reconcile producer health
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/reconcile_producer_exports.py
+      - name: Process retrieved exports
+        run: python scripts/process_producer_intake.py
+      - name: Validate producer health contract
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from jsonschema import Draft202012Validator
+          schema = json.loads(Path('schemas/producer-health.schema.json').read_text())
+          health = json.loads(Path('producer_intake/producer-health.json').read_text())
+          errors = list(Draft202012Validator(schema).iter_errors(health))
+          if errors:
+              raise SystemExit(errors[0].message)
+          if health['authority']['may_promote'] or health['authority']['may_deprecate']:
+              raise SystemExit('Producer reconciliation exceeded authority')
+          PY
+      - name: Maintain governed reconciliation PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="automation/producer-reconciliation"
+          git config user.name "stegverse-producer-reconciliation-bot"
+          git config user.email "stegverse-producer-reconciliation-bot@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add producer_adapters/ producer_intake/
+          if git diff --cached --quiet; then
+            echo "No producer reconciliation changes."
+            exit 0
+          fi
+          git commit -m "chore: reconcile declared producer exports"
+          git push --force-with-lease origin "$BRANCH"
+          BODY="Automated retrieval, hashing, quarantine, retry scheduling, health reconciliation, and intake acknowledgment. Retrieval and acknowledgment do not confer final classification, promotion, publication, or producer deprecation authority."
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" --title "Reconcile declared producer exports" --body "$BODY"
+          else
+            gh pr create --base main --head "$BRANCH" --title "Reconcile declared producer exports" --body "$BODY"
+          fi

--- a/.github/workflows/reconcile-producer-exports.yml
+++ b/.github/workflows/reconcile-producer-exports.yml
@@ -1,6 +1,12 @@
 name: Reconcile Producer Exports
 
 on:
+  pull_request:
+    paths:
+      - "schemas/producer-health.schema.json"
+      - "scripts/reconcile_producer_exports.py"
+      - "scripts/process_producer_intake.py"
+      - ".github/workflows/reconcile-producer-exports.yml"
   schedule:
     - cron: "17 */6 * * *"
   workflow_dispatch:
@@ -18,7 +24,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: producer-export-reconciliation
+  group: producer-export-reconciliation-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -27,7 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
@@ -41,6 +46,7 @@ jobs:
       - name: Retrieve manifests and reconcile producer health
         env:
           GH_TOKEN: ${{ github.token }}
+          RECONCILIATION_TIME: "2026-07-20T14:00:00Z"
         run: python scripts/reconcile_producer_exports.py
       - name: Process retrieved exports
         run: python scripts/process_producer_intake.py
@@ -59,6 +65,7 @@ jobs:
               raise SystemExit('Producer reconciliation exceeded authority')
           PY
       - name: Maintain governed reconciliation PR
+        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/schemas/producer-health.schema.json
+++ b/schemas/producer-health.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger/schemas/producer-health.schema.json",
+  "title": "Producer Retrieval Health",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["generated_at", "producers", "authority"],
+  "properties": {
+    "generated_at": {"type": "string", "format": "date-time"},
+    "producers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["repository", "manifest_path", "status", "attempts", "next_retry_at", "last_error", "retrieved_records", "quarantined_records"],
+        "properties": {
+          "repository": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"},
+          "manifest_path": {"type": "string", "minLength": 1},
+          "status": {"enum": ["healthy", "degraded", "retry-scheduled", "quarantined", "unreachable"]},
+          "attempts": {"type": "integer", "minimum": 0},
+          "next_retry_at": {"type": ["string", "null"], "format": "date-time"},
+          "last_error": {"type": ["string", "null"]},
+          "retrieved_records": {"type": "integer", "minimum": 0},
+          "quarantined_records": {"type": "integer", "minimum": 0},
+          "producer_commit": {"type": ["string", "null"]},
+          "manifest_sha256": {"type": ["string", "null"], "pattern": "^[a-f0-9]{64}$"}
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["may_retrieve", "may_retry", "may_acknowledge", "may_promote", "may_deprecate"],
+      "properties": {
+        "may_retrieve": {"const": true},
+        "may_retry": {"const": true},
+        "may_acknowledge": {"const": true},
+        "may_promote": {"const": false},
+        "may_deprecate": {"const": false}
+      }
+    }
+  }
+}

--- a/scripts/reconcile_producer_exports.py
+++ b/scripts/reconcile_producer_exports.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Retrieve declared producer manifests and exports with deterministic health/retry state.
+
+Discovery identifies candidates. Retrieval may fetch, hash, stage, quarantine, acknowledge,
+and schedule retries. It may not promote, publish, or deprecate a producer.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DISCOVERED = ROOT / "producer_adapters/discovered.json"
+HEALTH = ROOT / "producer_intake/producer-health.json"
+INCOMING = ROOT / "producer_intake/incoming"
+FAILURES = ROOT / "producer_intake/retrieval-failures"
+
+
+def now() -> datetime:
+    value = os.environ.get("RECONCILIATION_TIME")
+    return datetime.fromisoformat(value.replace("Z", "+00:00")) if value else datetime.now(timezone.utc)
+
+
+def gh_json(repo: str, path: str) -> tuple[bytes, str]:
+    encoded = subprocess.check_output(
+        ["gh", "api", f"repos/{repo}/contents/{path}"], text=True
+    )
+    payload = json.loads(encoded)
+    content = base64.b64decode(payload["content"])
+    return content, payload.get("sha", "")
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    generated = now()
+    document = json.loads(DISCOVERED.read_text(encoding="utf-8")) if DISCOVERED.exists() else {"producers": []}
+    health_rows = []
+    for row in document.get("producers", []):
+        repo = row["repository"]
+        declaration = row["declaration"]
+        manifest_path = declaration["exports"]["manifest_path"]
+        retry = declaration["lifecycle"]["retry_policy"]
+        attempts = 0
+        last_error = None
+        retrieved = 0
+        quarantined = 0
+        producer_commit = None
+        manifest_hash = None
+        status = "healthy"
+        next_retry = None
+        try:
+            manifest_bytes, _ = gh_json(repo, manifest_path)
+            manifest_hash = hashlib.sha256(manifest_bytes).hexdigest()
+            manifest = json.loads(manifest_bytes)
+            if manifest.get("producer_repository") != repo:
+                raise ValueError("manifest producer identity mismatch")
+            producer_commit = manifest.get("producer_commit")
+            for item in manifest.get("records", []):
+                record_path = item["path"]
+                raw, _ = gh_json(repo, record_path)
+                digest = hashlib.sha256(raw).hexdigest()
+                if digest != item.get("sha256"):
+                    quarantined += 1
+                    write_json(FAILURES / repo.replace("/", "__") / f"{digest}.json", {
+                        "repository": repo,
+                        "path": record_path,
+                        "reason": "sha256-mismatch",
+                        "expected": item.get("sha256"),
+                        "actual": digest,
+                        "authority": {"may_promote": False, "may_deprecate": False}
+                    })
+                    continue
+                destination = INCOMING / repo.replace("/", "__") / f"{digest}.json"
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_bytes(raw)
+                retrieved += 1
+            status = "healthy" if quarantined == 0 else "quarantined"
+        except Exception as exc:
+            attempts = 1
+            last_error = str(exc)[:500]
+            backoff = retry.get("backoff_seconds", [3600])
+            next_retry = (generated + timedelta(seconds=backoff[0])).isoformat().replace("+00:00", "Z")
+            status = "retry-scheduled" if retry.get("max_attempts", 1) > 1 else "unreachable"
+        health_rows.append({
+            "repository": repo,
+            "manifest_path": manifest_path,
+            "status": status,
+            "attempts": attempts,
+            "next_retry_at": next_retry,
+            "last_error": last_error,
+            "retrieved_records": retrieved,
+            "quarantined_records": quarantined,
+            "producer_commit": producer_commit,
+            "manifest_sha256": manifest_hash
+        })
+    write_json(HEALTH, {
+        "generated_at": generated.isoformat().replace("+00:00", "Z"),
+        "producers": sorted(health_rows, key=lambda item: item["repository"]),
+        "authority": {"may_retrieve": True, "may_retry": True, "may_acknowledge": True, "may_promote": False, "may_deprecate": False}
+    })
+    print(f"Reconciled {len(health_rows)} discovered producers")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- adds discovery-driven live producer manifest retrieval without a repository allowlist;
- verifies producer identity, manifest and record SHA-256 values;
- stages valid exports for the existing deterministic intake processor;
- quarantines hash mismatches;
- records missing manifests and transient failures as retryable producer-health state using producer-declared backoff;
- maintains a governed reconciliation PR automatically;
- validates the producer-health authority contract on pull requests.

## Authority boundary

Retrieval may fetch, hash, stage, quarantine, acknowledge, and schedule retries. It may not promote, publish, finally classify, or deprecate a producer.

Advances Issue #18.