### PR TITLE
Route producer acknowledgments and governed review packets

### DIFF
--- a/.github/workflows/reconcile-producer-exports.yml
+++ b/.github/workflows/reconcile-producer-exports.yml
@@ -6,6 +6,7 @@ on:
       - "schemas/producer-health.schema.json"
       - "scripts/reconcile_producer_exports.py"
       - "scripts/process_producer_intake.py"
+      - "scripts/route_producer_intake.py"
       - ".github/workflows/reconcile-producer-exports.yml"
   schedule:
     - cron: "17 */6 * * *"
@@ -17,6 +18,7 @@ on:
       - "schemas/producer-health.schema.json"
       - "scripts/reconcile_producer_exports.py"
       - "scripts/process_producer_intake.py"
+      - "scripts/route_producer_intake.py"
       - ".github/workflows/reconcile-producer-exports.yml"
 
 permissions:
@@ -50,7 +52,9 @@ jobs:
         run: python scripts/reconcile_producer_exports.py
       - name: Process retrieved exports
         run: python scripts/process_producer_intake.py
-      - name: Validate producer health contract
+      - name: Route acknowledgments and governed review packets
+        run: python scripts/route_producer_intake.py
+      - name: Validate producer health and routing authority
         run: |
           python - <<'PY'
           import json
@@ -63,6 +67,14 @@ jobs:
               raise SystemExit(errors[0].message)
           if health['authority']['may_promote'] or health['authority']['may_deprecate']:
               raise SystemExit('Producer reconciliation exceeded authority')
+          for path in Path('producer_intake/acknowledgments').glob('**/*.json'):
+              document = json.loads(path.read_text())
+              if document['authority']['may_promote'] or document['authority']['may_publish']:
+                  raise SystemExit('Producer acknowledgment exceeded authority')
+          for path in Path('producer_intake/review-queue').glob('*.json'):
+              document = json.loads(path.read_text())
+              if document['authority']['automation_may_approve'] or document['authority']['automation_may_promote']:
+                  raise SystemExit('Producer review routing exceeded authority')
           PY
       - name: Maintain governed reconciliation PR
         if: github.event_name != 'pull_request'
@@ -80,7 +92,7 @@ jobs:
           fi
           git commit -m "chore: reconcile declared producer exports"
           git push --force-with-lease origin "$BRANCH"
-          BODY="Automated retrieval, hashing, quarantine, retry scheduling, health reconciliation, and intake acknowledgment. Retrieval and acknowledgment do not confer final classification, promotion, publication, or producer deprecation authority."
+          BODY="Automated retrieval, hashing, quarantine, retry scheduling, health reconciliation, intake acknowledgment, and governed review routing. Retrieval and acknowledgment do not confer final classification, promotion, publication, or producer deprecation authority."
           if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
             gh pr edit "$BRANCH" --title "Reconcile declared producer exports" --body "$BODY"
           else

--- a/scripts/route_producer_intake.py
+++ b/scripts/route_producer_intake.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Convert intake results into producer-specific acknowledgments and governed review packets."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RESULTS = ROOT / "producer_intake/results"
+ACKS = ROOT / "producer_intake/acknowledgments"
+REVIEW = ROOT / "producer_intake/review-queue"
+
+
+def write(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    generated_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    routed = 0
+    for path in sorted(RESULTS.glob("ERL-INTAKE-*.json")):
+        result = json.loads(path.read_text(encoding="utf-8"))
+        repo = result["producer_repository"]
+        token = hashlib.sha256(f'{repo}|{result["intake_id"]}|{result["export_sha256"]}'.encode()).hexdigest()[:20]
+        acknowledgment = {
+            "acknowledgment_id": f"ERL-ACK-{token.upper()}",
+            "generated_at": generated_at,
+            "producer_repository": repo,
+            "intake_id": result["intake_id"],
+            "export_path": result["export_path"],
+            "export_sha256": result["export_sha256"],
+            "state": "received" if result["status"] == "review-required" else result["status"],
+            "review_required": result["authority"]["requires_review"],
+            "authority": {
+                "may_acknowledge_receipt": True,
+                "may_classify_final": False,
+                "may_promote": False,
+                "may_publish": False
+            }
+        }
+        repo_dir = repo.replace("/", "__")
+        write(ACKS / repo_dir / f'{result["intake_id"]}.json', acknowledgment)
+        if result["status"] == "review-required":
+            packet = {
+                "review_packet_id": f"ERL-PRODUCER-REVIEW-{token.upper()}",
+                "generated_at": generated_at,
+                "source": "producer-intake",
+                "producer_repository": repo,
+                "intake_result": path.relative_to(ROOT).as_posix(),
+                "acknowledgment": (ACKS / repo_dir / f'{result["intake_id"]}.json').relative_to(ROOT).as_posix(),
+                "export_sha256": result["export_sha256"],
+                "review_status": "pending",
+                "authority": {
+                    "automation_may_assign": True,
+                    "automation_may_approve": False,
+                    "automation_may_promote": False,
+                    "automation_may_publish": False
+                }
+            }
+            write(REVIEW / f'{packet["review_packet_id"]}.json', packet)
+        routed += 1
+    print(f"Routed producer intake results: {routed}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds deterministic producer-specific intake acknowledgments and pending review packets after live export reconciliation. Automation may acknowledge and assign review, but may not approve, classify finally, promote, publish, or deprecate producers. Advances Issue #18.