### PR TITLE
Reconcile producer chronology and completion state

### DIFF
--- a/.github/workflows/reconcile-producer-exports.yml
+++ b/.github/workflows/reconcile-producer-exports.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     paths:
       - "schemas/producer-health.schema.json"
+      - "schemas/producer-completion-state.schema.json"
       - "scripts/reconcile_producer_exports.py"
       - "scripts/process_producer_intake.py"
       - "scripts/route_producer_intake.py"
+      - "scripts/reconcile_producer_completion.py"
       - ".github/workflows/reconcile-producer-exports.yml"
   schedule:
     - cron: "17 */6 * * *"
@@ -16,9 +18,11 @@ on:
       - main
     paths:
       - "schemas/producer-health.schema.json"
+      - "schemas/producer-completion-state.schema.json"
       - "scripts/reconcile_producer_exports.py"
       - "scripts/process_producer_intake.py"
       - "scripts/route_producer_intake.py"
+      - "scripts/reconcile_producer_completion.py"
       - ".github/workflows/reconcile-producer-exports.yml"
 
 permissions:
@@ -54,19 +58,30 @@ jobs:
         run: python scripts/process_producer_intake.py
       - name: Route acknowledgments and governed review packets
         run: python scripts/route_producer_intake.py
-      - name: Validate producer health and routing authority
+      - name: Reconcile chronology, acknowledgment consumption, and completion
+        env:
+          RECONCILIATION_TIME: "2026-07-20T14:00:00Z"
+        run: python scripts/reconcile_producer_completion.py
+      - name: Validate producer health, routing, and completion authority
         run: |
           python - <<'PY'
           import json
           from pathlib import Path
           from jsonschema import Draft202012Validator
-          schema = json.loads(Path('schemas/producer-health.schema.json').read_text())
+          health_schema = json.loads(Path('schemas/producer-health.schema.json').read_text())
           health = json.loads(Path('producer_intake/producer-health.json').read_text())
-          errors = list(Draft202012Validator(schema).iter_errors(health))
+          if list(Draft202012Validator(health_schema).iter_errors(health)):
+              raise SystemExit('Producer health failed schema validation')
+          completion_schema = json.loads(Path('schemas/producer-completion-state.schema.json').read_text())
+          completion = json.loads(Path('producer_intake/completion-state.json').read_text())
+          errors = list(Draft202012Validator(completion_schema).iter_errors(completion))
           if errors:
               raise SystemExit(errors[0].message)
           if health['authority']['may_promote'] or health['authority']['may_deprecate']:
               raise SystemExit('Producer reconciliation exceeded authority')
+          authority = completion['authority']
+          if authority['may_approve_review'] or authority['may_promote'] or authority['may_publish']:
+              raise SystemExit('Producer completion reconciliation exceeded authority')
           for path in Path('producer_intake/acknowledgments').glob('**/*.json'):
               document = json.loads(path.read_text())
               if document['authority']['may_promote'] or document['authority']['may_publish']:
@@ -92,7 +107,7 @@ jobs:
           fi
           git commit -m "chore: reconcile declared producer exports"
           git push --force-with-lease origin "$BRANCH"
-          BODY="Automated retrieval, hashing, quarantine, retry scheduling, health reconciliation, intake acknowledgment, and governed review routing. Retrieval and acknowledgment do not confer final classification, promotion, publication, or producer deprecation authority."
+          BODY="Automated retrieval, hashing, quarantine, retry scheduling, health reconciliation, intake acknowledgment, chronology reconciliation, completion verification, reviewed-only eligibility, and governed review routing. Automation does not confer final classification, promotion, publication, or producer deprecation authority."
           if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
             gh pr edit "$BRANCH" --title "Reconcile declared producer exports" --body "$BODY"
           else

--- a/schemas/producer-completion-state.schema.json
+++ b/schemas/producer-completion-state.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger/schemas/producer-completion-state.schema.json",
+  "title": "Producer Completion State",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["generated_at", "producers", "reviewed_output_eligibility", "authority"],
+  "properties": {
+    "generated_at": {"type": "string", "format": "date-time"},
+    "producers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["repository", "manifest_live", "records_seen", "records_acknowledged", "records_review_routed", "chronology_state", "acknowledgment_consumption", "capability_complete"],
+        "properties": {
+          "repository": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"},
+          "manifest_live": {"type": "boolean"},
+          "records_seen": {"type": "integer", "minimum": 0},
+          "records_acknowledged": {"type": "integer", "minimum": 0},
+          "records_review_routed": {"type": "integer", "minimum": 0},
+          "chronology_state": {"enum": ["empty", "consistent", "unresolved-reference", "cycle-detected"]},
+          "acknowledgment_consumption": {"enum": ["none", "available", "complete"]},
+          "capability_complete": {"type": "boolean"}
+        }
+      }
+    },
+    "reviewed_output_eligibility": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["intake_id", "producer_repository", "status", "reason"],
+        "properties": {
+          "intake_id": {"type": "string", "minLength": 1},
+          "producer_repository": {"type": "string"},
+          "status": {"enum": ["ineligible-unreviewed", "eligible-reviewed-only"]},
+          "reason": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["may_reconcile_chronology", "may_record_ack_consumption", "may_mark_reviewed_eligibility", "may_approve_review", "may_promote", "may_publish"],
+      "properties": {
+        "may_reconcile_chronology": {"const": true},
+        "may_record_ack_consumption": {"const": true},
+        "may_mark_reviewed_eligibility": {"const": true},
+        "may_approve_review": {"const": false},
+        "may_promote": {"const": false},
+        "may_publish": {"const": false}
+      }
+    }
+  }
+}

--- a/scripts/reconcile_producer_completion.py
+++ b/scripts/reconcile_producer_completion.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Reconcile producer chronology, acknowledgment consumption, and reviewed-output eligibility.
+
+This process may verify mechanical completion and identify reviewed-only eligibility. It may
+not approve review, promote candidates, or publish unresolved producer records.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HEALTH = ROOT / "producer_intake/producer-health.json"
+RESULTS = ROOT / "producer_intake/results"
+ACKS = ROOT / "producer_intake/acknowledgments"
+REVIEW = ROOT / "producer_intake/review-queue"
+REVIEWED = ROOT / "reviewed_receipts"
+OUTPUT = ROOT / "producer_intake/completion-state.json"
+
+
+def generated_at() -> str:
+    value = os.environ.get("RECONCILIATION_TIME")
+    return value or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_many(root: Path, pattern: str) -> list[dict]:
+    documents = []
+    if not root.exists():
+        return documents
+    for path in sorted(root.rglob(pattern)):
+        try:
+            documents.append(json.loads(path.read_text(encoding="utf-8")))
+        except Exception:
+            continue
+    return documents
+
+
+def chronology_state(rows: list[dict]) -> str:
+    if not rows:
+        return "empty"
+    ids = {row.get("intake_id") for row in rows}
+    edges: dict[str, set[str]] = {item: set() for item in ids if item}
+    unresolved = False
+    for row in rows:
+        source = row.get("intake_id")
+        chronology = row.get("chronology") or {}
+        for key in ("supersedes", "corrects"):
+            target = chronology.get(key)
+            if not target:
+                continue
+            if target not in ids:
+                unresolved = True
+            elif source:
+                edges.setdefault(source, set()).add(target)
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def cyclic(node: str) -> bool:
+        if node in visiting:
+            return True
+        if node in visited:
+            return False
+        visiting.add(node)
+        for target in edges.get(node, set()):
+            if cyclic(target):
+                return True
+        visiting.remove(node)
+        visited.add(node)
+        return False
+
+    if any(cyclic(node) for node in edges):
+        return "cycle-detected"
+    return "unresolved-reference" if unresolved else "consistent"
+
+
+def main() -> int:
+    health = json.loads(HEALTH.read_text(encoding="utf-8")) if HEALTH.exists() else {"producers": []}
+    results = load_many(RESULTS, "ERL-INTAKE-*.json")
+    acknowledgments = load_many(ACKS, "*.json")
+    review_packets = load_many(REVIEW, "*.json")
+    reviewed = load_many(REVIEWED, "*.json")
+    reviewed_ids = {
+        value
+        for document in reviewed
+        for value in (document.get("intake_id"), document.get("source_intake_id"))
+        if value
+    }
+
+    producer_rows = []
+    eligibility = []
+    repositories = sorted({row.get("repository") for row in health.get("producers", []) if row.get("repository")} | {row.get("producer_repository") for row in results if row.get("producer_repository")})
+    for repository in repositories:
+        producer_results = [row for row in results if row.get("producer_repository") == repository]
+        producer_acks = [row for row in acknowledgments if row.get("producer_repository") == repository]
+        producer_packets = [row for row in review_packets if row.get("producer_repository") == repository]
+        health_row = next((row for row in health.get("producers", []) if row.get("repository") == repository), {})
+        state = chronology_state(producer_results)
+        seen = len(producer_results)
+        acknowledged = len({row.get("intake_id") for row in producer_acks if row.get("intake_id")})
+        routed = len({row.get("intake_result") for row in producer_packets if row.get("intake_result")})
+        ack_state = "none" if acknowledged == 0 else ("complete" if acknowledged >= seen else "available")
+        capability_complete = bool(health_row.get("status") == "healthy" and state in {"empty", "consistent"} and acknowledged >= seen and routed >= sum(1 for row in producer_results if row.get("status") == "review-required"))
+        producer_rows.append({
+            "repository": repository,
+            "manifest_live": health_row.get("status") in {"healthy", "quarantined"},
+            "records_seen": seen,
+            "records_acknowledged": acknowledged,
+            "records_review_routed": routed,
+            "chronology_state": state,
+            "acknowledgment_consumption": ack_state,
+            "capability_complete": capability_complete,
+        })
+        for row in producer_results:
+            intake_id = row.get("intake_id")
+            is_reviewed = intake_id in reviewed_ids
+            eligibility.append({
+                "intake_id": intake_id,
+                "producer_repository": repository,
+                "status": "eligible-reviewed-only" if is_reviewed else "ineligible-unreviewed",
+                "reason": "durable reviewed receipt found" if is_reviewed else "pending final evidentiary review; automation cannot approve",
+            })
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(json.dumps({
+        "generated_at": generated_at(),
+        "producers": producer_rows,
+        "reviewed_output_eligibility": sorted(eligibility, key=lambda row: (row["producer_repository"], row["intake_id"] or "")),
+        "authority": {
+            "may_reconcile_chronology": True,
+            "may_record_ack_consumption": True,
+            "may_mark_reviewed_eligibility": True,
+            "may_approve_review": False,
+            "may_promote": False,
+            "may_publish": False,
+        },
+    }, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Reconciled completion state for {len(producer_rows)} producers")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- adds a strict producer completion-state schema;
- reconciles correction and supersession references across repeated intake cycles;
- detects unresolved chronology references and cycles without resolving evidentiary meaning;
- records producer-specific acknowledgment consumption and deterministic capability completion;
- marks records eligible for reviewed-only compendium flow only when a durable reviewed receipt exists;
- extends scheduled reconciliation and governed PR maintenance.

## Authority boundary

Automation may reconcile mechanical chronology, record acknowledgment consumption, verify capability completion, and identify reviewed-receipt eligibility. It may not approve review, promote candidates, publish unresolved records, or deprecate producers.

Advances Issue #18.