### PR TITLE
Automate governed producer review completion

### DIFF
--- a/.github/workflows/activate-reviewed-producer-record.yml
+++ b/.github/workflows/activate-reviewed-producer-record.yml
@@ -1,0 +1,74 @@
+name: Activate Reviewed Producer Record
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "producer_intake/reviewed-receipts/**"
+      - "schemas/producer-reviewed-receipt.schema.json"
+      - "scripts/verify_governed_producer_review.py"
+      - ".github/workflows/activate-reviewed-producer-record.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: activate-reviewed-producer-record
+  cancel-in-progress: false
+
+jobs:
+  activate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validator
+        run: python -m pip install --upgrade jsonschema referencing
+      - name: Verify governed review receipt
+        run: python scripts/verify_governed_producer_review.py
+      - name: Stop when no approved receipt exists
+        id: gate
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          path = Path('producer_intake/review-activation/ADMINISTRATIONS-EXPORT-EO14179-ACTION-001.json')
+          state = json.loads(path.read_text())
+          with open('$GITHUB_OUTPUT', 'a') as handle:
+              handle.write(f"eligible={'true' if state.get('compendium_eligible') else 'false'}\n")
+          PY
+      - name: Generate reviewed-only compendium and delivery manifests
+        if: steps.gate.outputs.eligible == 'true'
+        run: python scripts/generate_compendium_and_deliveries.py
+      - name: Verify destination propagation state
+        if: steps.gate.outputs.eligible == 'true'
+        run: python scripts/verify_destination_acknowledgments.py
+      - name: Maintain governed post-review PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="automation/reviewed-producer-activation"
+          git config user.name "stegverse-reviewed-producer-bot"
+          git config user.email "stegverse-reviewed-producer-bot@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add producer_intake/review-activation publication delivery_manifests propagation
+          if git diff --cached --quiet; then
+            echo "No post-review activation changes."
+            exit 0
+          fi
+          git commit -m "chore: activate governed producer review result"
+          git push --force-with-lease origin "$BRANCH"
+          BODY="Verified human-authored review receipt and generated only the mechanically authorized activation state. Automation did not create or broaden the review decision. Reviewed-only publication outputs are included only when the receipt disposition is approved-action-record."
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" --title "Activate governed producer review result" --body "$BODY"
+          else
+            gh pr create --base main --head "$BRANCH" --title "Activate governed producer review result" --body "$BODY"
+          fi

--- a/.github/workflows/activate-reviewed-producer-record.yml
+++ b/.github/workflows/activate-reviewed-producer-record.yml
@@ -34,17 +34,18 @@ jobs:
         run: python -m pip install --upgrade jsonschema referencing
       - name: Verify governed review receipt
         run: python scripts/verify_governed_producer_review.py
-      - name: Stop when no approved receipt exists
+      - name: Determine reviewed-only eligibility
         id: gate
         run: |
-          python - <<'PY'
+          ELIGIBLE=$(python - <<'PY'
           import json
           from pathlib import Path
           path = Path('producer_intake/review-activation/ADMINISTRATIONS-EXPORT-EO14179-ACTION-001.json')
           state = json.loads(path.read_text())
-          with open('$GITHUB_OUTPUT', 'a') as handle:
-              handle.write(f"eligible={'true' if state.get('compendium_eligible') else 'false'}\n")
+          print('true' if state.get('compendium_eligible') else 'false')
           PY
+          )
+          echo "eligible=$ELIGIBLE" >> "$GITHUB_OUTPUT"
       - name: Generate reviewed-only compendium and delivery manifests
         if: steps.gate.outputs.eligible == 'true'
         run: python scripts/generate_compendium_and_deliveries.py

--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -44,6 +44,23 @@ jobs:
           test -s scripts/discover_producer_adapters.py
           test -s scripts/validate_producer_adapters.py
           echo "Verified governed producer adapter foundation artifacts."
+      - name: Validate governed review gate without a receipt
+        run: |
+          rm -rf /tmp/governed-review
+          python scripts/verify_governed_producer_review.py \
+            --receipt /tmp/governed-review/nonexistent.json \
+            --output /tmp/governed-review/activation.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          state = json.loads(Path('/tmp/governed-review/activation.json').read_text())
+          if state['status'] != 'awaiting-governed-review':
+              raise SystemExit('Missing review receipt did not preserve blocked state')
+          if state['compendium_eligible'] or state['propagation_eligible']:
+              raise SystemExit('Unreviewed producer record became eligible')
+          if state['authority']['automation_created_decision']:
+              raise SystemExit('Automation claimed review authority')
+          PY
       - name: Generate and validate producer intake results
         run: |
           rm -rf /tmp/producer-intake-results /tmp/producer-intake-quarantine

--- a/docs/review/ISSUE-26-REVIEW-RECEIPT-TEMPLATE.json
+++ b/docs/review/ISSUE-26-REVIEW-RECEIPT-TEMPLATE.json
@@ -1,0 +1,22 @@
+{
+  "review_receipt_id": "REPLACE-WITH-DURABLE-ID",
+  "review_issue": 26,
+  "reviewer": "REPLACE-WITH-REVIEWER-IDENTITY",
+  "reviewed_at": "REPLACE-WITH-ISO-8601-TIMESTAMP",
+  "producer_repository": "StegVerse-Labs/Administrations",
+  "intake_id": "ADMINISTRATIONS-EXPORT-EO14179-ACTION-001",
+  "export_sha256": "REPLACE-WITH-VERIFIED-64-CHARACTER-SHA256",
+  "disposition": "REPLACE-WITH-ONE-ALLOWED-DISPOSITION",
+  "rationale": "Record the bounded evidentiary rationale. Approval may cover issuance and text of EO 14179 only; it may not establish truth of embedded rhetoric or broader causation.",
+  "scope": {
+    "documents_issuance_and_text": false,
+    "proves_embedded_rhetoric_truth": false,
+    "permits_broader_causation_claim": false
+  },
+  "authority": {
+    "human_reviewed": true,
+    "automation_may_verify": true,
+    "automation_may_create_decision": false,
+    "automation_may_expand_scope": false
+  }
+}

--- a/schemas/producer-reviewed-receipt.schema.json
+++ b/schemas/producer-reviewed-receipt.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger/schemas/producer-reviewed-receipt.schema.json",
+  "title": "Governed Producer Reviewed Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["review_receipt_id", "review_issue", "reviewer", "reviewed_at", "producer_repository", "intake_id", "export_sha256", "disposition", "rationale", "scope", "authority"],
+  "properties": {
+    "review_receipt_id": {"type": "string", "minLength": 1},
+    "review_issue": {"const": 26},
+    "reviewer": {"type": "string", "minLength": 1},
+    "reviewed_at": {"type": "string", "format": "date-time"},
+    "producer_repository": {"const": "StegVerse-Labs/Administrations"},
+    "intake_id": {"const": "ADMINISTRATIONS-EXPORT-EO14179-ACTION-001"},
+    "export_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "disposition": {"enum": ["approved-action-record", "needs-primary-source", "needs-context-revision", "rejected-unsupported", "rejected-out-of-scope"]},
+    "rationale": {"type": "string", "minLength": 20},
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["documents_issuance_and_text", "proves_embedded_rhetoric_truth", "permits_broader_causation_claim"],
+      "properties": {
+        "documents_issuance_and_text": {"type": "boolean"},
+        "proves_embedded_rhetoric_truth": {"const": false},
+        "permits_broader_causation_claim": {"const": false}
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["human_reviewed", "automation_may_verify", "automation_may_create_decision", "automation_may_expand_scope"],
+      "properties": {
+        "human_reviewed": {"const": true},
+        "automation_may_verify": {"const": true},
+        "automation_may_create_decision": {"const": false},
+        "automation_may_expand_scope": {"const": false}
+      }
+    }
+  }
+}

--- a/scripts/verify_governed_producer_review.py
+++ b/scripts/verify_governed_producer_review.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Verify a human-authored producer review receipt and emit bounded activation state.
+
+This script validates a decision; it never creates, changes, or broadens one.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas/producer-reviewed-receipt.schema.json"
+DEFAULT_RECEIPT = ROOT / "producer_intake/reviewed-receipts/ADMINISTRATIONS-EXPORT-EO14179-ACTION-001.json"
+DEFAULT_OUTPUT = ROOT / "producer_intake/review-activation/ADMINISTRATIONS-EXPORT-EO14179-ACTION-001.json"
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--receipt", type=Path, default=DEFAULT_RECEIPT)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    if not args.receipt.exists():
+        write_json(args.output, {
+            "intake_id": "ADMINISTRATIONS-EXPORT-EO14179-ACTION-001",
+            "status": "awaiting-governed-review",
+            "review_issue": 26,
+            "compendium_eligible": False,
+            "propagation_eligible": False,
+            "authority": {
+                "automation_created_decision": False,
+                "automation_may_verify": True,
+                "automation_may_publish_without_approval": False
+            }
+        })
+        print("No governed review receipt exists; activation remains blocked.")
+        return 0
+
+    receipt_bytes = args.receipt.read_bytes()
+    receipt = json.loads(receipt_bytes)
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    errors = sorted(
+        Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(receipt),
+        key=lambda error: list(error.path),
+    )
+    if errors:
+        raise SystemExit(f"Governed review receipt invalid: {errors[0].message}")
+
+    approved = receipt["disposition"] == "approved-action-record"
+    if approved and not receipt["scope"]["documents_issuance_and_text"]:
+        raise SystemExit("Approved action record must affirm bounded issuance/text scope")
+
+    write_json(args.output, {
+        "intake_id": receipt["intake_id"],
+        "review_issue": receipt["review_issue"],
+        "review_receipt_id": receipt["review_receipt_id"],
+        "review_receipt_sha256": hashlib.sha256(receipt_bytes).hexdigest(),
+        "disposition": receipt["disposition"],
+        "status": "reviewed-approved" if approved else "reviewed-not-approved",
+        "compendium_eligible": approved,
+        "propagation_eligible": approved,
+        "scope": receipt["scope"],
+        "authority": {
+            "automation_created_decision": False,
+            "automation_may_verify": True,
+            "automation_may_publish_without_approval": False,
+            "automation_may_expand_scope": False
+        }
+    })
+    print(f"Verified governed review disposition: {receipt['disposition']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- creates a strict human-authored reviewed-receipt contract for Issue #26;
- adds a bounded reviewer template for the Administrations EO 14179 action record;
- verifies review receipts without creating or broadening a decision;
- keeps unreviewed records blocked from compendium and propagation eligibility;
- automatically generates post-review activation, reviewed-only publication outputs, and propagation state only after a valid `approved-action-record` receipt exists;
- adds CI evidence that a missing receipt remains blocked.

## Authority boundary

Automation may validate and execute a human decision. It may not create the review disposition, expand its scope, or publish an unreviewed record.

Advances Issues #18 and #26.