### PR TITLE
Add Ruben Ray Martinez South Padre Island force-event candidate

### DIFF
--- a/research-candidates/2025-ruben-ray-martinez-south-padre-island.md
+++ b/research-candidates/2025-ruben-ray-martinez-south-padre-island.md
@@ -1,0 +1,68 @@
+# Research Candidate: Ruben Ray Martinez South Padre Island Shooting
+
+## Candidate identity
+
+```yaml
+candidate_id: "ERL-FORCE-CANDIDATE-RUBEN-RAY-MARTINEZ-2025-03-15"
+subject: "Ruben Ray Martinez"
+event_date: "2025-03-15"
+location: "South Padre Island, Texas"
+event_class: "fatal-federal-use-of-force"
+review_status: "candidate-review-required"
+risk_level: "critical"
+```
+
+## Established event posture
+
+Ruben Ray Martinez, a 23-year-old United States citizen from San Antonio, was fatally shot on South Padre Island on March 15, 2025, by a Homeland Security Investigations agent while federal agents were assisting local police near a traffic-control scene.
+
+The federal role was not identified in early public reporting and became publicly documented through records released in February 2026.
+
+## Official account
+
+The Department of Homeland Security stated that Martinez intentionally ran over or struck an agent with his vehicle and that another agent fired defensive shots. Records describe an agent receiving treatment for a knee injury.
+
+This statement is retained as an official institutional assertion. It is not adopted as a final factual finding by this candidate.
+
+## Video and witness variance
+
+South Padre Island police body-camera and security footage released in March 2026 shows Martinez's vehicle moving slowly or nearly stationary around the time the shots were fired, with brake lights visible. The available footage does not fully show the area immediately beside the driver's window or every movement of the agents.
+
+The footage also records conflicting commands, including an instruction to keep moving followed by commands to stop. Martinez's passenger disputed the claim that Martinez intentionally drove into an agent.
+
+The video evidence creates a material unresolved variance with the later DHS description. It does not, by itself, complete a legal use-of-force determination.
+
+## Procedural posture
+
+A Texas grand jury reportedly declined to indict the federal agent. That outcome is recorded as a charging decision, not as proof that every element of the official public account was factually established.
+
+Open review questions include:
+
+- whether the available video can be reconciled with the assertion that Martinez intentionally struck an agent;
+- what evidence was presented to the grand jury;
+- whether federal disclosure and body-camera practices impaired independent reconstruction;
+- whether immediate medical-response and post-shooting restraint practices require separate review;
+- whether later administrative, inspector-general, civil, or congressional findings exist.
+
+## Source receipts
+
+1. Texas Tribune, February 20, 2026 — records identifying the federal immigration-agent role and DHS account.
+2. Texas Tribune, March 6, 2026 — released body-camera and security footage and the visible movement of the vehicle.
+3. Texas Tribune, May 4, 2026 — detailed reconstruction, passenger account, conflicting commands, and investigative records.
+4. CBS News, 2026 — body-camera analysis describing the vehicle as moving very slowly or not at all when shots were fired.
+5. Associated Press, 2026 — video-based reporting, agent identity, grand-jury posture, and unresolved official-account questions.
+6. Reuters, February 21, 2026 — records-based confirmation of the DHS-agent shooting and ongoing investigative posture.
+
+## Governance boundary
+
+```text
+Official assertion != final factual finding.
+Video variance != completed contradiction adjudication.
+Grand-jury non-indictment != proof of the public narrative.
+Candidate capture != reviewed ledger receipt.
+Fatal force event != automatic constitutional or criminal conclusion.
+```
+
+## Required routing
+
+Route to the civil-rights-high-risk queue with evidence-reviewer, civil-rights-reviewer, and legal-reviewer authority. Minimum quorum: 2. Preserve the case as unresolved until the official account, available recordings, witness evidence, medical evidence, and investigative records are reviewed together.


### PR DESCRIPTION
Adds a sourced, critical-risk force-event research candidate for the March 15, 2025 fatal shooting of Ruben Ray Martinez on South Padre Island.

The record separately preserves:
- the DHS official account;
- body-camera and security-footage variance;
- conflicting commands and witness posture;
- the grand-jury non-indictment as a charging outcome rather than proof of the public narrative;
- unresolved medical-response, disclosure, investigative, and legal questions.

The candidate is routed to civil-rights-high-risk review and does not assert final contradiction, criminal liability, constitutional violation, or publication authority.