### PR TITLE
Structure Ruben Ray Martinez force-event review packets

### DIFF
--- a/.github/workflows/validate-federal-force-events.yml
+++ b/.github/workflows/validate-federal-force-events.yml
@@ -1,0 +1,31 @@
+name: Validate Federal Force Events
+
+on:
+  pull_request:
+    paths:
+      - "schemas/federal-force-event.schema.json"
+      - "assessments/events/RRM-FORCE-*.json"
+      - "scripts/validate_federal_force_events.py"
+      - ".github/workflows/validate-federal-force-events.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "schemas/federal-force-event.schema.json"
+      - "assessments/events/RRM-FORCE-*.json"
+      - "scripts/validate_federal_force_events.py"
+      - ".github/workflows/validate-federal-force-events.yml"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validator
+        run: python -m pip install --upgrade jsonschema referencing
+      - name: Validate federal force-event packets
+        run: python scripts/validate_federal_force_events.py

--- a/assessments/events/RRM-FORCE-001-vehicle-encounter.json
+++ b/assessments/events/RRM-FORCE-001-vehicle-encounter.json
@@ -1,0 +1,19 @@
+{
+  "event_id": "RRM-FORCE-001",
+  "case_id": "RRM-SPI-2025-03-15",
+  "event_status": "candidate-review-required",
+  "event_type": "vehicle-encounter",
+  "event_date": "2025-03-15",
+  "location": "South Padre Island, Texas",
+  "subject": {"name": "Ruben Ray Martinez", "identity_status": "identified", "citizenship_posture": "reported United States citizen", "role_status": "driver"},
+  "government_action": {"agency": "Homeland Security Investigations assisting local police", "actor_identity_status": "partially-identified", "action_description": "Federal agents interacted with and positioned around Martinez's vehicle near a traffic-control scene.", "force_tools": []},
+  "official_assertions": ["DHS stated that Martinez intentionally struck or ran over an agent with the vehicle.", "Records describe an agent receiving treatment for a knee injury."],
+  "observed_or_reported_evidence": ["Released body-camera and security footage reportedly shows the vehicle moving slowly or nearly stationary near the time of the shooting.", "Brake lights are visible in released footage.", "Audio reportedly includes an instruction to keep moving followed by commands to stop.", "The passenger disputed intentional contact with an agent."],
+  "material_variances": ["The visible vehicle movement and conflicting commands require reconciliation with the assertion of an intentional vehicle assault.", "The available footage does not show every movement beside the driver's window."],
+  "prohibited_inferences": ["Video variance alone does not prove criminal liability or constitutional violation.", "An agent injury does not by itself establish intent or complete chronology."],
+  "missing_evidence": ["Complete unedited body-camera and security recordings", "Scene diagram and vehicle telemetry if available", "All agent and witness statements", "Medical documentation concerning the reported agent injury", "Dispatch and command records"],
+  "source_refs": ["research-candidates/2025-ruben-ray-martinez-south-padre-island.md", "Texas Tribune 2026-03-06 reporting", "Texas Tribune 2026-05-04 reconstruction", "CBS News body-camera analysis"],
+  "review_routing": {"queue": "civil-rights-high-risk", "risk_level": "critical", "required_authority": ["evidence-reviewer", "civil-rights-reviewer", "legal-reviewer"], "minimum_quorum": 2},
+  "classification": {"necessity": "not-established", "proportionality": "not-established", "lawfulness": "not-established", "official_account_reconciled": false, "confidence": "low", "notes": "Chronology and intent remain unresolved."},
+  "authority": {"automation_may_catalogue": true, "automation_may_flag_variance": true, "automation_may_decide_liability": false, "automation_may_find_constitutional_violation": false, "automation_may_publish": false}
+}

--- a/assessments/events/RRM-FORCE-002-firearm-discharge.json
+++ b/assessments/events/RRM-FORCE-002-firearm-discharge.json
@@ -1,0 +1,19 @@
+{
+  "event_id": "RRM-FORCE-002",
+  "case_id": "RRM-SPI-2025-03-15",
+  "event_status": "candidate-review-required",
+  "event_type": "firearm-discharge",
+  "event_date": "2025-03-15",
+  "location": "South Padre Island, Texas",
+  "subject": {"name": "Ruben Ray Martinez", "identity_status": "identified", "citizenship_posture": "reported United States citizen", "role_status": "driver and fatal-force subject"},
+  "government_action": {"agency": "Homeland Security Investigations", "actor_identity_status": "identified in later records", "action_description": "An HSI agent fired into Martinez's vehicle, fatally wounding him.", "force_tools": ["firearm"]},
+  "official_assertions": ["DHS described the shooting as defensive force after Martinez intentionally struck an agent with the vehicle."],
+  "observed_or_reported_evidence": ["Released recordings reportedly show slow or nearly stationary vehicle movement around the time shots were fired.", "The recordings do not fully show every movement beside the driver's window.", "Martinez died from the gunfire."],
+  "material_variances": ["The timing, vehicle movement, line of sight, agent position, commands, and perceived threat require frame-level reconstruction before the defensive-force account can be reconciled."],
+  "prohibited_inferences": ["A fatal outcome does not alone establish unlawfulness.", "A grand-jury non-indictment does not establish that every factual element of the public account was proven.", "Incomplete video does not permit filling gaps in favor of either party."],
+  "missing_evidence": ["Complete synchronized recordings", "Firearms and trajectory analysis", "Agent use-of-force reports and compelled statements", "Component use-of-force policy applicable on the event date", "Autopsy and medical records where lawfully available", "Evidence presented to the grand jury"],
+  "source_refs": ["research-candidates/2025-ruben-ray-martinez-south-padre-island.md", "Texas Tribune 2026-02-20 records reporting", "Texas Tribune 2026-03-06 video reporting", "Associated Press 2026 reporting", "Reuters 2026-02-21 reporting"],
+  "review_routing": {"queue": "civil-rights-high-risk", "risk_level": "critical", "required_authority": ["evidence-reviewer", "civil-rights-reviewer", "legal-reviewer"], "minimum_quorum": 2},
+  "classification": {"necessity": "disputed", "proportionality": "not-established", "lawfulness": "not-established", "official_account_reconciled": false, "confidence": "low", "notes": "The fatal firearm discharge is established; justification and legal standing remain unresolved."},
+  "authority": {"automation_may_catalogue": true, "automation_may_flag_variance": true, "automation_may_decide_liability": false, "automation_may_find_constitutional_violation": false, "automation_may_publish": false}
+}

--- a/assessments/events/RRM-FORCE-002-firearm-discharge.json
+++ b/assessments/events/RRM-FORCE-002-firearm-discharge.json
@@ -6,7 +6,7 @@
   "event_date": "2025-03-15",
   "location": "South Padre Island, Texas",
   "subject": {"name": "Ruben Ray Martinez", "identity_status": "identified", "citizenship_posture": "reported United States citizen", "role_status": "driver and fatal-force subject"},
-  "government_action": {"agency": "Homeland Security Investigations", "actor_identity_status": "identified in later records", "action_description": "An HSI agent fired into Martinez's vehicle, fatally wounding him.", "force_tools": ["firearm"]},
+  "government_action": {"agency": "Homeland Security Investigations", "actor_identity_status": "identified", "action_description": "An HSI agent, identified in later records, fired into Martinez's vehicle, fatally wounding him.", "force_tools": ["firearm"]},
   "official_assertions": ["DHS described the shooting as defensive force after Martinez intentionally struck an agent with the vehicle."],
   "observed_or_reported_evidence": ["Released recordings reportedly show slow or nearly stationary vehicle movement around the time shots were fired.", "The recordings do not fully show every movement beside the driver's window.", "Martinez died from the gunfire."],
   "material_variances": ["The timing, vehicle movement, line of sight, agent position, commands, and perceived threat require frame-level reconstruction before the defensive-force account can be reconciled."],

--- a/assessments/events/RRM-FORCE-003-post-shooting-response.json
+++ b/assessments/events/RRM-FORCE-003-post-shooting-response.json
@@ -1,0 +1,19 @@
+{
+  "event_id": "RRM-FORCE-003",
+  "case_id": "RRM-SPI-2025-03-15",
+  "event_status": "candidate-review-required",
+  "event_type": "post-force-restraint",
+  "event_date": "2025-03-15",
+  "location": "South Padre Island, Texas",
+  "subject": {"name": "Ruben Ray Martinez", "identity_status": "identified", "citizenship_posture": "reported United States citizen", "role_status": "wounded force subject"},
+  "government_action": {"agency": "Federal and local personnel at the scene", "actor_identity_status": "partially-identified", "action_description": "Personnel controlled the vehicle and scene after the shooting; the timing and nature of restraint and medical response require reconstruction.", "force_tools": ["scene control", "possible restraint"]},
+  "official_assertions": [],
+  "observed_or_reported_evidence": ["Reporting identifies unresolved questions concerning immediate medical response and post-shooting restraint practices.", "The currently catalogued public record is insufficient to reconstruct the full post-shooting timeline."],
+  "material_variances": ["The absence of a complete public medical-response timeline prevents evaluation of whether post-force duties were satisfied."],
+  "prohibited_inferences": ["Missing public records do not prove delayed aid or misconduct.", "Scene-security needs do not automatically resolve medical-response obligations."],
+  "missing_evidence": ["EMS dispatch and arrival records", "Body-camera footage after the firearm discharge", "Medical aid and restraint chronology", "Officer reports concerning scene safety and aid", "Autopsy and emergency-treatment records where lawfully available"],
+  "source_refs": ["research-candidates/2025-ruben-ray-martinez-south-padre-island.md", "Texas Tribune 2026-05-04 reconstruction"],
+  "review_routing": {"queue": "civil-rights-high-risk", "risk_level": "critical", "required_authority": ["evidence-reviewer", "civil-rights-reviewer", "legal-reviewer", "medical-evidence-reviewer"], "minimum_quorum": 2},
+  "classification": {"necessity": "not-established", "proportionality": "not-established", "lawfulness": "not-established", "official_account_reconciled": false, "confidence": "unknown", "notes": "The post-shooting response remains evidence-incomplete."},
+  "authority": {"automation_may_catalogue": true, "automation_may_flag_variance": true, "automation_may_decide_liability": false, "automation_may_find_constitutional_violation": false, "automation_may_publish": false}
+}

--- a/schemas/federal-force-event.schema.json
+++ b/schemas/federal-force-event.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger/schemas/federal-force-event.schema.json",
+  "title": "Federal Force Event Packet",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event_id", "case_id", "event_status", "event_type", "event_date", "location", "subject", "government_action", "official_assertions", "observed_or_reported_evidence", "material_variances", "missing_evidence", "source_refs", "review_routing", "classification", "authority"],
+  "properties": {
+    "event_id": {"type": "string", "pattern": "^[A-Z0-9-]+$"},
+    "case_id": {"type": "string", "pattern": "^[A-Z0-9-]+$"},
+    "event_status": {"enum": ["candidate-review-required", "under-review", "accepted-with-limitations", "disputed", "superseded"]},
+    "event_type": {"enum": ["vehicle-encounter", "firearm-discharge", "post-force-restraint", "medical-response", "disclosure-or-investigation", "other"]},
+    "event_date": {"type": "string", "format": "date"},
+    "location": {"type": "string", "minLength": 1},
+    "subject": {"type": "object", "additionalProperties": false, "required": ["name", "identity_status", "citizenship_posture", "role_status"], "properties": {"name": {"type": "string", "minLength": 1}, "identity_status": {"enum": ["identified", "partially-identified", "unknown"]}, "citizenship_posture": {"type": "string", "minLength": 1}, "role_status": {"type": "string", "minLength": 1}}},
+    "government_action": {"type": "object", "additionalProperties": false, "required": ["agency", "actor_identity_status", "action_description", "force_tools"], "properties": {"agency": {"type": "string", "minLength": 1}, "actor_identity_status": {"enum": ["identified", "partially-identified", "unknown"]}, "action_description": {"type": "string", "minLength": 1}, "force_tools": {"type": "array", "items": {"type": "string", "minLength": 1}}}},
+    "official_assertions": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "observed_or_reported_evidence": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "material_variances": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "prohibited_inferences": {"type": "array", "items": {"type": "string", "minLength": 1}},
+    "missing_evidence": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "source_refs": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "review_routing": {"type": "object", "additionalProperties": false, "required": ["queue", "risk_level", "required_authority", "minimum_quorum"], "properties": {"queue": {"const": "civil-rights-high-risk"}, "risk_level": {"const": "critical"}, "required_authority": {"type": "array", "minItems": 2, "uniqueItems": true, "items": {"enum": ["evidence-reviewer", "civil-rights-reviewer", "legal-reviewer", "medical-evidence-reviewer"]}}, "minimum_quorum": {"type": "integer", "minimum": 2}}},
+    "classification": {"type": "object", "additionalProperties": false, "required": ["necessity", "proportionality", "lawfulness", "official_account_reconciled", "confidence"], "properties": {"necessity": {"enum": ["not-established", "supported", "not-supported", "disputed"]}, "proportionality": {"enum": ["not-established", "supported", "not-supported", "disputed"]}, "lawfulness": {"enum": ["not-established", "supported", "not-supported", "disputed"]}, "official_account_reconciled": {"type": "boolean"}, "confidence": {"enum": ["high", "medium", "low", "unknown"]}, "notes": {"type": "string"}}},
+    "authority": {"type": "object", "additionalProperties": false, "required": ["automation_may_catalogue", "automation_may_flag_variance", "automation_may_decide_liability", "automation_may_find_constitutional_violation", "automation_may_publish"], "properties": {"automation_may_catalogue": {"const": true}, "automation_may_flag_variance": {"const": true}, "automation_may_decide_liability": {"const": false}, "automation_may_find_constitutional_violation": {"const": false}, "automation_may_publish": {"const": false}}}
+  }
+}

--- a/scripts/validate_federal_force_events.py
+++ b/scripts/validate_federal_force_events.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Validate repository-neutral federal force-event packets and authority boundaries."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = json.loads((ROOT / "schemas/federal-force-event.schema.json").read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    validator = Draft202012Validator(SCHEMA, format_checker=FormatChecker())
+    paths = sorted((ROOT / "assessments/events").glob("RRM-FORCE-*.json"))
+    if len(paths) != 3:
+        raise SystemExit(f"Expected three Ruben Ray Martinez force-event packets; found {len(paths)}")
+    ids: set[str] = set()
+    for path in paths:
+        document = json.loads(path.read_text(encoding="utf-8"))
+        errors = sorted(validator.iter_errors(document), key=lambda error: list(error.path))
+        if errors:
+            raise SystemExit(f"{path}: {errors[0].message}")
+        if document["event_id"] in ids:
+            raise SystemExit(f"Duplicate event ID: {document['event_id']}")
+        ids.add(document["event_id"])
+        if document["case_id"] != "RRM-SPI-2025-03-15":
+            raise SystemExit("Martinez packet escaped its case boundary")
+        if document["event_status"] != "candidate-review-required":
+            raise SystemExit("Unreviewed Martinez packet changed review status")
+        if document["classification"]["official_account_reconciled"]:
+            raise SystemExit("Automation falsely reconciled the official account")
+        authority = document["authority"]
+        if authority["automation_may_decide_liability"] or authority["automation_may_find_constitutional_violation"] or authority["automation_may_publish"]:
+            raise SystemExit("Federal force-event automation exceeded authority")
+        if document["review_routing"]["minimum_quorum"] < 2:
+            raise SystemExit("Critical civil-rights review requires quorum >= 2")
+    print(f"Validated {len(paths)} Ruben Ray Martinez federal force-event packets.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_force_event_packets.py
+++ b/scripts/validate_force_event_packets.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate individualized force-event packets and their cross-record links."""
+"""Validate Delaney Hall individualized force-event packets and their cross-record links."""
 
 from __future__ import annotations
 
@@ -50,9 +50,9 @@ def main() -> int:
         print(f"FAIL: unable to read {ASSESSMENT_INDEX.relative_to(ROOT)}: {exc}", file=sys.stderr)
         return 1
 
-    files = sorted(EVENT_DIR.glob("*.json"))
+    files = sorted(EVENT_DIR.glob("DH-FORCE-*.json"))
     if not files:
-        print("FAIL: no force-event packets found", file=sys.stderr)
+        print("FAIL: no Delaney Hall force-event packets found", file=sys.stderr)
         return 1
 
     failures: list[str] = []
@@ -122,7 +122,7 @@ def main() -> int:
         return 1
 
     print(
-        f"Validated {len(files)} individualized force-event packet(s), filenames, and assessment-index links."
+        f"Validated {len(files)} Delaney Hall individualized force-event packet(s), filenames, and assessment-index links."
     )
     return 0
 


### PR DESCRIPTION
## What changed

- adds a repository-neutral federal force-event schema rather than misusing the Delaney Hall-specific ID contract;
- creates individualized packets for the vehicle encounter, fatal firearm discharge, and post-shooting response;
- preserves official assertions, observed or reported evidence, material variances, missing evidence, prohibited inferences, and reviewer authority separately;
- adds dedicated CI validation for the new event class;
- routes the case to governed review in Issue #30.

## Authority boundary

The packets remain `candidate-review-required`. Automation may catalogue and flag variance; it may not reconcile the official account, decide liability, find a constitutional violation, or publish the case as reviewed.

Advances Issue #30.