### PR TITLE
Automate Ruben Ray Martinez governed review receipts

### DIFF
--- a/.github/workflows/aggregate-issue30-review.yml
+++ b/.github/workflows/aggregate-issue30-review.yml
@@ -1,0 +1,76 @@
+name: Aggregate Issue 30 Governed Review
+
+on:
+  issue_comment:
+    types: [created, edited]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  aggregate:
+    if: github.event_name == 'workflow_dispatch' || github.event.issue.number == 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validator
+        run: python -m pip install --upgrade jsonschema referencing
+      - name: Fetch all Issue 30 comments
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api --paginate repos/${{ github.repository }}/issues/30/comments > /tmp/issue30-comments.json
+      - name: Aggregate governed reviewer comments
+        run: |
+          rm -rf /tmp/issue30-review
+          mkdir -p /tmp/issue30-review
+          python scripts/aggregate_issue30_review.py \
+            --comments /tmp/issue30-comments.json \
+            --receipt /tmp/issue30-review/RRM-SPI-2025-03-15.json \
+            --state /tmp/issue30-review/state.json
+          cat /tmp/issue30-review/state.json
+      - name: Prepare governed receipt branch
+        id: prepare
+        run: |
+          created=$(python -c 'import json; print(str(json.load(open("/tmp/issue30-review/state.json"))["receipt_created"]).lower())')
+          echo "created=$created" >> "$GITHUB_OUTPUT"
+          if [ "$created" != "true" ]; then
+            exit 0
+          fi
+          branch="governed/issue-30-review-receipt"
+          git fetch origin "$branch" || true
+          if git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+            git checkout -B "$branch" "origin/$branch"
+          else
+            git checkout -b "$branch"
+          fi
+          mkdir -p assessments/reviewed-receipts review_state
+          cp /tmp/issue30-review/RRM-SPI-2025-03-15.json assessments/reviewed-receipts/RRM-SPI-2025-03-15.json
+          cp /tmp/issue30-review/state.json review_state/RRM-SPI-2025-03-15.json
+          git config user.name "stegverse-governance-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add assessments/reviewed-receipts/RRM-SPI-2025-03-15.json review_state/RRM-SPI-2025-03-15.json
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+          git commit -m "Record governed Issue 30 review receipt"
+          git push --force-with-lease origin "$branch"
+      - name: Open or update governed integration PR
+        if: steps.prepare.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="governed/issue-30-review-receipt"
+          existing=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --head "$branch" \
+              --base main \
+              --title "Record governed Ruben Ray Martinez review receipt" \
+              --body "Aggregates matching, independently authored Issue #30 reviewer comments into a schema-valid receipt. Automation did not select the disposition or expand reviewer findings. Closes #30 only after validation and reviewed-output propagation complete."
+          fi

--- a/.github/workflows/validate-issue30-review-automation.yml
+++ b/.github/workflows/validate-issue30-review-automation.yml
@@ -1,0 +1,70 @@
+name: Validate Issue 30 Review Automation
+
+on:
+  pull_request:
+    paths:
+      - "schemas/federal-force-review-receipt.schema.json"
+      - "scripts/aggregate_issue30_review.py"
+      - "samples/issue30-review-comments.sample.json"
+      - ".github/workflows/aggregate-issue30-review.yml"
+      - ".github/workflows/validate-issue30-review-automation.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/federal-force-review-receipt.schema.json"
+      - "scripts/aggregate_issue30_review.py"
+      - "samples/issue30-review-comments.sample.json"
+      - ".github/workflows/aggregate-issue30-review.yml"
+      - ".github/workflows/validate-issue30-review-automation.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade jsonschema referencing
+      - name: Prove matching quorum creates a bounded receipt
+        run: |
+          rm -rf /tmp/issue30-test
+          python scripts/aggregate_issue30_review.py \
+            --comments samples/issue30-review-comments.sample.json \
+            --receipt /tmp/issue30-test/receipt.json \
+            --state /tmp/issue30-test/state.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          receipt = json.loads(Path('/tmp/issue30-test/receipt.json').read_text())
+          state = json.loads(Path('/tmp/issue30-test/state.json').read_text())
+          assert state['receipt_created'] is True
+          assert state['manual_mechanics_remaining'] is False
+          assert receipt['disposition'] == 'accepted-with-limitations'
+          assert len({r['github_login'] for r in receipt['reviewers']}) >= 2
+          assert len({r['authority'] for r in receipt['reviewers']}) >= 2
+          assert receipt['authority']['automation_selected_disposition'] is False
+          assert receipt['authority']['automation_expanded_findings'] is False
+          PY
+      - name: Prove absent quorum remains blocked
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          comments = json.loads(Path('samples/issue30-review-comments.sample.json').read_text())[:1]
+          Path('/tmp/one-review.json').write_text(json.dumps(comments))
+          PY
+          rm -rf /tmp/issue30-blocked
+          python scripts/aggregate_issue30_review.py \
+            --comments /tmp/one-review.json \
+            --receipt /tmp/issue30-blocked/receipt.json \
+            --state /tmp/issue30-blocked/state.json
+          test ! -e /tmp/issue30-blocked/receipt.json
+          python - <<'PY'
+          import json
+          state = json.load(open('/tmp/issue30-blocked/state.json'))
+          assert state['status'] == 'awaiting-governed-review'
+          assert state['receipt_created'] is False
+          assert state['manual_mechanics_remaining'] is False
+          assert state['human_authority_remaining'] is True
+          PY

--- a/docs/review/ISSUE-30-AUTOMATED-REVIEW-PROTOCOL.md
+++ b/docs/review/ISSUE-30-AUTOMATED-REVIEW-PROTOCOL.md
@@ -1,0 +1,42 @@
+# Issue #30 automated governed-review protocol
+
+Issue #30 is the sole human evidentiary authority surface for case `RRM-SPI-2025-03-15`.
+
+Each reviewer records one independently authored comment using this exact structure:
+
+```text
+ERL-REVIEW-V1
+disposition: accepted-with-limitations
+authority: evidence-reviewer
+finding: <the reviewer's bounded finding>
+evidence-limit: <records or conclusions that remain unavailable or unresolved>
+```
+
+Allowed dispositions:
+
+- `accepted-with-limitations`
+- `needs-more-evidence`
+- `disputed`
+- `rejected-unsupported`
+- `rejected-out-of-scope`
+
+Allowed authorities:
+
+- `evidence-reviewer`
+- `civil-rights-reviewer`
+- `legal-reviewer`
+- `medical-evidence-reviewer`
+
+The workflow automatically reads every Issue #30 comment after creation or editing. A receipt is created only when at least two distinct GitHub reviewers, representing at least two distinct reviewer authorities, submit the same disposition. The latest valid comment from each login controls that reviewer's vote.
+
+When quorum exists, automation:
+
+1. copies reviewer-authored findings and evidence limits without expansion;
+2. creates a schema-valid reviewed receipt;
+3. creates or updates branch `governed/issue-30-review-receipt`;
+4. opens a governed integration pull request;
+5. leaves publication, compendium inclusion, propagation, and closure to the repository's existing reviewed-only validation chain.
+
+Automation may not choose a disposition, manufacture quorum, infer reviewer authority, add findings, resolve evidentiary conflicts, determine liability, or find a constitutional violation.
+
+No manual file creation, branch creation, commit, pull request, receipt formatting, or workflow dispatch is required after reviewers post their comments.

--- a/samples/issue30-review-comments.sample.json
+++ b/samples/issue30-review-comments.sample.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 300001,
+    "created_at": "2026-07-21T14:00:00Z",
+    "user": {"login": "evidence-reviewer-one"},
+    "body": "ERL-REVIEW-V1\ndisposition: accepted-with-limitations\nauthority: evidence-reviewer\nfinding: The fatal shooting and material variance between the public account and released recordings are sufficiently supported for constrained catalogue treatment.\nevidence-limit: Complete synchronized recordings, component reports, medical records, and grand-jury evidence remain unavailable."
+  },
+  {
+    "id": 300002,
+    "created_at": "2026-07-21T14:05:00Z",
+    "user": {"login": "civil-rights-reviewer-two"},
+    "body": "ERL-REVIEW-V1\ndisposition: accepted-with-limitations\nauthority: civil-rights-reviewer\nfinding: The case warrants reviewed inclusion as an unresolved federal fatal-force event without a final liability or constitutional conclusion.\nevidence-limit: The available public record does not complete the threat, intent, medical-response, or legal-authority reconstruction."
+  }
+]

--- a/schemas/federal-force-review-receipt.schema.json
+++ b/schemas/federal-force-review-receipt.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger/schemas/federal-force-review-receipt.schema.json",
+  "title": "Governed Federal Force Review Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["receipt_version", "issue_number", "case_id", "reviewed_event_ids", "disposition", "reviewers", "findings", "evidence_limits", "created_at", "authority"],
+  "properties": {
+    "receipt_version": {"const": "1.0"},
+    "issue_number": {"const": 30},
+    "case_id": {"const": "RRM-SPI-2025-03-15"},
+    "reviewed_event_ids": {"type": "array", "minItems": 3, "uniqueItems": true, "items": {"enum": ["RRM-FORCE-001", "RRM-FORCE-002", "RRM-FORCE-003"]}},
+    "disposition": {"enum": ["accepted-with-limitations", "needs-more-evidence", "disputed", "rejected-unsupported", "rejected-out-of-scope"]},
+    "reviewers": {
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["github_login", "authority", "comment_id", "comment_created_at"],
+        "properties": {
+          "github_login": {"type": "string", "minLength": 1},
+          "authority": {"enum": ["evidence-reviewer", "civil-rights-reviewer", "legal-reviewer", "medical-evidence-reviewer"]},
+          "comment_id": {"type": "integer", "minimum": 1},
+          "comment_created_at": {"type": "string", "format": "date-time"}
+        }
+      }
+    },
+    "findings": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "evidence_limits": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "created_at": {"type": "string", "format": "date-time"},
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["automation_aggregated_comments", "automation_selected_disposition", "automation_expanded_findings", "publication_authorized"],
+      "properties": {
+        "automation_aggregated_comments": {"const": true},
+        "automation_selected_disposition": {"const": false},
+        "automation_expanded_findings": {"const": false},
+        "publication_authorized": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/scripts/aggregate_issue30_review.py
+++ b/scripts/aggregate_issue30_review.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Aggregate bounded Issue #30 reviewer comments into a governed receipt.
+
+The script never invents a disposition or finding. It emits a blocked state until
+at least two distinct reviewers submit matching dispositions through ERL-REVIEW-V1
+comment blocks.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "federal-force-review-receipt.schema.json"
+MARKER = "ERL-REVIEW-V1"
+EVENTS = ["RRM-FORCE-001", "RRM-FORCE-002", "RRM-FORCE-003"]
+ALLOWED_AUTHORITY = {"evidence-reviewer", "civil-rights-reviewer", "legal-reviewer", "medical-evidence-reviewer"}
+ALLOWED_DISPOSITIONS = {"accepted-with-limitations", "needs-more-evidence", "disputed", "rejected-unsupported", "rejected-out-of-scope"}
+
+
+def parse_block(body: str) -> dict[str, object] | None:
+    if MARKER not in body:
+        return None
+    values: dict[str, str] = {}
+    for line in body.splitlines():
+        match = re.match(r"^([a-z-]+):\s*(.+?)\s*$", line.strip())
+        if match:
+            values[match.group(1)] = match.group(2)
+    required = {"disposition", "authority", "finding", "evidence-limit"}
+    if not required.issubset(values):
+        return None
+    if values["disposition"] not in ALLOWED_DISPOSITIONS or values["authority"] not in ALLOWED_AUTHORITY:
+        return None
+    return values
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--comments", required=True)
+    parser.add_argument("--receipt", required=True)
+    parser.add_argument("--state", required=True)
+    args = parser.parse_args()
+
+    comments = json.loads(Path(args.comments).read_text(encoding="utf-8"))
+    parsed: list[dict[str, object]] = []
+    for comment in comments:
+        block = parse_block(str(comment.get("body", "")))
+        if block is None:
+            continue
+        parsed.append({
+            **block,
+            "github_login": str(comment.get("user", {}).get("login", "")),
+            "comment_id": int(comment["id"]),
+            "comment_created_at": str(comment["created_at"]),
+        })
+
+    latest_by_login: dict[str, dict[str, object]] = {}
+    for item in sorted(parsed, key=lambda x: (str(x["comment_created_at"]), int(x["comment_id"]))):
+        latest_by_login[str(item["github_login"])] = item
+    votes = list(latest_by_login.values())
+
+    counts: dict[str, int] = {}
+    for vote in votes:
+        disposition = str(vote["disposition"])
+        counts[disposition] = counts.get(disposition, 0) + 1
+    agreed = sorted([key for key, count in counts.items() if count >= 2])
+
+    state = {
+        "case_id": "RRM-SPI-2025-03-15",
+        "issue_number": 30,
+        "status": "awaiting-governed-review",
+        "valid_reviewer_comments": len(votes),
+        "matching_quorum_dispositions": agreed,
+        "receipt_created": False,
+        "manual_mechanics_remaining": False,
+        "human_authority_remaining": True,
+    }
+
+    if len(agreed) == 1:
+        disposition = agreed[0]
+        agreeing = [vote for vote in votes if vote["disposition"] == disposition]
+        authorities = {str(vote["authority"]) for vote in agreeing}
+        if len(authorities) >= 2:
+            receipt = {
+                "receipt_version": "1.0",
+                "issue_number": 30,
+                "case_id": "RRM-SPI-2025-03-15",
+                "reviewed_event_ids": EVENTS,
+                "disposition": disposition,
+                "reviewers": [{
+                    "github_login": vote["github_login"],
+                    "authority": vote["authority"],
+                    "comment_id": vote["comment_id"],
+                    "comment_created_at": vote["comment_created_at"],
+                } for vote in agreeing],
+                "findings": [str(vote["finding"]) for vote in agreeing],
+                "evidence_limits": [str(vote["evidence-limit"]) for vote in agreeing],
+                "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+                "authority": {
+                    "automation_aggregated_comments": True,
+                    "automation_selected_disposition": False,
+                    "automation_expanded_findings": False,
+                    "publication_authorized": disposition == "accepted-with-limitations",
+                },
+            }
+            errors = list(Draft202012Validator(json.loads(SCHEMA.read_text())).iter_errors(receipt))
+            if errors:
+                raise SystemExit("Generated receipt failed schema validation: " + "; ".join(error.message for error in errors))
+            receipt_path = Path(args.receipt)
+            receipt_path.parent.mkdir(parents=True, exist_ok=True)
+            receipt_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+            state.update({"status": "governed-review-receipt-ready", "receipt_created": True, "human_authority_remaining": False, "disposition": disposition})
+
+    state_path = Path(args.state)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(state, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- adds a strict reviewed-receipt schema for Issue #30;
- parses bounded `ERL-REVIEW-V1` comments from Issue #30;
- requires matching dispositions from at least two distinct reviewers with at least two distinct authorities;
- automatically creates a governed receipt branch and integration PR when quorum exists;
- proves that absent quorum remains blocked;
- eliminates manual receipt formatting, branch creation, commits, PR creation, and workflow dispatch.

## Authority boundary

Automation aggregates reviewer-authored decisions but cannot select a disposition, infer authority, manufacture quorum, expand findings, determine liability, or find a constitutional violation.

Advances Issue #30.