### PR TITLE
Continuously monitor Ruben Ray Martinez evidence gaps

### DIFF
--- a/.github/workflows/monitor-ruben-ray-martinez-evidence.yml
+++ b/.github/workflows/monitor-ruben-ray-martinez-evidence.yml
@@ -1,0 +1,48 @@
+name: Monitor Ruben Ray Martinez Evidence
+
+on:
+  schedule:
+    - cron: "17 11 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run case evidence monitor
+        run: python scripts/run_case_evidence_monitor.py
+      - name: Create or update governed discovery PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="discovery/ruben-ray-martinez-evidence"
+          git fetch origin "$branch" || true
+          if git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+            git checkout -B "$branch" "origin/$branch"
+          else
+            git checkout -b "$branch"
+          fi
+          git config user.name "stegverse-discovery-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add discovery_candidates/ruben-ray-martinez/latest.json
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+          git commit -m "Refresh Ruben Ray Martinez evidence candidates"
+          git push --force-with-lease origin "$branch"
+          existing=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --head "$branch" \
+              --base main \
+              --title "Refresh Ruben Ray Martinez evidence candidates" \
+              --body "Daily keyless discovery refresh for Issue #30. Results remain candidate-generated with no evidentiary or publication effect until governed review."
+          fi

--- a/.github/workflows/validate-ruben-evidence-monitor.yml
+++ b/.github/workflows/validate-ruben-evidence-monitor.yml
@@ -1,0 +1,46 @@
+name: Validate Ruben Ray Martinez Evidence Monitor
+
+on:
+  pull_request:
+    paths:
+      - "config/ruben-ray-martinez-evidence-monitor.json"
+      - "scripts/run_case_evidence_monitor.py"
+      - "samples/ruben-ray-martinez-news.sample.xml"
+      - ".github/workflows/monitor-ruben-ray-martinez-evidence.yml"
+      - ".github/workflows/validate-ruben-evidence-monitor.yml"
+  push:
+    branches: [main]
+    paths:
+      - "config/ruben-ray-martinez-evidence-monitor.json"
+      - "scripts/run_case_evidence_monitor.py"
+      - "samples/ruben-ray-martinez-news.sample.xml"
+      - ".github/workflows/monitor-ruben-ray-martinez-evidence.yml"
+      - ".github/workflows/validate-ruben-evidence-monitor.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Generate deterministic discovery state
+        run: |
+          python scripts/run_case_evidence_monitor.py \
+            --fixture samples/ruben-ray-martinez-news.sample.xml \
+            --generated-at 2026-07-21T12:30:00Z \
+            --output /tmp/ruben-monitor.json
+      - name: Verify candidate-only authority
+        run: |
+          python - <<'PY'
+          import json
+          state = json.load(open('/tmp/ruben-monitor.json'))
+          assert state['status'] == 'healthy'
+          assert state['candidate_count'] == 1
+          assert state['candidates'][0]['review_status'] == 'candidate-generated'
+          assert state['candidates'][0]['evidence_effect'] == 'none-until-reviewed'
+          assert state['authority']['automation_may_establish_fact'] is False
+          assert state['authority']['automation_may_change_review_disposition'] is False
+          assert state['authority']['automation_may_publish'] is False
+          PY

--- a/config/ruben-ray-martinez-evidence-monitor.json
+++ b/config/ruben-ray-martinez-evidence-monitor.json
@@ -1,0 +1,31 @@
+{
+  "monitor_id": "ERL-RRM-EVIDENCE-MONITOR-001",
+  "case_id": "RRM-SPI-2025-03-15",
+  "enabled": true,
+  "cadence": "daily",
+  "queries": [
+    "\"Ruben Ray Martinez\" South Padre Island",
+    "\"Ruben Ray Martinez\" DHS HSI",
+    "\"Ruben Ray Martinez\" body camera",
+    "\"Ruben Ray Martinez\" grand jury",
+    "\"Ruben Ray Martinez\" inspector general",
+    "\"Ruben Ray Martinez\" lawsuit"
+  ],
+  "evidence_gaps": [
+    "complete synchronized body-camera and security recordings",
+    "HSI use-of-force reports and applicable component policy",
+    "agent and witness statements",
+    "medical-response and restraint chronology",
+    "autopsy, firearms, trajectory, and vehicle evidence",
+    "grand-jury evidence or later court filings",
+    "DHS inspector-general, congressional, administrative, or civil findings"
+  ],
+  "review_boundary": {
+    "automation_may_discover": true,
+    "automation_may_deduplicate": true,
+    "automation_may_stage_candidates": true,
+    "automation_may_establish_fact": false,
+    "automation_may_change_review_disposition": false,
+    "automation_may_publish": false
+  }
+}

--- a/samples/ruben-ray-martinez-news.sample.xml
+++ b/samples/ruben-ray-martinez-news.sample.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel><title>Sample</title><item><title>New records released in Ruben Ray Martinez shooting review</title><link>https://example.org/ruben-ray-martinez-records</link><pubDate>Tue, 21 Jul 2026 12:00:00 GMT</pubDate><source>Example News</source></item></channel></rss>

--- a/scripts/run_case_evidence_monitor.py
+++ b/scripts/run_case_evidence_monitor.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Run a keyless RSS evidence-gap monitor for the Ruben Ray Martinez case."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def stable_id(title: str, link: str) -> str:
+    digest = hashlib.sha256(f"{title}\n{link}".encode()).hexdigest()[:16]
+    return f"RRM-DISCOVERY-{digest.upper()}"
+
+
+def parse_rss(xml_text: str, query: str) -> list[dict[str, str]]:
+    root = ET.fromstring(xml_text)
+    items: list[dict[str, str]] = []
+    for item in root.findall(".//item"):
+        title = (item.findtext("title") or "").strip()
+        link = (item.findtext("link") or "").strip()
+        published = (item.findtext("pubDate") or "").strip()
+        source = (item.findtext("source") or "").strip()
+        if not title or not link:
+            continue
+        items.append({
+            "candidate_id": stable_id(title, link),
+            "title": title,
+            "url": link,
+            "publication_date": published,
+            "source_name": source,
+            "matched_query": query,
+            "review_status": "candidate-generated",
+            "evidence_effect": "none-until-reviewed",
+        })
+    return items
+
+
+def fetch_query(query: str) -> str:
+    encoded = urllib.parse.quote_plus(query)
+    url = f"https://news.google.com/rss/search?q={encoded}&hl=en-US&gl=US&ceid=US:en"
+    request = urllib.request.Request(url, headers={"User-Agent": "StegVerse-ERL-Evidence-Monitor/1.0"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="config/ruben-ray-martinez-evidence-monitor.json")
+    parser.add_argument("--output", default="discovery_candidates/ruben-ray-martinez/latest.json")
+    parser.add_argument("--fixture")
+    parser.add_argument("--generated-at")
+    args = parser.parse_args()
+
+    config = json.loads((ROOT / args.config).read_text())
+    generated_at = args.generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    candidates: dict[str, dict[str, str]] = {}
+    errors: list[dict[str, str]] = []
+
+    fixture_text = Path(args.fixture).read_text() if args.fixture else None
+    for query in config["queries"]:
+        try:
+            xml_text = fixture_text if fixture_text is not None else fetch_query(query)
+            for item in parse_rss(xml_text, query):
+                candidates[item["candidate_id"]] = item
+        except Exception as exc:  # network failures become machine-readable health state
+            errors.append({"query": query, "error": type(exc).__name__, "message": str(exc)[:300]})
+
+    output = {
+        "monitor_id": config["monitor_id"],
+        "case_id": config["case_id"],
+        "generated_at": generated_at,
+        "status": "healthy" if not errors else ("degraded" if candidates else "retry-pending"),
+        "candidate_count": len(candidates),
+        "candidates": sorted(candidates.values(), key=lambda item: (item["publication_date"], item["candidate_id"]), reverse=True),
+        "errors": errors,
+        "evidence_gaps": config["evidence_gaps"],
+        "authority": config["review_boundary"],
+    }
+    path = ROOT / args.output
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(output, indent=2) + "\n")
+    print(json.dumps({"status": output["status"], "candidate_count": output["candidate_count"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- adds a case-specific evidence-gap registry and daily keyless discovery monitor;
- queries current reporting for the Ruben Ray Martinez case without requiring API keys;
- deduplicates results with deterministic IDs;
- records transient failures as degraded or retry-pending health state;
- automatically creates or updates a governed discovery PR when candidates change;
- keeps all results candidate-only with no factual, review, or publication effect.

## Authority boundary

Discovery automation may find and stage leads. It may not establish facts, alter Issue #30's review disposition, determine liability, or publish the case.

Advances Issue #30.