### PR TITLE
Automate Issue 26 producer review receipt creation

### DIFF
--- a/.github/workflows/materialize-issue26-review.yml
+++ b/.github/workflows/materialize-issue26-review.yml
@@ -1,0 +1,71 @@
+name: Materialize Issue 26 Governed Review
+
+on:
+  issue_comment:
+    types: [created, edited]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  materialize:
+    if: github.event_name == 'workflow_dispatch' || github.event.issue.number == 26
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade jsonschema referencing
+      - name: Fetch Issue 26 comments and producer manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --paginate repos/${{ github.repository }}/issues/26/comments > /tmp/issue26-comments.json
+          gh api repos/StegVerse-Labs/Administrations/contents/datasets/exports/executive-rhetoric-ledger/manifest.json \
+            --jq '.content' | tr -d '\n' | base64 -d > /tmp/administrations-manifest.json
+      - name: Materialize bounded receipt
+        id: materialize
+        run: |
+          rm -rf /tmp/issue26-review
+          python scripts/materialize_issue26_review.py \
+            --comments /tmp/issue26-comments.json \
+            --manifest /tmp/administrations-manifest.json \
+            --receipt /tmp/issue26-review/ADMINISTRATIONS-EXPORT-EO14179-ACTION-001.json \
+            --state /tmp/issue26-review/state.json
+          created=$(python -c 'import json; print(str(json.load(open("/tmp/issue26-review/state.json"))["receipt_created"]).lower())')
+          echo "created=$created" >> "$GITHUB_OUTPUT"
+      - name: Create or update governed review branch
+        if: steps.materialize.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="governed/issue-26-review-receipt"
+          git fetch origin "$branch" || true
+          if git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+            git checkout -B "$branch" "origin/$branch"
+          else
+            git checkout -b "$branch"
+          fi
+          mkdir -p producer_intake/reviewed-receipts producer_intake/review-activation
+          cp /tmp/issue26-review/ADMINISTRATIONS-EXPORT-EO14179-ACTION-001.json producer_intake/reviewed-receipts/ADMINISTRATIONS-EXPORT-EO14179-ACTION-001.json
+          python scripts/verify_governed_producer_review.py
+          git config user.name "stegverse-governance-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add producer_intake/reviewed-receipts/ADMINISTRATIONS-EXPORT-EO14179-ACTION-001.json producer_intake/review-activation/ADMINISTRATIONS-EXPORT-EO14179-ACTION-001.json
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+          git commit -m "Record governed Issue 26 review receipt"
+          git push --force-with-lease origin "$branch"
+          existing=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --head "$branch" \
+              --base main \
+              --title "Record governed EO 14179 producer review" \
+              --body "Materializes the latest valid Issue #26 human disposition, resolves the producer export SHA-256 automatically, validates scope, and runs the existing reviewed-output activation path. Automation did not create or broaden the decision."
+          fi

--- a/.github/workflows/validate-issue26-comment-review.yml
+++ b/.github/workflows/validate-issue26-comment-review.yml
@@ -1,0 +1,67 @@
+name: Validate Issue 26 Comment Review
+
+on:
+  pull_request:
+    paths:
+      - "scripts/materialize_issue26_review.py"
+      - "samples/issue26-review-comments.sample.json"
+      - "samples/issue26-administrations-manifest.sample.json"
+      - ".github/workflows/materialize-issue26-review.yml"
+      - ".github/workflows/validate-issue26-comment-review.yml"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/materialize_issue26_review.py"
+      - "samples/issue26-review-comments.sample.json"
+      - "samples/issue26-administrations-manifest.sample.json"
+      - ".github/workflows/materialize-issue26-review.yml"
+      - ".github/workflows/validate-issue26-comment-review.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade jsonschema referencing
+      - name: Materialize deterministic receipt
+        run: |
+          rm -rf /tmp/issue26-test
+          python scripts/materialize_issue26_review.py \
+            --comments samples/issue26-review-comments.sample.json \
+            --manifest samples/issue26-administrations-manifest.sample.json \
+            --receipt /tmp/issue26-test/receipt.json \
+            --state /tmp/issue26-test/state.json
+          python - <<'PY'
+          import json
+          receipt = json.load(open('/tmp/issue26-test/receipt.json'))
+          state = json.load(open('/tmp/issue26-test/state.json'))
+          assert state['receipt_created'] is True
+          assert state['manual_mechanics_remaining'] is False
+          assert state['human_authority_remaining'] is False
+          assert receipt['export_sha256'] == '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+          assert receipt['disposition'] == 'approved-action-record'
+          assert receipt['scope']['documents_issuance_and_text'] is True
+          assert receipt['scope']['proves_embedded_rhetoric_truth'] is False
+          assert receipt['scope']['permits_broader_causation_claim'] is False
+          assert receipt['authority']['automation_may_create_decision'] is False
+          PY
+      - name: Prove absent comment remains blocked
+        run: |
+          echo '[]' > /tmp/no-comments.json
+          rm -rf /tmp/issue26-blocked
+          python scripts/materialize_issue26_review.py \
+            --comments /tmp/no-comments.json \
+            --manifest samples/issue26-administrations-manifest.sample.json \
+            --receipt /tmp/issue26-blocked/receipt.json \
+            --state /tmp/issue26-blocked/state.json
+          test ! -e /tmp/issue26-blocked/receipt.json
+          python - <<'PY'
+          import json
+          state = json.load(open('/tmp/issue26-blocked/state.json'))
+          assert state['status'] == 'awaiting-governed-review'
+          assert state['manual_mechanics_remaining'] is False
+          assert state['human_authority_remaining'] is True
+          PY

--- a/samples/issue26-administrations-manifest.sample.json
+++ b/samples/issue26-administrations-manifest.sample.json
@@ -1,0 +1,10 @@
+{
+  "producer_repo": "StegVerse-Labs/Administrations",
+  "exports": [
+    {
+      "ingestion_id": "ADMINISTRATIONS-EXPORT-EO14179-ACTION-001",
+      "path": "datasets/exports/executive-rhetoric-ledger/ADMINISTRATIONS-EXPORT-EO14179-ACTION-001.json",
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  ]
+}

--- a/samples/issue26-review-comments.sample.json
+++ b/samples/issue26-review-comments.sample.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": 260001,
+    "created_at": "2026-07-21T15:00:00Z",
+    "user": {"login": "governed-reviewer"},
+    "body": "ERL-PRODUCER-REVIEW-V1\ndisposition: approved-action-record\nrationale: The record is approved only as evidence that Executive Order 14179 was issued and contains the documented text; embedded claims and broader causation remain unproven.\ndocuments-issuance-and-text: true"
+  }
+]

--- a/scripts/materialize_issue26_review.py
+++ b/scripts/materialize_issue26_review.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Materialize the latest valid Issue #26 review comment into a governed receipt."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "producer-reviewed-receipt.schema.json"
+INTAKE_ID = "ADMINISTRATIONS-EXPORT-EO14179-ACTION-001"
+MARKER = "ERL-PRODUCER-REVIEW-V1"
+ALLOWED = {"approved-action-record", "needs-primary-source", "needs-context-revision", "rejected-unsupported", "rejected-out-of-scope"}
+
+
+def parse(body: str) -> dict[str, str] | None:
+    if MARKER not in body:
+        return None
+    fields: dict[str, str] = {}
+    for line in body.splitlines():
+        m = re.match(r"^([a-z-]+):\s*(.+?)\s*$", line.strip())
+        if m:
+            fields[m.group(1)] = m.group(2)
+    if not {"disposition", "rationale", "documents-issuance-and-text"}.issubset(fields):
+        return None
+    if fields["disposition"] not in ALLOWED:
+        return None
+    if fields["documents-issuance-and-text"].lower() not in {"true", "false"}:
+        return None
+    return fields
+
+
+def find_sha(value: object) -> str | None:
+    if isinstance(value, dict):
+        if value.get("ingestion_id") == INTAKE_ID or value.get("intake_id") == INTAKE_ID:
+            for key in ("sha256", "export_sha256", "record_sha256"):
+                candidate = value.get(key)
+                if isinstance(candidate, str) and re.fullmatch(r"[a-f0-9]{64}", candidate):
+                    return candidate
+        for child in value.values():
+            found = find_sha(child)
+            if found:
+                return found
+    elif isinstance(value, list):
+        for child in value:
+            found = find_sha(child)
+            if found:
+                return found
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--comments", required=True)
+    ap.add_argument("--manifest", required=True)
+    ap.add_argument("--receipt", required=True)
+    ap.add_argument("--state", required=True)
+    args = ap.parse_args()
+
+    comments = json.loads(Path(args.comments).read_text())
+    valid = []
+    for comment in comments:
+        parsed = parse(str(comment.get("body", "")))
+        if parsed:
+            valid.append((str(comment["created_at"]), int(comment["id"]), comment, parsed))
+    state = {"review_issue": 26, "intake_id": INTAKE_ID, "status": "awaiting-governed-review", "receipt_created": False, "manual_mechanics_remaining": False, "human_authority_remaining": True}
+    if valid:
+        _, comment_id, comment, fields = sorted(valid)[-1]
+        export_sha = find_sha(json.loads(Path(args.manifest).read_text()))
+        if not export_sha:
+            state["status"] = "retry-pending-manifest-hash"
+        else:
+            disposition = fields["disposition"]
+            issuance = fields["documents-issuance-and-text"].lower() == "true"
+            if disposition == "approved-action-record" and not issuance:
+                raise SystemExit("approved-action-record requires documents-issuance-and-text: true")
+            receipt = {
+                "review_receipt_id": f"ERL-ISSUE26-COMMENT-{comment_id}",
+                "review_issue": 26,
+                "reviewer": str(comment.get("user", {}).get("login", "")),
+                "reviewed_at": str(comment["created_at"]),
+                "producer_repository": "StegVerse-Labs/Administrations",
+                "intake_id": INTAKE_ID,
+                "export_sha256": export_sha,
+                "disposition": disposition,
+                "rationale": fields["rationale"],
+                "scope": {"documents_issuance_and_text": issuance, "proves_embedded_rhetoric_truth": False, "permits_broader_causation_claim": False},
+                "authority": {"human_reviewed": True, "automation_may_verify": True, "automation_may_create_decision": False, "automation_may_expand_scope": False}
+            }
+            errors = list(Draft202012Validator(json.loads(SCHEMA.read_text()), format_checker=FormatChecker()).iter_errors(receipt))
+            if errors:
+                raise SystemExit(errors[0].message)
+            out = Path(args.receipt); out.parent.mkdir(parents=True, exist_ok=True); out.write_text(json.dumps(receipt, indent=2) + "\n")
+            state.update({"status": "governed-review-receipt-ready", "receipt_created": True, "human_authority_remaining": False, "disposition": disposition})
+    state_path = Path(args.state); state_path.parent.mkdir(parents=True, exist_ok=True); state_path.write_text(json.dumps(state, indent=2) + "\n")
+    print(json.dumps(state, sort_keys=True))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- accepts the latest valid `ERL-PRODUCER-REVIEW-V1` comment on Issue #26;
- automatically resolves the current Administrations export SHA-256 from the producer manifest;
- materializes and validates the bounded reviewed receipt;
- runs the existing activation verifier;
- creates or updates a governed branch and integration PR;
- proves absent human disposition remains blocked.

## Authority boundary

Automation performs hash lookup, formatting, validation, branch creation, and PR creation. It may not create the disposition, broaden rationale, prove embedded rhetoric, or infer broader causation.

Advances Issues #26 and #18.