### PR TITLE
Route reviewed records to person-specific repositories

### DIFF
--- a/.github/workflows/activate-reviewed-producer-record.yml
+++ b/.github/workflows/activate-reviewed-producer-record.yml
@@ -6,8 +6,11 @@ on:
       - main
     paths:
       - "producer_intake/reviewed-receipts/**"
+      - "ledger_receipts/reviewed/**"
       - "schemas/producer-reviewed-receipt.schema.json"
+      - "integration/related-repositories.json"
       - "scripts/verify_governed_producer_review.py"
+      - "scripts/generate_compendium_and_deliveries.py"
       - ".github/workflows/activate-reviewed-producer-record.yml"
   workflow_dispatch:
 
@@ -46,9 +49,9 @@ jobs:
           PY
           )
           echo "eligible=$ELIGIBLE" >> "$GITHUB_OUTPUT"
-      - name: Generate reviewed-only compendium and delivery manifests
+      - name: Generate reviewed-only compendium, person projections, and delivery manifests
         if: steps.gate.outputs.eligible == 'true'
-        run: python scripts/generate_compendium_and_deliveries.py
+        run: python scripts/generate_compendium_and_deliveries.py --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
       - name: Verify destination propagation state
         if: steps.gate.outputs.eligible == 'true'
         run: python scripts/verify_destination_acknowledgments.py
@@ -60,14 +63,14 @@ jobs:
           git config user.name "stegverse-reviewed-producer-bot"
           git config user.email "stegverse-reviewed-producer-bot@users.noreply.github.com"
           git checkout -B "$BRANCH"
-          git add producer_intake/review-activation publication delivery_manifests propagation
+          git add producer_intake/review-activation publication person_specific_projections delivery_manifests propagation
           if git diff --cached --quiet; then
             echo "No post-review activation changes."
             exit 0
           fi
           git commit -m "chore: activate governed producer review result"
           git push --force-with-lease origin "$BRANCH"
-          BODY="Verified human-authored review receipt and generated only the mechanically authorized activation state. Automation did not create or broaden the review decision. Reviewed-only publication outputs are included only when the receipt disposition is approved-action-record."
+          BODY="Verified human-authored review receipt and generated only the mechanically authorized activation state. Automation did not create or broaden the review decision. Reviewed-only publication outputs and explicitly related person-specific projections are included only when the receipt disposition is approved-action-record. Person-specific projections cannot change native source records, destination verification labels, or evidentiary standing."
           if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
             gh pr edit "$BRANCH" --title "Activate governed producer review result" --body "$BODY"
           else

--- a/schemas/cross-repository-delivery.schema.json
+++ b/schemas/cross-repository-delivery.schema.json
@@ -23,14 +23,34 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["repository", "target_path", "delivery_status", "acknowledgment_required", "acknowledgment"],
+        "required": ["repository", "target_path", "delivery_status", "acknowledgment_required", "acknowledgment", "delivery_scope"],
         "properties": {
           "repository": {"type": "string", "minLength": 1},
           "target_path": {"type": "string", "minLength": 1},
+          "source_path": {"type": "string", "pattern": "^person_specific_projections/[a-z0-9-]+\\.json$"},
+          "source_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
           "delivery_status": {"enum": ["prepared", "delivered", "acknowledged", "failed"]},
           "acknowledgment_required": {"const": true},
-          "acknowledgment": {"type": ["object", "null"]}
-        }
+          "acknowledgment": {"type": ["object", "null"]},
+          "delivery_scope": {"enum": ["reviewed-compendium", "explicitly-related-reviewed-records-only"]}
+        },
+        "allOf": [
+          {
+            "if": {"properties": {"delivery_scope": {"const": "explicitly-related-reviewed-records-only"}}},
+            "then": {"required": ["source_path", "source_sha256"]}
+          },
+          {
+            "if": {"properties": {"delivery_scope": {"const": "reviewed-compendium"}}},
+            "then": {
+              "not": {
+                "anyOf": [
+                  {"required": ["source_path"]},
+                  {"required": ["source_sha256"]}
+                ]
+              }
+            }
+          }
+        ]
       }
     },
     "authority": {

--- a/scripts/generate_compendium_and_deliveries.py
+++ b/scripts/generate_compendium_and_deliveries.py
@@ -1,31 +1,204 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import argparse, hashlib, html, json
+
+import argparse
+import hashlib
+import html
+import json
+import re
 from pathlib import Path
+
 ROOT = Path(__file__).resolve().parents[1]
-DESTINATIONS = [
+RELATED_REPOSITORIES = ROOT / "integration" / "related-repositories.json"
+
+GENERAL_DESTINATIONS = [
     ("StegVerse-Labs/Site", "data/executive-rhetoric-ledger/compendium.json"),
     ("GCAT-BCAT-Engine/Publisher", "inputs/executive-rhetoric-ledger/compendium.json"),
     ("StegVerse-Labs/admissibility-wiki", "data/executive-rhetoric-ledger/compendium.json"),
     ("StegVerse-Labs/stegguardian-wiki", "data/executive-rhetoric-ledger/compendium.json"),
 ]
-def sha(data: bytes) -> str: return hashlib.sha256(data).hexdigest()
+
+
+def sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
 def title_of(text: str, fallback: str) -> str:
     for line in text.splitlines():
-        if line.startswith("# "): return line[2:].strip()
+        if line.startswith("# "):
+            return line[2:].strip()
     return fallback
 
+
+def slug(repository: str) -> str:
+    return repository.split("/", 1)[-1].lower().replace("_", "-")
+
+
+def reviewed_entries() -> list[dict]:
+    entries: list[dict] = []
+    for path in sorted((ROOT / "ledger_receipts" / "reviewed").glob("*.md")):
+        data = path.read_bytes()
+        text = data.decode("utf-8")
+        entries.append(
+            {
+                "entry_id": sha(str(path.relative_to(ROOT)).encode())[:20].upper(),
+                "title": title_of(text, path.stem),
+                "receipt_path": str(path.relative_to(ROOT)),
+                "receipt_sha256": sha(data),
+                "review_status": "reviewed",
+                "search_text": " ".join(text.split())[:12000],
+                "_source_text": text,
+            }
+        )
+    return entries
+
+
+def person_specific_repositories() -> list[dict]:
+    network = json.loads(RELATED_REPOSITORIES.read_text(encoding="utf-8"))
+    result = []
+    for item in network.get("repositories", []):
+        roles = set(item.get("roles", []))
+        if roles.intersection({"person-or-network-specific-record", "public-figure-record"}):
+            result.append(item)
+    return result
+
+
+def explicitly_related(entry: dict, repository: str) -> bool:
+    text = entry["_source_text"]
+    repo_short = repository.split("/", 1)[-1]
+    patterns = (
+        rf'producer_repo:\s*["\']?{re.escape(repository)}["\']?',
+        rf'producer_repo:\s*["\']?{re.escape(repo_short)}["\']?',
+        rf'person_specific_repository:\s*["\']?{re.escape(repository)}["\']?',
+        rf'person_specific_repository:\s*["\']?{re.escape(repo_short)}["\']?',
+        rf'target_repository:\s*["\']?{re.escape(repository)}["\']?',
+    )
+    return any(re.search(pattern, text, re.IGNORECASE) for pattern in patterns)
+
+
+def public_entry(entry: dict) -> dict:
+    return {key: value for key, value in entry.items() if not key.startswith("_")}
+
+
+def write_person_specific_projections(entries: list[dict], generated_at: str) -> list[dict]:
+    output_dir = ROOT / "person_specific_projections"
+    output_dir.mkdir(exist_ok=True)
+    destinations: list[dict] = []
+
+    for related in person_specific_repositories():
+        repository = related["repository"]
+        matched = [public_entry(entry) for entry in entries if explicitly_related(entry, repository)]
+        if not matched:
+            continue
+
+        projection = {
+            "schema": "stegverse.executive_rhetoric_ledger.person_specific_projection.v1",
+            "projection_id": "PERSON-PROJECTION-" + sha(
+                (repository + "|" + "|".join(item["receipt_sha256"] for item in matched)).encode()
+            )[:20].upper(),
+            "generated_at": generated_at,
+            "source_repository": "StegVerse-Labs/Executive_Rhetoric_Ledger",
+            "destination_repository": repository,
+            "projection_status": "reviewed-ledger-projection",
+            "entries": matched,
+            "evidence_boundary": related["evidence_boundary"],
+            "authority": {
+                "reviewed_only": True,
+                "may_include_candidates": False,
+                "may_change_native_source_records": False,
+                "may_change_destination_verification_labels": False,
+                "may_establish_culpability": False,
+                "may_claim_delivery": False,
+                "may_claim_acknowledgment": False,
+            },
+        }
+        material = json.dumps(projection, sort_keys=True, separators=(",", ":")).encode()
+        projection["projection_sha256"] = sha(material)
+        output_path = output_dir / f"{slug(repository)}.json"
+        output_path.write_text(json.dumps(projection, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        destinations.append(
+            {
+                "repository": repository,
+                "target_path": "data/receipts/ledger_reviewed_projections/latest.json",
+                "source_path": str(output_path.relative_to(ROOT)),
+                "source_sha256": sha(output_path.read_bytes()),
+                "delivery_status": "prepared",
+                "acknowledgment_required": True,
+                "acknowledgment": None,
+                "delivery_scope": "explicitly-related-reviewed-records-only",
+            }
+        )
+    return destinations
+
+
 def main() -> None:
-    p=argparse.ArgumentParser(); p.add_argument("--generated-at", required=True); a=p.parse_args()
-    entries=[]
-    for path in sorted((ROOT/"ledger_receipts/reviewed").glob("*.md")):
-        data=path.read_bytes(); text=data.decode("utf-8")
-        entries.append({"entry_id":sha(str(path.relative_to(ROOT)).encode())[:20].upper(),"title":title_of(text,path.stem),"receipt_path":str(path.relative_to(ROOT)),"receipt_sha256":sha(data),"review_status":"reviewed","search_text":" ".join(text.split())[:12000]})
-    pub={"publication_id":"COMPENDIUM-"+sha("|".join(e["receipt_sha256"] for e in entries).encode())[:20].upper(),"generated_at":a.generated_at,"publication_status":"reviewed-only-compendium","entries":entries,"authority":{"reviewed_only":True,"may_include_candidates":False,"may_promote":False}}
-    out=ROOT/"publication"; out.mkdir(exist_ok=True)
-    json_bytes=(json.dumps(pub,indent=2,sort_keys=True)+"\n").encode(); (out/"compendium.json").write_bytes(json_bytes)
-    rows="".join(f"<article><h2>{html.escape(e['title'])}</h2><p><code>{html.escape(e['receipt_path'])}</code></p></article>" for e in entries)
-    (out/"index.html").write_text("<!doctype html><html><head><meta charset='utf-8'><title>Executive Rhetoric Ledger</title></head><body><h1>Reviewed Receipt Compendium</h1>"+rows+"</body></html>\n",encoding="utf-8")
-    delivery={"delivery_id":"DELIVERY-"+sha(json_bytes)[:20].upper(),"generated_at":a.generated_at,"source_publication":{"path":"publication/compendium.json","sha256":sha(json_bytes)},"destinations":[{"repository":r,"target_path":t,"delivery_status":"prepared","acknowledgment_required":True,"acknowledgment":None} for r,t in DESTINATIONS],"authority":{"may_prepare":True,"may_claim_delivery":False,"may_claim_acknowledgment":False}}
-    d=ROOT/"delivery_manifests"; d.mkdir(exist_ok=True); (d/"generated.json").write_text(json.dumps(delivery,indent=2,sort_keys=True)+"\n",encoding="utf-8")
-if __name__=="__main__": main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--generated-at", required=True)
+    args = parser.parse_args()
+
+    entries = reviewed_entries()
+    public_entries = [public_entry(entry) for entry in entries]
+    publication = {
+        "publication_id": "COMPENDIUM-" + sha(
+            "|".join(entry["receipt_sha256"] for entry in public_entries).encode()
+        )[:20].upper(),
+        "generated_at": args.generated_at,
+        "publication_status": "reviewed-only-compendium",
+        "entries": public_entries,
+        "authority": {
+            "reviewed_only": True,
+            "may_include_candidates": False,
+            "may_promote": False,
+        },
+    }
+
+    publication_dir = ROOT / "publication"
+    publication_dir.mkdir(exist_ok=True)
+    json_bytes = (json.dumps(publication, indent=2, sort_keys=True) + "\n").encode()
+    (publication_dir / "compendium.json").write_bytes(json_bytes)
+    rows = "".join(
+        f"<article><h2>{html.escape(entry['title'])}</h2><p><code>{html.escape(entry['receipt_path'])}</code></p></article>"
+        for entry in public_entries
+    )
+    (publication_dir / "index.html").write_text(
+        "<!doctype html><html><head><meta charset='utf-8'><title>Executive Rhetoric Ledger</title></head>"
+        "<body><h1>Reviewed Receipt Compendium</h1>" + rows + "</body></html>\n",
+        encoding="utf-8",
+    )
+
+    destinations = [
+        {
+            "repository": repository,
+            "target_path": target_path,
+            "delivery_status": "prepared",
+            "acknowledgment_required": True,
+            "acknowledgment": None,
+            "delivery_scope": "reviewed-compendium",
+        }
+        for repository, target_path in GENERAL_DESTINATIONS
+    ]
+    destinations.extend(write_person_specific_projections(entries, args.generated_at))
+
+    delivery = {
+        "delivery_id": "DELIVERY-" + sha(json_bytes)[:20].upper(),
+        "generated_at": args.generated_at,
+        "source_publication": {
+            "path": "publication/compendium.json",
+            "sha256": sha(json_bytes),
+        },
+        "destinations": destinations,
+        "authority": {
+            "may_prepare": True,
+            "may_claim_delivery": False,
+            "may_claim_acknowledgment": False,
+        },
+    }
+    delivery_dir = ROOT / "delivery_manifests"
+    delivery_dir.mkdir(exist_ok=True)
+    (delivery_dir / "generated.json").write_text(
+        json.dumps(delivery, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_compendium_and_deliveries.py
+++ b/scripts/validate_compendium_and_deliveries.py
@@ -1,24 +1,92 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import hashlib, json
+
+import hashlib
+import json
 from pathlib import Path
+
 from jsonschema import Draft202012Validator
-ROOT=Path(__file__).resolve().parents[1]
-def load(p): return json.loads((ROOT/p).read_text())
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(path):
+    return json.loads((ROOT / path).read_text())
+
+
 def validate(schema_path, doc_path):
-    errors=list(Draft202012Validator(load(schema_path)).iter_errors(load(doc_path)))
-    if errors: raise SystemExit(f"{doc_path} failed schema validation: {errors[0].message}")
+    errors = list(Draft202012Validator(load(schema_path)).iter_errors(load(doc_path)))
+    if errors:
+        raise SystemExit(f"{doc_path} failed schema validation: {errors[0].message}")
+
+
+def validate_person_projection(destination: dict) -> None:
+    source_path = ROOT / destination["source_path"]
+    if not source_path.exists():
+        raise SystemExit(f"Person-specific projection missing: {destination['source_path']}")
+    raw = source_path.read_bytes()
+    if destination["source_sha256"] != hashlib.sha256(raw).hexdigest():
+        raise SystemExit("Person-specific projection delivery hash mismatch")
+    projection = json.loads(raw)
+    if projection.get("destination_repository") != destination["repository"]:
+        raise SystemExit("Person-specific projection destination mismatch")
+    if projection.get("projection_status") != "reviewed-ledger-projection":
+        raise SystemExit("Person-specific projection status is not reviewed")
+    authority = projection.get("authority") or {}
+    if authority.get("reviewed_only") is not True:
+        raise SystemExit("Person-specific projection is not reviewed-only")
+    for key in (
+        "may_include_candidates",
+        "may_change_native_source_records",
+        "may_change_destination_verification_labels",
+        "may_establish_culpability",
+        "may_claim_delivery",
+        "may_claim_acknowledgment",
+    ):
+        if authority.get(key) is not False:
+            raise SystemExit(f"Person-specific projection authority violation: {key}")
+    for entry in projection.get("entries", []):
+        if entry.get("review_status") != "reviewed":
+            raise SystemExit("Non-reviewed entry leaked into person-specific projection")
+        if not str(entry.get("receipt_path", "")).startswith("ledger_receipts/reviewed/"):
+            raise SystemExit("Person-specific projection entry is outside reviewed receipts")
+
+
 def main():
-    validate("schemas/publication-index.schema.json","publication/compendium.json")
-    validate("schemas/cross-repository-delivery.schema.json","delivery_manifests/generated.json")
-    pub=load("publication/compendium.json"); delivery=load("delivery_manifests/generated.json")
-    reviewed={str(p.relative_to(ROOT)) for p in (ROOT/"ledger_receipts/reviewed").glob("*.md")}
-    published={e["receipt_path"] for e in pub["entries"]}
-    if published != reviewed: raise SystemExit("Compendium must include all and only reviewed receipts")
-    forbidden=("discovery_candidates/","variance_candidates/","promotion_candidates/","review_assignments/")
-    if any(any(e["receipt_path"].startswith(x) for x in forbidden) for e in pub["entries"]): raise SystemExit("Candidate material leaked into publication")
-    data=(ROOT/"publication/compendium.json").read_bytes()
-    if delivery["source_publication"]["sha256"] != hashlib.sha256(data).hexdigest(): raise SystemExit("Delivery hash mismatch")
-    if any(d["delivery_status"]!="prepared" or d["acknowledgment"] is not None for d in delivery["destinations"]): raise SystemExit("Automation may only prepare unacknowledged deliveries")
-    print("Validated reviewed-only compendium and delivery authority boundaries")
-if __name__=="__main__": main()
+    validate("schemas/publication-index.schema.json", "publication/compendium.json")
+    validate("schemas/cross-repository-delivery.schema.json", "delivery_manifests/generated.json")
+    publication = load("publication/compendium.json")
+    delivery = load("delivery_manifests/generated.json")
+    reviewed = {
+        str(path.relative_to(ROOT)) for path in (ROOT / "ledger_receipts" / "reviewed").glob("*.md")
+    }
+    published = {entry["receipt_path"] for entry in publication["entries"]}
+    if published != reviewed:
+        raise SystemExit("Compendium must include all and only reviewed receipts")
+    forbidden = (
+        "discovery_candidates/",
+        "variance_candidates/",
+        "promotion_candidates/",
+        "review_assignments/",
+    )
+    if any(
+        any(entry["receipt_path"].startswith(prefix) for prefix in forbidden)
+        for entry in publication["entries"]
+    ):
+        raise SystemExit("Candidate material leaked into publication")
+    data = (ROOT / "publication" / "compendium.json").read_bytes()
+    if delivery["source_publication"]["sha256"] != hashlib.sha256(data).hexdigest():
+        raise SystemExit("Delivery hash mismatch")
+    if any(
+        item["delivery_status"] != "prepared" or item["acknowledgment"] is not None
+        for item in delivery["destinations"]
+    ):
+        raise SystemExit("Automation may only prepare unacknowledged deliveries")
+    for destination in delivery["destinations"]:
+        if destination["delivery_scope"] == "explicitly-related-reviewed-records-only":
+            validate_person_projection(destination)
+    print("Validated reviewed-only compendium, person-specific projections, and delivery authority boundaries")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_person_specific_projections.py
+++ b/tests/test_person_specific_projections.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "generate_compendium_and_deliveries.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("generate_compendium_and_deliveries", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_trumpality_receipt_is_explicitly_related() -> None:
+    module = load_module()
+    path = ROOT / "ledger_receipts" / "reviewed" / "PIT-MODERN-2025-AI-EO-14179__action-record.reviewed.md"
+    entry = {"_source_text": path.read_text(encoding="utf-8")}
+    assert module.explicitly_related(entry, "StegVerse-Labs/Trumpality") is True
+    assert module.explicitly_related(entry, "StegVerse-Labs/Giuffre-ality") is False
+    assert module.explicitly_related(entry, "StegVerse-Labs/Maxwellality") is False
+    assert module.explicitly_related(entry, "StegVerse-Labs/Epsteinality") is False
+
+
+def test_person_specific_projection_is_reviewed_only_and_non_authorizing(tmp_path, monkeypatch) -> None:
+    module = load_module()
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+    monkeypatch.setattr(module, "RELATED_REPOSITORIES", tmp_path / "integration" / "related-repositories.json")
+    (tmp_path / "integration").mkdir()
+    (tmp_path / "integration" / "related-repositories.json").write_text(
+        json.dumps(
+            {
+                "repositories": [
+                    {
+                        "repository": "StegVerse-Labs/Trumpality",
+                        "roles": ["person-or-network-specific-record"],
+                        "evidence_boundary": "Distinguish rhetoric, action, allegation, finding, and outcome.",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    entries = [
+        {
+            "entry_id": "ENTRY-1",
+            "title": "Reviewed action",
+            "receipt_path": "ledger_receipts/reviewed/example.md",
+            "receipt_sha256": "a" * 64,
+            "review_status": "reviewed",
+            "search_text": "reviewed action",
+            "_source_text": 'producer_repo: "StegVerse-Labs/Trumpality"',
+        },
+        {
+            "entry_id": "ENTRY-2",
+            "title": "Unrelated reviewed action",
+            "receipt_path": "ledger_receipts/reviewed/unrelated.md",
+            "receipt_sha256": "b" * 64,
+            "review_status": "reviewed",
+            "search_text": "unrelated",
+            "_source_text": 'producer_repo: "StegVerse-Labs/Administrations"',
+        },
+    ]
+
+    destinations = module.write_person_specific_projections(entries, "2026-07-22T00:00:00Z")
+    assert len(destinations) == 1
+    projection_path = tmp_path / destinations[0]["source_path"]
+    projection = json.loads(projection_path.read_text(encoding="utf-8"))
+    assert projection["destination_repository"] == "StegVerse-Labs/Trumpality"
+    assert [item["entry_id"] for item in projection["entries"]] == ["ENTRY-1"]
+    assert projection["authority"] == {
+        "reviewed_only": True,
+        "may_include_candidates": False,
+        "may_change_native_source_records": False,
+        "may_change_destination_verification_labels": False,
+        "may_establish_culpability": False,
+        "may_claim_delivery": False,
+        "may_claim_acknowledgment": False,
+    }
+    material = dict(projection)
+    expected = material.pop("projection_sha256")
+    import hashlib
+    actual = hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    assert expected == actual


### PR DESCRIPTION
Extends the existing reviewed-only compendium and delivery generator with filtered person-specific projections. A reviewed receipt is routed only when it explicitly names a declared person-specific repository through producer_repo/person_specific_repository/target_repository metadata. The first vertical slice routes the already-reviewed EO 14179 action record to StegVerse-Labs/Trumpality. General compendium delivery remains unchanged. Projections cannot include candidates, mutate destination native records or verification labels, establish culpability, or claim delivery/acknowledgment. The existing post-review workflow and PR are reused; no scheduler, evidence authority, or publication authority is added.