### PR TITLE
Add live OSINT sources for Operation Charlotte's Web

### DIFF
--- a/config/source-adapters.json
+++ b/config/source-adapters.json
@@ -22,7 +22,7 @@
     {
       "adapter_id": "SCSJ_REISINI_ROOS_CASE_PAGE",
       "enabled": true,
-      "adapter_type": "http",
+      "adapter_type": "html-document",
       "source_class": "advocacy-record",
       "endpoint": "https://southerncoalition.org/case/reisini-roos-v-u-s-department-of-homeland-security-et-al/",
       "request_headers": {
@@ -44,7 +44,7 @@
     {
       "adapter_id": "SCSJ_REISINI_ROOS_FTCA_ANNOUNCEMENT",
       "enabled": true,
-      "adapter_type": "http",
+      "adapter_type": "html-document",
       "source_class": "advocacy-record",
       "endpoint": "https://southerncoalition.org/two-women-assaulted-arrested-during-operation-charlottes-web-file-federal-claims-against-immigration-agents/",
       "request_headers": {
@@ -66,7 +66,7 @@
     {
       "adapter_id": "WBTV_REISINI_ROOS_OPERATION_CHARLOTTES_WEB",
       "enabled": true,
-      "adapter_type": "http",
+      "adapter_type": "html-document",
       "source_class": "local-reporting",
       "endpoint": "https://www.wbtv.com/2026/07/22/charlotte-women-file-claims-notice-against-us-government-after-arrest-during-operation-charlottes-web/",
       "request_headers": {

--- a/config/source-adapters.json
+++ b/config/source-adapters.json
@@ -18,6 +18,72 @@
         "automation_may_propose": true,
         "automation_may_promote": false
       }
+    },
+    {
+      "adapter_id": "SCSJ_REISINI_ROOS_CASE_PAGE",
+      "enabled": true,
+      "adapter_type": "http",
+      "source_class": "advocacy-record",
+      "endpoint": "https://southerncoalition.org/case/reisini-roos-v-u-s-department-of-homeland-security-et-al/",
+      "request_headers": {
+        "User-Agent": "StegVerse-ERL-OSINT/1.0 (+https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger)"
+      },
+      "timeout_seconds": 30,
+      "capture_policy": {
+        "retain_raw": true,
+        "hash_algorithm": "sha256",
+        "deduplicate": true,
+        "archive_directory": "archive/captures"
+      },
+      "review_boundary": {
+        "automation_may_capture": true,
+        "automation_may_propose": true,
+        "automation_may_promote": false
+      }
+    },
+    {
+      "adapter_id": "SCSJ_REISINI_ROOS_FTCA_ANNOUNCEMENT",
+      "enabled": true,
+      "adapter_type": "http",
+      "source_class": "advocacy-record",
+      "endpoint": "https://southerncoalition.org/two-women-assaulted-arrested-during-operation-charlottes-web-file-federal-claims-against-immigration-agents/",
+      "request_headers": {
+        "User-Agent": "StegVerse-ERL-OSINT/1.0 (+https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger)"
+      },
+      "timeout_seconds": 30,
+      "capture_policy": {
+        "retain_raw": true,
+        "hash_algorithm": "sha256",
+        "deduplicate": true,
+        "archive_directory": "archive/captures"
+      },
+      "review_boundary": {
+        "automation_may_capture": true,
+        "automation_may_propose": true,
+        "automation_may_promote": false
+      }
+    },
+    {
+      "adapter_id": "WBTV_REISINI_ROOS_OPERATION_CHARLOTTES_WEB",
+      "enabled": true,
+      "adapter_type": "http",
+      "source_class": "local-reporting",
+      "endpoint": "https://www.wbtv.com/2026/07/22/charlotte-women-file-claims-notice-against-us-government-after-arrest-during-operation-charlottes-web/",
+      "request_headers": {
+        "User-Agent": "StegVerse-ERL-OSINT/1.0 (+https://github.com/StegVerse-Labs/Executive_Rhetoric_Ledger)"
+      },
+      "timeout_seconds": 30,
+      "capture_policy": {
+        "retain_raw": true,
+        "hash_algorithm": "sha256",
+        "deduplicate": true,
+        "archive_directory": "archive/captures"
+      },
+      "review_boundary": {
+        "automation_may_capture": true,
+        "automation_may_propose": true,
+        "automation_may_promote": false
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds three live governed source adapters for the Reisini & Roos / Operation Charlotte's Web matter: the Southern Coalition for Social Justice case page, its July 20, 2026 FTCA filing announcement, and WBTV local reporting. This converts the user-provided MSN lead into primary/near-primary and local-source monitoring. Adapters retain raw bytes, hash and deduplicate captures, and create review-required candidates only. Automation may not promote, establish truth, assign culpability, or bypass governed review. The incident date and later filing date remain distinct evidence events.