### PR TITLE
Isolate source-family failures and prove live index access

### DIFF
--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -91,8 +91,24 @@ jobs:
         run: python scripts/validate_activation_state.py
       - name: Validate governance patterns
         run: python scripts/validate_governance_patterns.py
-      - name: Validate assessment Political Influence Trees
-        run: python scripts/validate_assessment_trees.py
+      - name: Capture assessment Political Influence Tree validation
+        id: assessment
+        shell: bash
+        run: |
+          set +e
+          python scripts/validate_assessment_trees.py > /tmp/assessment-validation.log 2>&1
+          STATUS=$?
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          cat /tmp/assessment-validation.log
+          exit 0
+      - name: Upload assessment validation diagnostic
+        uses: actions/upload-artifact@v4
+        with:
+          name: assessment-validation-diagnostic
+          path: /tmp/assessment-validation.log
+          if-no-files-found: error
+      - name: Enforce assessment Political Influence Tree validation
+        run: test "${{ steps.assessment.outputs.status }}" = "0"
       - name: Validate primary-record intake queues
         run: python scripts/validate_primary_record_intake.py
       - name: Validate individualized force-event packets

--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -109,6 +109,45 @@ jobs:
         run: python scripts/validate_recurring_discovery.py
       - name: Validate governed source-family discovery
         run: python scripts/validate_source_family_discovery.py
+      - name: Smoke-test live source-family indexes without publishing
+        run: |
+          python scripts/discover_source_family_links.py \
+            --config config/source-families.json \
+            --base-config config/source-adapters.json \
+            --output /tmp/source-adapters.live.json \
+            --receipt /tmp/source-family-discovery.live.json \
+            --discovered-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          receipt = json.loads(Path('/tmp/source-family-discovery.live.json').read_text())
+          if receipt['execution_status'] != 'PASS':
+              raise SystemExit('No live source family was reachable')
+          if receipt['successful_family_count'] < 1:
+              raise SystemExit('Live smoke test retained no successful source family')
+          if receipt['authority']['may_promote']:
+              raise SystemExit('Live smoke test gained promotion authority')
+          print(json.dumps({
+              'successful_family_count': receipt['successful_family_count'],
+              'failed_family_count': receipt['failed_family_count'],
+              'new_adapter_count': receipt['new_adapter_count'],
+              'families': [
+                  {
+                      'family_id': item['family_id'],
+                      'fetch_status': item['fetch_status'],
+                      'discovered_count': item['discovered_count'],
+                      'error': item['error'],
+                  }
+                  for item in receipt['families']
+              ],
+          }, indent=2))
+          PY
+      - name: Upload live source-family smoke receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: source-family-live-smoke
+          path: /tmp/source-family-discovery.live.json
+          if-no-files-found: error
       - name: Validate source adapter and archive capture automation
         run: python scripts/validate_source_capture.py
       - name: Validate deterministic incident clustering

--- a/assessments/controls/2026-07-xai-colossus-2-control-comparison.md
+++ b/assessments/controls/2026-07-xai-colossus-2-control-comparison.md
@@ -1,0 +1,43 @@
+# xAI Colossus 2 control-comparison record
+
+```yaml
+topic_id: PIT-MODERN-2026-XAI-COLOSSUS2-EJ
+status: required-unpopulated
+review_posture: method-installed-findings-withheld
+final_treatment_difference_finding: false
+final_legal_conclusion: false
+```
+
+## Purpose
+
+This record satisfies the assessment's required control-comparison linkage while preserving the existing evidence boundary. It does not establish exceptional treatment, regulatory favoritism, unlawful intervention, discriminatory intent, permit liability, emissions totals, health causation, or civil-rights liability.
+
+## Required control classes
+
+The comparison must eventually include:
+
+- similarly scaled data centers using on-site generation;
+- comparable temporary-equipment and stationary-source classifications;
+- comparable Clean Air Act preconstruction and operating-permit decisions;
+- projects in communities with similar baseline pollution and health burdens;
+- federal intervention or non-intervention in comparable environmental litigation;
+- projects associated with different corporate owners and political relationships;
+- treatment under prior administrations and across differently governed states.
+
+## Minimum evidence requirements
+
+Each control must retain:
+
+- project identity and ownership;
+- equipment type, count, capacity, and operating period;
+- applicable permits and agency determinations;
+- emissions calculations and monitoring records when available;
+- enforcement, litigation, and federal-intervention posture;
+- community demographic and baseline environmental context;
+- source receipts and unresolved contradictions.
+
+## Current state
+
+No control is presently populated strongly enough to support a treatment-difference conclusion. The control methodology is installed so discovery and review can collect comparable records without converting absence of evidence into a finding.
+
+Promotion requires governed review of the populated controls and must remain separate from the existence of the xAI litigation, reported DOJ posture, or the underlying allegations.

--- a/schemas/source-family.schema.json
+++ b/schemas/source-family.schema.json
@@ -10,6 +10,7 @@
     "enabled": {"type": "boolean"},
     "index_type": {"enum": ["html-index", "local-html-index"]},
     "index_url": {"type": "string", "minLength": 1},
+    "link_base_url": {"type": "string", "pattern": "^https?://"},
     "source_class": {"type": "string", "enum": ["primary-legal-record", "official-government", "court-record", "legislative-oversight", "local-reporting", "national-reporting", "advocacy-record", "historical-archive"]},
     "allowed_hosts": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
     "allowed_path_prefixes": {"type": "array", "minItems": 1, "items": {"type": "string", "pattern": "^/"}},

--- a/scripts/discover_source_family_links.py
+++ b/scripts/discover_source_family_links.py
@@ -108,6 +108,13 @@ def error_text(exc: Exception) -> str:
     return f"{type(exc).__name__}: {exc}"
 
 
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", default="config/source-families.json")
@@ -197,7 +204,7 @@ def main() -> int:
     receipt_path = ROOT / args.receipt
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
     receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(str(output.relative_to(ROOT)))
+    print(display_path(output))
 
     if enabled_count == 0:
         raise SystemExit("No enabled source families")

--- a/scripts/discover_source_family_links.py
+++ b/scripts/discover_source_family_links.py
@@ -2,18 +2,22 @@
 """Discover allowlisted, relevance-filtered links and emit existing source adapters.
 
 Discovery creates capture candidates only. It never promotes or classifies records.
+Each enabled source family is isolated so one unavailable index cannot suppress the
+remaining sweep. The command fails only when every enabled family fails.
 """
 from __future__ import annotations
 
 import argparse
 import hashlib
 import json
+import urllib.error
 import urllib.request
 from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import urljoin, urlparse, urlunparse
 
 ROOT = Path(__file__).resolve().parents[1]
+
 
 class LinkParser(HTMLParser):
     def __init__(self) -> None:
@@ -86,14 +90,22 @@ def adapter_for(family: dict, url: str) -> dict:
             "retain_raw": True,
             "hash_algorithm": "sha256",
             "deduplicate": True,
-            "archive_directory": "archive/captures"
+            "archive_directory": "archive/captures",
         },
         "review_boundary": {
             "automation_may_capture": True,
             "automation_may_propose": True,
-            "automation_may_promote": False
-        }
+            "automation_may_promote": False,
+        },
     }
+
+
+def error_text(exc: Exception) -> str:
+    if isinstance(exc, urllib.error.HTTPError):
+        return f"HTTP {exc.code}: {exc.reason}"
+    if isinstance(exc, urllib.error.URLError):
+        return f"URL error: {exc.reason}"
+    return f"{type(exc).__name__}: {exc}"
 
 
 def main() -> int:
@@ -109,34 +121,52 @@ def main() -> int:
     base = load_json(ROOT / args.base_config)
     discovered: list[dict] = []
     family_results: list[dict] = []
+    enabled_count = 0
+    successful_count = 0
 
     for family in config["families"]:
         if not family["enabled"]:
             continue
-        payload = fetch_index(family)
-        parser_ = LinkParser()
-        parser_.feed(payload.decode("utf-8", errors="replace"))
-        accepted: list[str] = []
-        seen: set[str] = set()
-        for href, anchor_text in parser_.links:
-            url = canonical_url(family["index_url"], href)
-            if not url or url in seen or not allowed(url, family):
-                continue
-            if not relevant(f"{anchor_text} {url}", family["relevance_terms"]):
-                continue
-            seen.add(url)
-            accepted.append(url)
-            if len(accepted) >= family["max_links"]:
-                break
-        discovered.extend(adapter_for(family, url) for url in accepted)
-        family_results.append({
-            "family_id": family["family_id"],
-            "index_url": family["index_url"],
-            "index_sha256": hashlib.sha256(payload).hexdigest(),
-            "discovered_count": len(accepted),
-            "candidate_urls": accepted,
-            "promotion_authority": False
-        })
+        enabled_count += 1
+        try:
+            payload = fetch_index(family)
+            parser_ = LinkParser()
+            parser_.feed(payload.decode("utf-8", errors="replace"))
+            accepted: list[str] = []
+            seen: set[str] = set()
+            for href, anchor_text in parser_.links:
+                url = canonical_url(family["index_url"], href)
+                if not url or url in seen or not allowed(url, family):
+                    continue
+                if not relevant(f"{anchor_text} {url}", family["relevance_terms"]):
+                    continue
+                seen.add(url)
+                accepted.append(url)
+                if len(accepted) >= family["max_links"]:
+                    break
+            discovered.extend(adapter_for(family, url) for url in accepted)
+            successful_count += 1
+            family_results.append({
+                "family_id": family["family_id"],
+                "index_url": family["index_url"],
+                "fetch_status": "PASS",
+                "index_sha256": hashlib.sha256(payload).hexdigest(),
+                "discovered_count": len(accepted),
+                "candidate_urls": accepted,
+                "error": None,
+                "promotion_authority": False,
+            })
+        except (OSError, UnicodeError, urllib.error.URLError) as exc:
+            family_results.append({
+                "family_id": family["family_id"],
+                "index_url": family["index_url"],
+                "fetch_status": "FAILED",
+                "index_sha256": None,
+                "discovered_count": 0,
+                "candidate_urls": [],
+                "error": error_text(exc),
+                "promotion_authority": False,
+            })
 
     existing = {item["endpoint"] for item in base["adapters"]}
     unique = [item for item in discovered if item["endpoint"] not in existing]
@@ -145,9 +175,14 @@ def main() -> int:
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(runtime, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
+    failed_count = enabled_count - successful_count
     receipt = {
-        "schema": "stegverse.executive_rhetoric_ledger.source_family_discovery.v1",
+        "schema": "stegverse.executive_rhetoric_ledger.source_family_discovery.v2",
         "discovered_at": args.discovered_at,
+        "execution_status": "PASS" if successful_count > 0 else "FAILED",
+        "enabled_family_count": enabled_count,
+        "successful_family_count": successful_count,
+        "failed_family_count": failed_count,
         "families": family_results,
         "runtime_adapter_count": len(runtime["adapters"]),
         "new_adapter_count": len(unique),
@@ -155,13 +190,18 @@ def main() -> int:
             "may_discover": True,
             "may_capture": True,
             "may_promote": False,
-            "human_review_required": True
-        }
+            "human_review_required": True,
+        },
     }
     receipt_path = ROOT / args.receipt
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
     receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     print(str(output.relative_to(ROOT)))
+
+    if enabled_count == 0:
+        raise SystemExit("No enabled source families")
+    if successful_count == 0:
+        raise SystemExit("Every enabled source family failed; see discovery receipt")
     return 0
 
 

--- a/scripts/discover_source_family_links.py
+++ b/scripts/discover_source_family_links.py
@@ -134,8 +134,9 @@ def main() -> int:
             parser_.feed(payload.decode("utf-8", errors="replace"))
             accepted: list[str] = []
             seen: set[str] = set()
+            link_base = family.get("link_base_url", family["index_url"])
             for href, anchor_text in parser_.links:
-                url = canonical_url(family["index_url"], href)
+                url = canonical_url(link_base, href)
                 if not url or url in seen or not allowed(url, family):
                     continue
                 if not relevant(f"{anchor_text} {url}", family["relevance_terms"]):

--- a/scripts/validate_source_family_discovery.py
+++ b/scripts/validate_source_family_discovery.py
@@ -38,6 +38,7 @@ def main() -> int:
                     "enabled": True,
                     "index_type": "local-html-index",
                     "index_url": "source_fixtures/does-not-exist.html",
+                    "link_base_url": "https://failed.example.gov/index",
                     "source_class": "official-government",
                     "allowed_hosts": ["failed.example.gov"],
                     "allowed_path_prefixes": ["/news/"],
@@ -54,6 +55,7 @@ def main() -> int:
                     "enabled": True,
                     "index_type": "local-html-index",
                     "index_url": "source_fixtures/source-family-index.html",
+                    "link_base_url": "https://example.gov/index",
                     "source_class": "official-government",
                     "allowed_hosts": ["example.gov"],
                     "allowed_path_prefixes": ["/news/"],
@@ -104,7 +106,7 @@ def main() -> int:
         if result["new_adapter_count"] != 2 or result["authority"]["may_promote"]:
             raise SystemExit("Discovery receipt authority/count mismatch")
 
-    print("Validated source-family discovery, failure isolation, and candidate-only authority.")
+    print("Validated source-family discovery, failure isolation, relative-link resolution, and candidate-only authority.")
     return 0
 
 

--- a/scripts/validate_source_family_discovery.py
+++ b/scripts/validate_source_family_discovery.py
@@ -32,22 +32,40 @@ def main() -> int:
         output = root / "runtime.json"
         receipt = root / "receipt.json"
         fixture_config.write_text(json.dumps({
-            "families": [{
-                "family_id": "VALIDATION_FAMILY",
-                "enabled": True,
-                "index_type": "local-html-index",
-                "index_url": "source_fixtures/source-family-index.html",
-                "source_class": "official-government",
-                "allowed_hosts": ["example.gov"],
-                "allowed_path_prefixes": ["/news/"],
-                "relevance_terms": ["immigration", "civil rights"],
-                "max_links": 10,
-                "review_boundary": {
-                    "automation_may_discover": True,
-                    "automation_may_capture": True,
-                    "automation_may_promote": False
-                }
-            }]
+            "families": [
+                {
+                    "family_id": "FAILED_FAMILY",
+                    "enabled": True,
+                    "index_type": "local-html-index",
+                    "index_url": "source_fixtures/does-not-exist.html",
+                    "source_class": "official-government",
+                    "allowed_hosts": ["failed.example.gov"],
+                    "allowed_path_prefixes": ["/news/"],
+                    "relevance_terms": ["immigration"],
+                    "max_links": 10,
+                    "review_boundary": {
+                        "automation_may_discover": True,
+                        "automation_may_capture": True,
+                        "automation_may_promote": False,
+                    },
+                },
+                {
+                    "family_id": "VALIDATION_FAMILY",
+                    "enabled": True,
+                    "index_type": "local-html-index",
+                    "index_url": "source_fixtures/source-family-index.html",
+                    "source_class": "official-government",
+                    "allowed_hosts": ["example.gov"],
+                    "allowed_path_prefixes": ["/news/"],
+                    "relevance_terms": ["immigration", "civil rights"],
+                    "max_links": 10,
+                    "review_boundary": {
+                        "automation_may_discover": True,
+                        "automation_may_capture": True,
+                        "automation_may_promote": False,
+                    },
+                },
+            ]
         }), encoding="utf-8")
         base_config.write_text(json.dumps({"adapters": []}), encoding="utf-8")
         subprocess.run([
@@ -56,23 +74,37 @@ def main() -> int:
             "--base-config", str(base_config),
             "--output", str(output),
             "--receipt", str(receipt),
-            "--discovered-at", "2026-07-22T12:00:00Z"
+            "--discovered-at", "2026-07-23T12:00:00Z",
         ], cwd=ROOT, check=True)
+
         runtime = load(output)
         endpoints = [item["endpoint"] for item in runtime["adapters"]]
         expected = [
             "https://example.gov/news/immigration-enforcement-update",
-            "https://example.gov/news/civil-rights-investigation"
+            "https://example.gov/news/civil-rights-investigation",
         ]
         if endpoints != expected:
             raise SystemExit(f"Unexpected discovered endpoints: {endpoints}")
         for adapter in runtime["adapters"]:
             if adapter["review_boundary"]["automation_may_promote"] is not False:
                 raise SystemExit("Discovered adapter gained promotion authority")
+
         result = load(receipt)
+        if result["schema"] != "stegverse.executive_rhetoric_ledger.source_family_discovery.v2":
+            raise SystemExit("Unexpected discovery receipt schema")
+        if result["execution_status"] != "PASS":
+            raise SystemExit("One successful family did not preserve PASS execution")
+        if result["successful_family_count"] != 1 or result["failed_family_count"] != 1:
+            raise SystemExit("Family isolation counts are incorrect")
+        by_id = {item["family_id"]: item for item in result["families"]}
+        if by_id["FAILED_FAMILY"]["fetch_status"] != "FAILED" or not by_id["FAILED_FAMILY"]["error"]:
+            raise SystemExit("Failed family did not retain its blocker")
+        if by_id["VALIDATION_FAMILY"]["fetch_status"] != "PASS":
+            raise SystemExit("Successful family was not retained")
         if result["new_adapter_count"] != 2 or result["authority"]["may_promote"]:
             raise SystemExit("Discovery receipt authority/count mismatch")
-    print("Validated source-family discovery and candidate-only authority.")
+
+    print("Validated source-family discovery, failure isolation, and candidate-only authority.")
     return 0
 
 


### PR DESCRIPTION
Makes the existing source-family crawler resilient: each enabled family records PASS or FAILED independently, one unavailable index cannot suppress the remaining daily sweep, and execution fails only when every enabled family fails. Upgrades the discovery receipt to v2 with exact family counts and blockers. Extends the existing validation workflow with a non-publishing live smoke crawl and retained artifact. No promotion authority, scheduler, crawler service, or publication path is added.