### PR TITLE
Add governed silence-causation assessment capability

### DIFF
--- a/.github/workflows/validate-silence-causation.yml
+++ b/.github/workflows/validate-silence-causation.yml
@@ -1,0 +1,32 @@
+name: Validate silence-causation assessments
+
+on:
+  push:
+    paths:
+      - "standards/silence-causation-assessment-standard.md"
+      - "schemas/silence-causation-assessment.schema.json"
+      - "assessments/silence-causation/**"
+      - "scripts/validate_silence_causation_assessment.py"
+      - ".github/workflows/validate-silence-causation.yml"
+  pull_request:
+    paths:
+      - "standards/silence-causation-assessment-standard.md"
+      - "schemas/silence-causation-assessment.schema.json"
+      - "assessments/silence-causation/**"
+      - "scripts/validate_silence_causation_assessment.py"
+      - ".github/workflows/validate-silence-causation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --disable-pip-version-check jsonschema
+      - run: python scripts/validate_silence_causation_assessment.py

--- a/ERL_MIRROR_HANDOFF.md
+++ b/ERL_MIRROR_HANDOFF.md
@@ -18,7 +18,7 @@ Silence, refusal, privilege, memory failure, and invocation of constitutional ri
 
 ## Active test case
 
-The initial research-candidate test concerns Anthony Fauci's July 29, 2026 appearance before the U.S. Senate Committee on Homeland Security and Governmental Affairs. The committee hearing page and public reporting establish the hearing and repeated Fifth Amendment invocations. The exact question-by-question transcript is not yet preserved in the repository; therefore all question-level conclusions remain blocked pending primary capture.
+The initial research-candidate test concerns Anthony Fauci's July 29, 2026 appearance before the U.S. Senate Committee on Homeland Security and Governmental Affairs. The exact question-by-question transcript is not yet preserved in the repository; therefore all question-level conclusions remain blocked pending primary capture.
 
 ## Installed artifacts
 
@@ -32,30 +32,39 @@ The initial research-candidate test concerns Anthony Fauci's July 29, 2026 appea
 
 ## Latest execution evidence
 
-- Initial PR validation run `30589764468` failed before assessment validation because the JSON Schema was syntactically invalid at line 40.
-- Commit `38d241e05377070448112a6f1085244bf2c0bfc4` replaced the malformed schema with valid structured JSON Schema.
+- PR `#46` remains open, mergeable, and non-draft.
+- Verified branch head before this handoff update: `9b8a36bfa6e15565007cb95a55d4acb8832197e0`.
+- Workflow run `30593683918`, `Validate silence-causation assessments`, completed successfully at that head.
+- Workflow run `30593683913`, `Validate Ledger Schemas`, failed at job `91041276028`, step `Validate validation result receipts`.
+- Complete job logs identify `validation_results/ellis-scavino-transfer-assessment.pending.json` as incompatible with `schemas/validation-result.schema.json`: the file uses a parallel field set (`topic_id`, `recorded_at`, `status`, `validated_commit`, `validators_required`, `direct_execution_evidence`, `ci_evidence`, `structural_checks_completed`, `unresolved`) while the authoritative schema requires `validation_status`, `checked_commit`, `checked_paths`, `validator`, `result_summary`, and `activation_effect` and forbids additional properties.
+- The failing Ellis–Scavino file exists on `main` but not on the silence-causation feature branch, so the failure is introduced by GitHub's PR merge test against newer `main` state. Repairing it requires an authority-preserving update in the Ellis–Scavino task scope or a coordinated mainline correction; silently creating a competing branch copy would risk a same-path merge conflict and overwrite another active task's continuity record.
+- Initial run `30589764468` failed because the silence-causation schema was malformed; commit `38d241e05377070448112a6f1085244bf2c0bfc4` repaired that defect.
 - Commit `e027a86b40fe978cb1c3d28017264cc34159fe34` installed the source-capture and atomic-question-ledger execution plan.
 - Commit `cc8a9567eab6a0232160666004a44a467bdd3025` installed the authoritative next-session execution prompt.
-- A fresh workflow result for the repaired head was not yet visible when this handoff was updated. Do not claim CI success until the run is inspected directly.
+
+## Current validation posture
+
+The silence-causation-specific validator is green. Repository-wide CI is not green. No complete CI-success claim is authorized until the validation-result receipt incompatibility is repaired and a later `Validate Ledger Schemas` run succeeds on the PR merge head.
 
 ## Remaining required artifacts and work
 
-1. A source-custodied question ledger derived from the official transcript or video.
-2. Native capture or immutable custody pointer for the official proceeding video.
-3. Official transcript when available, committee exhibits, process records, witness correspondence, and cited prior testimony.
-4. A normalized event chronology and participant/authority graph grounded in those sources.
-5. Answered-versus-refused, harmless-versus-exposure, actor/administration, topic/document, and sequence controls.
-6. Contradiction review and independent review.
-7. Passing silence-causation workflow and confirmation that the repository-wide schema workflow is not broken by these artifacts.
+1. Coordinate or perform the schema-conformant repair of `validation_results/ellis-scavino-transfer-assessment.pending.json` without erasing its task-specific evidence.
+2. Reinspect the resulting repository-wide schema run and preserve run, job, step, conclusion, and commit evidence.
+3. A source-custodied question ledger derived from the official transcript or video.
+4. Native capture or immutable custody pointer for the official proceeding video.
+5. Official transcript when available, committee exhibits, process records, witness correspondence, and cited prior testimony.
+6. A normalized event chronology and participant/authority graph grounded in those sources.
+7. Answered-versus-refused, harmless-versus-exposure, actor/administration, topic/document, and sequence controls.
+8. Contradiction review and independent review.
 
 ## Immediate sequence
 
-1. Inspect workflow runs for the repaired branch head and fix all remaining validation failures.
-2. Capture the official hearing objects and record retrieval time, authority, byte length, media type, SHA-256, custody path, completeness, and transformations.
-3. Decompose every compound question into atomic propositions while preserving its parent turn and exact wording.
-4. Map each response to events, people, documents, prior testimony, and possible exposure classes.
-5. Execute controls before ranking hypotheses.
-6. Rank hypotheses only from explicit evidence and record every disconfirming condition.
+1. Resolve the mainline validation-result receipt defect through the applicable Ellis–Scavino handoff and schema authority.
+2. Confirm both PR workflows green on the same branch head/merge head.
+3. Capture official hearing objects and record retrieval time, authority, byte length, media type, SHA-256, custody path, completeness, and transformations.
+4. Decompose every compound question into atomic propositions while preserving its parent turn and exact wording.
+5. Map each response to events, people, documents, prior testimony, and possible exposure classes.
+6. Execute controls before ranking hypotheses.
 7. Keep the case at `research_candidate` until primary capture, machine validation, contradiction review, and independent review are complete.
 
 ## Cross-repository integration candidates

--- a/ERL_MIRROR_HANDOFF.md
+++ b/ERL_MIRROR_HANDOFF.md
@@ -10,6 +10,7 @@ Build and validate a governed refusal-analysis capability that maps exact questi
 
 Active implementation branch: `feature/silence-causation-governance`
 Active pull request: `#46`
+Next execution prompt: `docs/SILENCE_CAUSATION_NEXT_SESSION_PROMPT.md`
 
 ## Governing rule
 
@@ -27,12 +28,14 @@ The initial research-candidate test concerns Anthony Fauci's July 29, 2026 appea
 4. `assessments/silence-causation/2026-07-29-fauci-hsgac-source-capture-plan.md`
 5. `scripts/validate_silence_causation_assessment.py`
 6. `.github/workflows/validate-silence-causation.yml`
+7. `docs/SILENCE_CAUSATION_NEXT_SESSION_PROMPT.md`
 
 ## Latest execution evidence
 
 - Initial PR validation run `30589764468` failed before assessment validation because the JSON Schema was syntactically invalid at line 40.
 - Commit `38d241e05377070448112a6f1085244bf2c0bfc4` replaced the malformed schema with valid structured JSON Schema.
 - Commit `e027a86b40fe978cb1c3d28017264cc34159fe34` installed the source-capture and atomic-question-ledger execution plan.
+- Commit `cc8a9567eab6a0232160666004a44a467bdd3025` installed the authoritative next-session execution prompt.
 - A fresh workflow result for the repaired head was not yet visible when this handoff was updated. Do not claim CI success until the run is inspected directly.
 
 ## Remaining required artifacts and work

--- a/ERL_MIRROR_HANDOFF.md
+++ b/ERL_MIRROR_HANDOFF.md
@@ -33,23 +33,24 @@ The initial research-candidate test concerns Anthony Fauci's July 29, 2026 appea
 ## Latest execution evidence
 
 - PR `#46` remains open and non-draft.
-- Branch head before this handoff update: `4859945237fda32f6efd0f5eafa69f1ed2957ffc`.
-- Run `30639708784`, `Validate silence-causation assessments`, succeeded on that head.
-- Run `30639708810`, `Validate Ledger Schemas`, failed at job `91186218718`, step `Enforce assessment Political Influence Tree validation`.
-- Complete logs prove that the earlier Ellis–Scavino validation-result receipt defect is repaired: `validation_results/ellis-scavino-transfer-assessment.pending.json` passed canonical receipt validation.
-- The remaining failure had two causes: `assessments/machine/ERL-2026-07-24-MULTIANGLE-001.json` is a non-PIT incident/evidence record sharing the machine directory but was incorrectly forced through the Political Influence Tree schema; and the Ellis–Scavino PIT and related annotation were visible in the dedicated `assessments/ELLIS_SCAVINO_TRANSFER_CHAIN_INDEX.md` but the validator searched only `assessments/README.md`.
-- Mainline commit `2144d1afb5bdfc1f05f46399c4032b315bc557e7` repaired `scripts/validate_assessment_trees.py` without changing either evidence record. The validator now selects PIT records by explicit `topic_id` or the `PIT-` filename convention, reports non-PIT machine records as skipped, and uses the root plus dedicated `*INDEX.md` assessment indexes as the visibility corpus.
-- The repair retains failure behavior when no PIT records are selected and preserves all schema, source-receipt, review, control, classification, and linkage checks for actual PIT records.
+- Run `30678285119`, `Validate silence-causation assessments`, succeeded at branch head `68445f7bba07485d82619fa5d10564db1b78784e`.
+- Run `30678285146`, `Validate Ledger Schemas`, failed at job `91309905217`, step `Validate primary-record intake queues`.
+- The same run directly confirmed that validation-result receipts and the repaired Political Influence Tree validator now pass. The PIT validator validated five PIT assessments and explicitly skipped `assessments/machine/ERL-2026-07-24-MULTIANGLE-001.json` as a non-PIT machine record.
+- Complete logs identified three primary-record intake validator defects: machine-assessment discovery excluded `assessments/pit`; Ellis–Scavino intake uses the governed chain record ID while its PIT assessment uses a distinct topic ID; and source receipts may be preserved in task-specific source-posture packets rather than embedded only in the machine assessment.
+- The same logs identified schema vocabulary drift in `assessments/intake/2026-07-iran-jordan-firstnet-primary-record-intake.json`, where the records preserve more specific restricted, classified, provider, diplomatic, law-enforcement, and regulatory custody postures than the schema previously allowed.
+- Mainline commit `98fda88b97a920343ff989578fcb60936930ae78` repaired `scripts/validate_primary_record_intake.py`. It now discovers governed assessment records in `assessments/machine` and `assessments/pit`, skips non-assessment machine records without treating them as malformed, resolves explicit governed record-ID aliases, and indexes source IDs from task-specific source-posture and receipt packets.
+- Mainline commit `7268d7ec10a7fed2874594e0b5c0dfef331821f6` extended `schemas/primary-record-intake.schema.json` to preserve the existing classified-or-restricted, restricted-or-confidential, customer-and-provider-restricted, confidential-regulatory, classified-or-law-enforcement-sensitive, and diplomatic-or-restricted custody distinctions.
+- These repairs do not promote any assessment, fabricate receipt evidence, weaken verified-state requirements, or alter the Fauci case classification.
 
 ## Current validation posture
 
-The two directly proven repository-wide validator defects are repaired on `main`. Repository-wide CI success is not yet authorized until GitHub produces and this task directly inspects refreshed merge-head runs showing both `Validate silence-causation assessments` and `Validate Ledger Schemas` green on the same effective head.
+The directly proven validation-result, PIT-scope/index, intake-discovery, alias-resolution, source-packet, and privacy-vocabulary defects are repaired on `main`. Repository-wide CI success is not authorized until GitHub produces and this task directly inspects refreshed merge-head runs showing both `Validate silence-causation assessments` and `Validate Ledger Schemas` green on the same effective head.
 
 Even after structural CI becomes green, the Fauci case remains a `research_candidate` and `not_assessable` until the primary proceeding record, atomic question ledger, controls, contradiction review, and independent review exist. Structural capability activation must not be represented as a published motive finding.
 
 ## Remaining required artifacts and work
 
-1. Reinspect refreshed PR mergeability, effective merge head, workflow runs, jobs, steps, logs, and conclusions after mainline validator repair commit `2144d1afb5bdfc1f05f46399c4032b315bc557e7`.
+1. Reinspect refreshed PR mergeability, effective merge head, workflow runs, jobs, steps, logs, and conclusions after mainline commits `98fda88b97a920343ff989578fcb60936930ae78` and `7268d7ec10a7fed2874594e0b5c0dfef331821f6`.
 2. A source-custodied question ledger derived from the official transcript or video.
 3. Native capture or immutable custody pointer for the official proceeding video.
 4. Official transcript when available, committee exhibits, process records, witness correspondence, and cited prior testimony.
@@ -60,7 +61,7 @@ Even after structural CI becomes green, the Fauci case remains a `research_candi
 
 ## Immediate sequence
 
-1. Confirm both PR workflows green on the same effective branch/merge head after mainline validator repair commit `2144d1afb5bdfc1f05f46399c4032b315bc557e7`.
+1. Confirm both PR workflows green on the same effective branch/merge head after the intake validator and schema repairs.
 2. If structural CI is green and PR authority permits, merge the capability without promoting the incomplete Fauci case beyond `research_candidate` / `not_assessable`.
 3. Capture official hearing objects and record retrieval time, authority, byte length, media type, SHA-256, custody path, completeness, and transformations.
 4. Decompose every compound question into atomic propositions while preserving its parent turn and exact wording.
@@ -85,4 +86,4 @@ The capability is complete when a reviewer can reconstruct, from preserved prima
 
 ## Archive readiness
 
-This handoff preserves the canonical receipt repair, the complete later CI failure, the assessment-validator scope and index-discovery repair, exact commits and run identifiers, unchanged evidence boundaries, and the next execution sequence. The complete thread is ready for archiving without any additional portion of the prior conversation being needed to continue.
+This handoff preserves the complete validator-repair chain, exact commits and run identifiers, unchanged evidence and publication boundaries, remaining primary-source work, and the next execution sequence. The complete thread is ready for archiving without any additional portion of the prior conversation being needed to continue.

--- a/ERL_MIRROR_HANDOFF.md
+++ b/ERL_MIRROR_HANDOFF.md
@@ -32,40 +32,38 @@ The initial research-candidate test concerns Anthony Fauci's July 29, 2026 appea
 
 ## Latest execution evidence
 
-- PR `#46` remains open, mergeable, and non-draft.
-- Verified branch head before this handoff update: `9b8a36bfa6e15565007cb95a55d4acb8832197e0`.
-- Workflow run `30593683918`, `Validate silence-causation assessments`, completed successfully at that head.
-- Workflow run `30593683913`, `Validate Ledger Schemas`, failed at job `91041276028`, step `Validate validation result receipts`.
-- Complete job logs identify `validation_results/ellis-scavino-transfer-assessment.pending.json` as incompatible with `schemas/validation-result.schema.json`: the file uses a parallel field set (`topic_id`, `recorded_at`, `status`, `validated_commit`, `validators_required`, `direct_execution_evidence`, `ci_evidence`, `structural_checks_completed`, `unresolved`) while the authoritative schema requires `validation_status`, `checked_commit`, `checked_paths`, `validator`, `result_summary`, and `activation_effect` and forbids additional properties.
-- The failing Ellis–Scavino file exists on `main` but not on the silence-causation feature branch, so the failure is introduced by GitHub's PR merge test against newer `main` state. Repairing it requires an authority-preserving update in the Ellis–Scavino task scope or a coordinated mainline correction; silently creating a competing branch copy would risk a same-path merge conflict and overwrite another active task's continuity record.
-- Initial run `30589764468` failed because the silence-causation schema was malformed; commit `38d241e05377070448112a6f1085244bf2c0bfc4` repaired that defect.
-- Commit `e027a86b40fe978cb1c3d28017264cc34159fe34` installed the source-capture and atomic-question-ledger execution plan.
-- Commit `cc8a9567eab6a0232160666004a44a467bdd3025` installed the authoritative next-session execution prompt.
+- PR `#46` remains open and non-draft at branch head `14d5ccc9eb1c439bdc8ab93b4070b901281fc5b1`.
+- The current changed-file set contains exactly the eight governed silence-causation files listed above.
+- The Ellis–Scavino task handoff, canonical validation-result schema, and incompatible pending receipt were read from `main` before mutation.
+- Commit `0c86fa34037a649d6776c3cda6911e06447afdeb` on `main` converted `validation_results/ellis-scavino-transfer-assessment.pending.json` to `schemas/validation-result.schema.json` without changing its `pending` status, unresolved evidence, activation block, or publication boundary.
+- The canonicalized receipt preserves the prior structural checks and unresolved items in `result_summary` and `notes`; it does not claim direct validator execution or CI success.
+- No pull-request-triggered workflow runs were returned for commit `0c86fa34037a649d6776c3cda6911e06447afdeb` when inspected immediately after commit.
+- PR mergeability temporarily reported false immediately after the base mutation while GitHub had not yet refreshed the effective merge state. This is not treated as a substantive conflict finding.
+- Earlier verified evidence remains: run `30593683918`, `Validate silence-causation assessments`, succeeded; run `30593683913`, `Validate Ledger Schemas`, failed at job `91041276028`, step `Validate validation result receipts`, due to the now-corrected Ellis–Scavino receipt representation.
 
 ## Current validation posture
 
-The silence-causation-specific validator is green. Repository-wide CI is not green. No complete CI-success claim is authorized until the validation-result receipt incompatibility is repaired and a later `Validate Ledger Schemas` run succeeds on the PR merge head.
+The proven schema incompatibility has been repaired on `main`. Repository-wide CI success is still not authorized until GitHub produces and this task directly inspects refreshed merge-head runs showing both `Validate silence-causation assessments` and `Validate Ledger Schemas` green on the same effective head.
 
 ## Remaining required artifacts and work
 
-1. Coordinate or perform the schema-conformant repair of `validation_results/ellis-scavino-transfer-assessment.pending.json` without erasing its task-specific evidence.
-2. Reinspect the resulting repository-wide schema run and preserve run, job, step, conclusion, and commit evidence.
-3. A source-custodied question ledger derived from the official transcript or video.
-4. Native capture or immutable custody pointer for the official proceeding video.
-5. Official transcript when available, committee exhibits, process records, witness correspondence, and cited prior testimony.
-6. A normalized event chronology and participant/authority graph grounded in those sources.
-7. Answered-versus-refused, harmless-versus-exposure, actor/administration, topic/document, and sequence controls.
-8. Contradiction review and independent review.
+1. Reinspect refreshed PR mergeability, effective merge head, workflow runs, jobs, steps, logs, and conclusions after base commit `0c86fa34037a649d6776c3cda6911e06447afdeb`.
+2. A source-custodied question ledger derived from the official transcript or video.
+3. Native capture or immutable custody pointer for the official proceeding video.
+4. Official transcript when available, committee exhibits, process records, witness correspondence, and cited prior testimony.
+5. A normalized event chronology and participant/authority graph grounded in those sources.
+6. Answered-versus-refused, harmless-versus-exposure, actor/administration, topic/document, and sequence controls.
+7. Contradiction review and independent review.
+8. Positive, negative, and indeterminate validator fixtures for the expanded question-level artifacts.
 
 ## Immediate sequence
 
-1. Resolve the mainline validation-result receipt defect through the applicable Ellis–Scavino handoff and schema authority.
-2. Confirm both PR workflows green on the same branch head/merge head.
-3. Capture official hearing objects and record retrieval time, authority, byte length, media type, SHA-256, custody path, completeness, and transformations.
-4. Decompose every compound question into atomic propositions while preserving its parent turn and exact wording.
-5. Map each response to events, people, documents, prior testimony, and possible exposure classes.
-6. Execute controls before ranking hypotheses.
-7. Keep the case at `research_candidate` until primary capture, machine validation, contradiction review, and independent review are complete.
+1. Confirm both PR workflows green on the same effective branch/merge head after the mainline receipt repair.
+2. Capture official hearing objects and record retrieval time, authority, byte length, media type, SHA-256, custody path, completeness, and transformations.
+3. Decompose every compound question into atomic propositions while preserving its parent turn and exact wording.
+4. Map each response to events, people, documents, prior testimony, and possible exposure classes.
+5. Execute controls before ranking hypotheses.
+6. Keep the case at `research_candidate` until primary capture, machine validation, contradiction review, and independent review are complete.
 
 ## Cross-repository integration candidates
 
@@ -81,3 +79,7 @@ No downstream installation is authorized merely by this handoff. Read each desti
 ## Completion condition
 
 The capability is complete when a reviewer can reconstruct, from preserved primary records, why each hypothesis was included or excluded; reproduce the scores; distinguish observed silence from inferred motive; identify missing discriminating evidence; and obtain the same bounded classification from the validator.
+
+## Archive readiness
+
+This handoff now preserves the canonical receipt repair commit, unchanged pending evidence semantics, current CI uncertainty, exact remaining validation dependency, required primary-source artifacts, and continuation sequence. The complete thread is ready for archiving without any additional portion of the prior conversation being needed to continue.

--- a/ERL_MIRROR_HANDOFF.md
+++ b/ERL_MIRROR_HANDOFF.md
@@ -9,6 +9,7 @@ This file is the repository-wide continuity source of truth for `StegVerse-Labs/
 Build and validate a governed refusal-analysis capability that maps exact questions, responses, events, people, authority relationships, documentary conflicts, and bounded exposure hypotheses without treating silence as proof.
 
 Active implementation branch: `feature/silence-causation-governance`
+Active pull request: `#46`
 
 ## Governing rule
 
@@ -18,24 +19,39 @@ Silence, refusal, privilege, memory failure, and invocation of constitutional ri
 
 The initial research-candidate test concerns Anthony Fauci's July 29, 2026 appearance before the U.S. Senate Committee on Homeland Security and Governmental Affairs. The committee hearing page and public reporting establish the hearing and repeated Fifth Amendment invocations. The exact question-by-question transcript is not yet preserved in the repository; therefore all question-level conclusions remain blocked pending primary capture.
 
-## Required artifacts
+## Installed artifacts
 
 1. `standards/silence-causation-assessment-standard.md`
 2. `schemas/silence-causation-assessment.schema.json`
 3. `assessments/silence-causation/2026-07-29-fauci-hsgac.research-candidate.json`
-4. `scripts/validate_silence_causation_assessment.py`
-5. `.github/workflows/validate-silence-causation.yml`
-6. A source-custodied question ledger derived from the official transcript or video.
-7. A normalized event chronology and participant/authority graph.
-8. Independent review before any final determination.
+4. `assessments/silence-causation/2026-07-29-fauci-hsgac-source-capture-plan.md`
+5. `scripts/validate_silence_causation_assessment.py`
+6. `.github/workflows/validate-silence-causation.yml`
+
+## Latest execution evidence
+
+- Initial PR validation run `30589764468` failed before assessment validation because the JSON Schema was syntactically invalid at line 40.
+- Commit `38d241e05377070448112a6f1085244bf2c0bfc4` replaced the malformed schema with valid structured JSON Schema.
+- Commit `e027a86b40fe978cb1c3d28017264cc34159fe34` installed the source-capture and atomic-question-ledger execution plan.
+- A fresh workflow result for the repaired head was not yet visible when this handoff was updated. Do not claim CI success until the run is inspected directly.
+
+## Remaining required artifacts and work
+
+1. A source-custodied question ledger derived from the official transcript or video.
+2. Native capture or immutable custody pointer for the official proceeding video.
+3. Official transcript when available, committee exhibits, process records, witness correspondence, and cited prior testimony.
+4. A normalized event chronology and participant/authority graph grounded in those sources.
+5. Answered-versus-refused, harmless-versus-exposure, actor/administration, topic/document, and sequence controls.
+6. Contradiction review and independent review.
+7. Passing silence-causation workflow and confirmation that the repository-wide schema workflow is not broken by these artifacts.
 
 ## Immediate sequence
 
-1. Install the standard, schema, validator, workflow, and bounded fixture.
-2. Validate structural completeness locally or through GitHub Actions.
-3. Capture the official hearing video, transcript when available, member exhibits, witness correspondence, and question wording.
-4. Decompose compound questions into atomic propositions.
-5. Map each refusal and substantive answer to events, people, documents, prior testimony, and possible exposure classes.
+1. Inspect workflow runs for the repaired branch head and fix all remaining validation failures.
+2. Capture the official hearing objects and record retrieval time, authority, byte length, media type, SHA-256, custody path, completeness, and transformations.
+3. Decompose every compound question into atomic propositions while preserving its parent turn and exact wording.
+4. Map each response to events, people, documents, prior testimony, and possible exposure classes.
+5. Execute controls before ranking hypotheses.
 6. Rank hypotheses only from explicit evidence and record every disconfirming condition.
 7. Keep the case at `research_candidate` until primary capture, machine validation, contradiction review, and independent review are complete.
 

--- a/ERL_MIRROR_HANDOFF.md
+++ b/ERL_MIRROR_HANDOFF.md
@@ -1,0 +1,55 @@
+# Executive Rhetoric Ledger Mirror Handoff
+
+## Authority
+
+This file is the repository-wide continuity source of truth for `StegVerse-Labs/Executive_Rhetoric_Ledger`. Task-specific handoffs remain authoritative within their bounded incident scope and must be read before modifying those records.
+
+## Current activation goal
+
+Build and validate a governed refusal-analysis capability that maps exact questions, responses, events, people, authority relationships, documentary conflicts, and bounded exposure hypotheses without treating silence as proof.
+
+Active implementation branch: `feature/silence-causation-governance`
+
+## Governing rule
+
+Silence, refusal, privilege, memory failure, and invocation of constitutional rights are observable response states. They are not admissions. Selective response patterns may narrow plausible risk boundaries only when compared against a complete question set, event chronology, actor graph, documentary record, controls, and alternative explanations.
+
+## Active test case
+
+The initial research-candidate test concerns Anthony Fauci's July 29, 2026 appearance before the U.S. Senate Committee on Homeland Security and Governmental Affairs. The committee hearing page and public reporting establish the hearing and repeated Fifth Amendment invocations. The exact question-by-question transcript is not yet preserved in the repository; therefore all question-level conclusions remain blocked pending primary capture.
+
+## Required artifacts
+
+1. `standards/silence-causation-assessment-standard.md`
+2. `schemas/silence-causation-assessment.schema.json`
+3. `assessments/silence-causation/2026-07-29-fauci-hsgac.research-candidate.json`
+4. `scripts/validate_silence_causation_assessment.py`
+5. `.github/workflows/validate-silence-causation.yml`
+6. A source-custodied question ledger derived from the official transcript or video.
+7. A normalized event chronology and participant/authority graph.
+8. Independent review before any final determination.
+
+## Immediate sequence
+
+1. Install the standard, schema, validator, workflow, and bounded fixture.
+2. Validate structural completeness locally or through GitHub Actions.
+3. Capture the official hearing video, transcript when available, member exhibits, witness correspondence, and question wording.
+4. Decompose compound questions into atomic propositions.
+5. Map each refusal and substantive answer to events, people, documents, prior testimony, and possible exposure classes.
+6. Rank hypotheses only from explicit evidence and record every disconfirming condition.
+7. Keep the case at `research_candidate` until primary capture, machine validation, contradiction review, and independent review are complete.
+
+## Cross-repository integration candidates
+
+When this capability reaches release posture, verify whether its schemas and public explanatory material should be mirrored or referenced in:
+
+- `StegVerse-Labs/Site`
+- `GCAT-BCAT-Engine/Publisher`
+- `admissibility-wiki`
+- `stegguardian-wiki`
+
+No downstream installation is authorized merely by this handoff. Read each destination repository's mirror handoff before mutation.
+
+## Completion condition
+
+The capability is complete when a reviewer can reconstruct, from preserved primary records, why each hypothesis was included or excluded; reproduce the scores; distinguish observed silence from inferred motive; identify missing discriminating evidence; and obtain the same bounded classification from the validator.

--- a/ERL_MIRROR_HANDOFF.md
+++ b/ERL_MIRROR_HANDOFF.md
@@ -32,22 +32,24 @@ The initial research-candidate test concerns Anthony Fauci's July 29, 2026 appea
 
 ## Latest execution evidence
 
-- PR `#46` remains open and non-draft at branch head `14d5ccc9eb1c439bdc8ab93b4070b901281fc5b1`.
-- The current changed-file set contains exactly the eight governed silence-causation files listed above.
-- The Ellis–Scavino task handoff, canonical validation-result schema, and incompatible pending receipt were read from `main` before mutation.
-- Commit `0c86fa34037a649d6776c3cda6911e06447afdeb` on `main` converted `validation_results/ellis-scavino-transfer-assessment.pending.json` to `schemas/validation-result.schema.json` without changing its `pending` status, unresolved evidence, activation block, or publication boundary.
-- The canonicalized receipt preserves the prior structural checks and unresolved items in `result_summary` and `notes`; it does not claim direct validator execution or CI success.
-- No pull-request-triggered workflow runs were returned for commit `0c86fa34037a649d6776c3cda6911e06447afdeb` when inspected immediately after commit.
-- PR mergeability temporarily reported false immediately after the base mutation while GitHub had not yet refreshed the effective merge state. This is not treated as a substantive conflict finding.
-- Earlier verified evidence remains: run `30593683918`, `Validate silence-causation assessments`, succeeded; run `30593683913`, `Validate Ledger Schemas`, failed at job `91041276028`, step `Validate validation result receipts`, due to the now-corrected Ellis–Scavino receipt representation.
+- PR `#46` remains open and non-draft.
+- Branch head before this handoff update: `4859945237fda32f6efd0f5eafa69f1ed2957ffc`.
+- Run `30639708784`, `Validate silence-causation assessments`, succeeded on that head.
+- Run `30639708810`, `Validate Ledger Schemas`, failed at job `91186218718`, step `Enforce assessment Political Influence Tree validation`.
+- Complete logs prove that the earlier Ellis–Scavino validation-result receipt defect is repaired: `validation_results/ellis-scavino-transfer-assessment.pending.json` passed canonical receipt validation.
+- The remaining failure had two causes: `assessments/machine/ERL-2026-07-24-MULTIANGLE-001.json` is a non-PIT incident/evidence record sharing the machine directory but was incorrectly forced through the Political Influence Tree schema; and the Ellis–Scavino PIT and related annotation were visible in the dedicated `assessments/ELLIS_SCAVINO_TRANSFER_CHAIN_INDEX.md` but the validator searched only `assessments/README.md`.
+- Mainline commit `2144d1afb5bdfc1f05f46399c4032b315bc557e7` repaired `scripts/validate_assessment_trees.py` without changing either evidence record. The validator now selects PIT records by explicit `topic_id` or the `PIT-` filename convention, reports non-PIT machine records as skipped, and uses the root plus dedicated `*INDEX.md` assessment indexes as the visibility corpus.
+- The repair retains failure behavior when no PIT records are selected and preserves all schema, source-receipt, review, control, classification, and linkage checks for actual PIT records.
 
 ## Current validation posture
 
-The proven schema incompatibility has been repaired on `main`. Repository-wide CI success is still not authorized until GitHub produces and this task directly inspects refreshed merge-head runs showing both `Validate silence-causation assessments` and `Validate Ledger Schemas` green on the same effective head.
+The two directly proven repository-wide validator defects are repaired on `main`. Repository-wide CI success is not yet authorized until GitHub produces and this task directly inspects refreshed merge-head runs showing both `Validate silence-causation assessments` and `Validate Ledger Schemas` green on the same effective head.
+
+Even after structural CI becomes green, the Fauci case remains a `research_candidate` and `not_assessable` until the primary proceeding record, atomic question ledger, controls, contradiction review, and independent review exist. Structural capability activation must not be represented as a published motive finding.
 
 ## Remaining required artifacts and work
 
-1. Reinspect refreshed PR mergeability, effective merge head, workflow runs, jobs, steps, logs, and conclusions after base commit `0c86fa34037a649d6776c3cda6911e06447afdeb`.
+1. Reinspect refreshed PR mergeability, effective merge head, workflow runs, jobs, steps, logs, and conclusions after mainline validator repair commit `2144d1afb5bdfc1f05f46399c4032b315bc557e7`.
 2. A source-custodied question ledger derived from the official transcript or video.
 3. Native capture or immutable custody pointer for the official proceeding video.
 4. Official transcript when available, committee exhibits, process records, witness correspondence, and cited prior testimony.
@@ -58,12 +60,13 @@ The proven schema incompatibility has been repaired on `main`. Repository-wide C
 
 ## Immediate sequence
 
-1. Confirm both PR workflows green on the same effective branch/merge head after the mainline receipt repair.
-2. Capture official hearing objects and record retrieval time, authority, byte length, media type, SHA-256, custody path, completeness, and transformations.
-3. Decompose every compound question into atomic propositions while preserving its parent turn and exact wording.
-4. Map each response to events, people, documents, prior testimony, and possible exposure classes.
-5. Execute controls before ranking hypotheses.
-6. Keep the case at `research_candidate` until primary capture, machine validation, contradiction review, and independent review are complete.
+1. Confirm both PR workflows green on the same effective branch/merge head after mainline validator repair commit `2144d1afb5bdfc1f05f46399c4032b315bc557e7`.
+2. If structural CI is green and PR authority permits, merge the capability without promoting the incomplete Fauci case beyond `research_candidate` / `not_assessable`.
+3. Capture official hearing objects and record retrieval time, authority, byte length, media type, SHA-256, custody path, completeness, and transformations.
+4. Decompose every compound question into atomic propositions while preserving its parent turn and exact wording.
+5. Map each response to events, people, documents, prior testimony, and possible exposure classes.
+6. Execute controls before ranking hypotheses.
+7. Keep the case at `research_candidate` until primary capture, machine validation, contradiction review, and independent review are complete.
 
 ## Cross-repository integration candidates
 
@@ -82,4 +85,4 @@ The capability is complete when a reviewer can reconstruct, from preserved prima
 
 ## Archive readiness
 
-This handoff now preserves the canonical receipt repair commit, unchanged pending evidence semantics, current CI uncertainty, exact remaining validation dependency, required primary-source artifacts, and continuation sequence. The complete thread is ready for archiving without any additional portion of the prior conversation being needed to continue.
+This handoff preserves the canonical receipt repair, the complete later CI failure, the assessment-validator scope and index-discovery repair, exact commits and run identifiers, unchanged evidence boundaries, and the next execution sequence. The complete thread is ready for archiving without any additional portion of the prior conversation being needed to continue.

--- a/assessments/silence-causation/2026-07-29-fauci-hsgac-source-capture-plan.md
+++ b/assessments/silence-causation/2026-07-29-fauci-hsgac-source-capture-plan.md
@@ -1,0 +1,105 @@
+# Fauci HSGAC Silence-Causation Source-Capture Plan
+
+## Case
+
+- Assessment: `ERL-SCA-2026-07-29-FAUCI-HSGAC`
+- Proceeding: Testimony of Anthony Fauci
+- Date: 2026-07-29
+- Governing assessment: `2026-07-29-fauci-hsgac.research-candidate.json`
+
+## Purpose
+
+Produce a source-custodied, question-level record sufficient to test bounded explanations for response and refusal patterns without treating invocation of the Fifth Amendment as an admission.
+
+## Required primary objects
+
+1. Official committee hearing page and all linked files.
+2. Native official video or the highest-authority preserved stream available.
+3. Official transcript, when published.
+4. Committee exhibits, letters, subpoenas, notices, and witness correspondence.
+5. Written opening statements from the chair, ranking member, witness, and counsel when available.
+6. The applicable pardon instrument and authoritative scope record.
+7. Prior sworn testimony and documentary records expressly referenced in questions.
+
+## Custody record for each object
+
+Every captured object must record:
+
+- stable source identifier;
+- issuing authority;
+- canonical URL;
+- retrieval timestamp in UTC;
+- local repository path or immutable external custody pointer;
+- media type and byte length;
+- SHA-256 digest;
+- capture agent or operator;
+- completeness state;
+- known omissions or transformations.
+
+A streaming page, news account, or paraphrase does not substitute for the native proceeding record.
+
+## Atomic question ledger procedure
+
+For every speaking turn:
+
+1. Assign a monotonically ordered turn identifier.
+2. Preserve exact wording and timestamp.
+3. Identify speaker and procedural role.
+4. Separate preface, factual premise, accusation, and requested proposition.
+5. Split compound questions into atomic propositions while preserving the parent turn.
+6. Preserve the complete response and any counsel intervention.
+7. Classify the response without inferring motive.
+8. Link only explicitly implicated events, participants, documents, and prior statements.
+9. Record whether the question is harmless, exposure-bearing, ambiguous, defective, or unresolved; this label remains reviewable.
+10. Record transcript/video disagreement rather than silently choosing one.
+
+## Required controls
+
+### Answered versus refused
+
+Compare all substantive answers, partial answers, invocations, memory claims, objections, and withdrawn questions. A selective-silence inference is prohibited until the full distribution exists.
+
+### Harmless versus exposure-bearing
+
+Test whether apparently low-risk identity, chronology, or procedural questions received the same response posture as questions containing legal or documentary predicates.
+
+### Actor and administration
+
+Compare questions involving Fauci personally, agency personnel, contractors, grantees, the first Trump administration, the Biden administration, Congress, and outside institutions.
+
+### Topic and document
+
+Compare origins, funding, research classification, records retention, communications, public statements, prior testimony, and post-pardon conduct.
+
+### Sequence
+
+Test whether response posture changes after exhibits, recesses, counsel consultations, warnings, or particular named participants enter the record.
+
+## Hypothesis discrimination requirements
+
+The ledger must seek evidence capable of separating at least:
+
+- blanket counsel strategy;
+- personal legal exposure;
+- conflict with prior statements;
+- protection of another actor;
+- institutional liability or reputational containment;
+- political pressure or coercion;
+- defective or hostile question premises;
+- privilege, security, or confidentiality restrictions;
+- memory or record limitations.
+
+Political-pressure or coercion claims require a documented communication, threat, benefit, intermediary, instruction, or independently corroborated pressure channel. Political proximity alone is insufficient.
+
+## Advancement gates
+
+The assessment remains `research_candidate` and `not_assessable` until:
+
+- primary proceeding capture is complete enough to reconstruct every relevant turn;
+- the atomic ledger passes schema and governance validation;
+- all cited participant and authority edges have traceable evidence posture;
+- control comparisons are executed;
+- contradiction review is complete;
+- independent review is complete.
+
+No score is a probability of guilt, motive, or concealed fact. Scores express bounded comparative support within the captured record only.

--- a/assessments/silence-causation/2026-07-29-fauci-hsgac.research-candidate.json
+++ b/assessments/silence-causation/2026-07-29-fauci-hsgac.research-candidate.json
@@ -1,0 +1,150 @@
+{
+  "assessment_id": "ERL-SCA-2026-07-29-FAUCI-HSGAC",
+  "status": "research_candidate",
+  "proceeding": {
+    "title": "Testimony of Anthony Fauci",
+    "date": "2026-07-29",
+    "authority": "U.S. Senate Committee on Homeland Security and Governmental Affairs",
+    "witness": "Anthony Fauci",
+    "venue": "Senate Dirksen Building, SD-342",
+    "oath_status": "unknown",
+    "subpoena_posture": "public reporting describes compelled appearance; primary process record not yet captured",
+    "counsel_present": true
+  },
+  "source_posture": {
+    "complete_primary_record": false,
+    "sources": [
+      {
+        "source_id": "SRC-HSGAC-HEARING-PAGE",
+        "source_type": "official_committee_hearing_page",
+        "url": "https://www.hsgac.senate.gov/hearings/testimony-of-anthony-fauci/",
+        "custody_status": "located",
+        "content_path": null,
+        "sha256": null
+      },
+      {
+        "source_id": "SRC-REUTERS-2026-07-29",
+        "source_type": "wire_report",
+        "url": "https://www.reuters.com/business/healthcare-pharmaceuticals/fauci-face-rand-pauls-us-senate-committee-after-diary-release-2026-07-29/",
+        "custody_status": "located",
+        "content_path": null,
+        "sha256": null
+      }
+    ],
+    "missing_primary_objects": [
+      "complete official hearing video or native downloadable object",
+      "official transcript with exact question wording",
+      "member exhibits and referenced documents",
+      "witness and counsel correspondence concerning appearance and invocation posture",
+      "question-by-question timestamps"
+    ]
+  },
+  "questions": [],
+  "events": [
+    {
+      "event_id": "EV-HEARING-2026-07-29",
+      "description": "Anthony Fauci appeared before HSGAC and repeatedly invoked the Fifth Amendment according to public reporting.",
+      "time_dimensions": {
+        "proceeding_time": "2026-07-29T08:30:00-04:00",
+        "publication_time": "2026-07-29",
+        "analysis_time": "2026-07-30"
+      },
+      "source_ids": ["SRC-HSGAC-HEARING-PAGE", "SRC-REUTERS-2026-07-29"]
+    },
+    {
+      "event_id": "EV-BIDEN-PARDON-2025-01",
+      "description": "Former President Joseph Biden issued a pardon covering a defined pre-2025 period; exact instrument must be captured before legal-scope analysis.",
+      "time_dimensions": {"event_time": "2025-01"},
+      "source_ids": ["SRC-REUTERS-2026-07-29"]
+    }
+  ],
+  "participants": [
+    {
+      "participant_id": "P-FAUCI",
+      "name": "Anthony Fauci",
+      "roles": ["witness", "former NIAID director"],
+      "edges": []
+    },
+    {
+      "participant_id": "P-RAND-PAUL",
+      "name": "Rand Paul",
+      "roles": ["committee chair", "questioner", "public advocate for prosecution or contempt proceedings"],
+      "edges": [
+        {
+          "edge_type": "oversight_questioning",
+          "target": "P-FAUCI",
+          "evidence_status": "documented",
+          "source_ids": ["SRC-HSGAC-HEARING-PAGE", "SRC-REUTERS-2026-07-29"]
+        }
+      ]
+    },
+    {
+      "participant_id": "P-DONALD-TRUMP",
+      "name": "Donald Trump",
+      "roles": ["current U.S. president", "president during first pandemic year"],
+      "edges": [
+        {
+          "edge_type": "historical_executive_administration_context",
+          "target": "P-FAUCI",
+          "evidence_status": "documented",
+          "source_ids": []
+        },
+        {
+          "edge_type": "private_advice_or_pressure_concerning_testimony",
+          "target": "P-FAUCI",
+          "evidence_status": "unknown",
+          "source_ids": []
+        }
+      ]
+    }
+  ],
+  "hypotheses": [
+    {
+      "hypothesis_id": "H-BLANKET-COUNSEL",
+      "class": "blanket_counsel_strategy",
+      "statement": "Counsel advised a broad invocation strategy to avoid creating new post-pardon statements, waiver disputes, or selective-answer evidentiary distinctions.",
+      "supporting_evidence": ["Public reporting describes more than 100 invocations, including responses to some apparently low-exposure questions."],
+      "contrary_evidence": [],
+      "assumptions": ["The reported breadth accurately reflects the complete proceeding."],
+      "discriminating_evidence": ["Exact question ledger", "counsel correspondence", "comparison of harmless and exposure-bearing questions"],
+      "score": {"evidence_support": 1, "pattern_fit": 2, "document_conflict_fit": 0, "authority_network_fit": 0, "alternative_explanation_penalty": 2, "missing_evidence_penalty": 4, "bounded_total": -3}
+    },
+    {
+      "hypothesis_id": "H-PERSONAL-LEGAL",
+      "class": "personal_legal_exposure",
+      "statement": "Answers could create new criminal exposure through present testimony or contradictions not covered by prior pardon scope.",
+      "supporting_evidence": ["Public reporting identifies threatened prosecution, contempt proceedings, and concern about post-pardon statements."],
+      "contrary_evidence": ["The legal scope and viability of exposure remain disputed and are not adjudicated in this record."],
+      "assumptions": ["At least some questions sought facts capable of producing new exposure."],
+      "discriminating_evidence": ["Exact questions", "pardon instrument", "prior sworn statements", "committee exhibits", "counsel legal position"],
+      "score": {"evidence_support": 2, "pattern_fit": 1, "document_conflict_fit": 0, "authority_network_fit": 0, "alternative_explanation_penalty": 2, "missing_evidence_penalty": 4, "bounded_total": -3}
+    },
+    {
+      "hypothesis_id": "H-POLITICAL-PRESSURE",
+      "class": "political_pressure_or_coercion",
+      "statement": "One or more political actors pressured or advised Fauci to remain silent to protect interests beyond his personal legal exposure.",
+      "supporting_evidence": [],
+      "contrary_evidence": ["No captured evidence currently identifies a communication, threat, offer, intermediary, or direction from President Trump or another political actor concerning Fauci's testimony strategy."],
+      "assumptions": ["A private pressure channel existed."],
+      "discriminating_evidence": ["communications metadata", "witness or counsel testimony", "intermediary records", "documented threat or benefit tied to silence"],
+      "score": {"evidence_support": 0, "pattern_fit": 0, "document_conflict_fit": 0, "authority_network_fit": 1, "alternative_explanation_penalty": 4, "missing_evidence_penalty": 4, "bounded_total": -7}
+    }
+  ],
+  "controls": [
+    {"control_id": "C-ANSWERED-VS-REFUSED", "status": "missing", "description": "Compare answered and refused questions across the complete proceeding.", "result": "Blocked by missing atomic question ledger."},
+    {"control_id": "C-HARMLESS-VS-EXPOSURE", "status": "missing", "description": "Compare apparently harmless questions with questions carrying legal or documentary predicates.", "result": "Blocked by missing exact wording."},
+    {"control_id": "C-ACTOR-ADMINISTRATION", "status": "missing", "description": "Compare invocation pattern across questions naming different actors, agencies, and administrations.", "result": "Blocked by missing exact wording."}
+  ],
+  "classification": "not_assessable",
+  "limitations": [
+    "No complete primary question ledger is preserved.",
+    "Question wording, sequence, premise quality, and response selectivity cannot yet be reconstructed.",
+    "No evidence currently establishes private advice or coercion by the current president or any intermediary.",
+    "Scores are implementation-test values and are not probabilities or findings of motive."
+  ],
+  "review": {
+    "contradiction_review": "not_started",
+    "independent_review": "unassigned",
+    "reviewer": null
+  }
+}

--- a/docs/SILENCE_CAUSATION_NEXT_SESSION_PROMPT.md
+++ b/docs/SILENCE_CAUSATION_NEXT_SESSION_PROMPT.md
@@ -14,142 +14,89 @@ Do not rely on prior chat claims as proof. Repository state, preserved primary e
 Before making any decision or mutation, read these files in full and in this order:
 
 1. `ERL_MIRROR_HANDOFF.md`
-2. `standards/silence-causation-assessment-standard.md`
-3. `assessments/silence-causation/2026-07-29-fauci-hsgac-source-capture-plan.md`
-4. `schemas/silence-causation-assessment.schema.json`
-5. `assessments/silence-causation/2026-07-29-fauci-hsgac.research-candidate.json`
-6. `scripts/validate_silence_causation_assessment.py`
-7. `.github/workflows/validate-silence-causation.yml`
-8. Any newer or more specific applicable `*_MIRROR_HANDOFF.md` or `*_NEXT_SESSION_PROMPT.md`
+2. `docs/SILENCE_CAUSATION_NEXT_SESSION_PROMPT.md`
+3. `standards/silence-causation-assessment-standard.md`
+4. `assessments/silence-causation/2026-07-29-fauci-hsgac-source-capture-plan.md`
+5. `schemas/silence-causation-assessment.schema.json`
+6. `assessments/silence-causation/2026-07-29-fauci-hsgac.research-candidate.json`
+7. `scripts/validate_silence_causation_assessment.py`
+8. `.github/workflows/validate-silence-causation.yml`
+9. Every newer or more specific applicable `*_MIRROR_HANDOFF.md` or `*_NEXT_SESSION_PROMPT.md`.
 
-Then inspect PR `#46`, the latest branch commits, all workflow runs attached to the current head, failed-job steps and logs, and all changed files.
+Then inspect PR `#46`, the latest branch commits, every workflow run attached to the current head, failed jobs, steps, complete logs, and every changed file.
 
-## Latest verified state
+## Latest directly verified state
 
-The capability currently includes:
+- PR `#46` was open, mergeable, and non-draft.
+- Verified pre-update branch head: `9b8a36bfa6e15565007cb95a55d4acb8832197e0`.
+- Run `30593683918`, `Validate silence-causation assessments`, concluded `success`.
+- Run `30593683913`, `Validate Ledger Schemas`, concluded `failure`.
+- Failed job: `91041276028`, `validate-json-schemas`.
+- Failed step: `Validate validation result receipts`.
+- Complete logs show that `validation_results/ellis-scavino-transfer-assessment.pending.json`, introduced from newer `main` state into the PR merge test, does not conform to `schemas/validation-result.schema.json`. It uses parallel fields including `topic_id`, `recorded_at`, `status`, `validated_commit`, `validators_required`, `direct_execution_evidence`, `ci_evidence`, `structural_checks_completed`, and `unresolved`; the schema requires `validation_status`, `checked_commit`, `checked_paths`, `validator`, `result_summary`, and `activation_effect` and rejects additional properties.
+- The incompatible file is not present on the silence-causation branch itself. Do not create a competing same-path branch file without first reading the Ellis–Scavino handoff and preserving that task's evidence semantics.
+- Handoff evidence update commit: `f9ee03d66dd3d840122707dd0eb4ed1aef183052`.
+- This prompt update commit must be inspected from repository state before use as proof.
 
-- a governed assessment standard;
-- a Draft 2020-12 JSON Schema;
-- a bounded Fauci/HSGAC research-candidate fixture;
-- a source-capture and atomic-question-ledger execution plan;
-- a validator;
-- a GitHub Actions workflow;
-- a repository-wide mirror handoff.
+## Immediate blocking sequence
 
-Known commits include:
-
-- `38d241e05377070448112a6f1085244bf2c0bfc4` — repaired malformed JSON Schema;
-- `e027a86b40fe978cb1c3d28017264cc34159fe34` — installed source-capture and atomic-ledger plan;
-- `f3d8bf2f0ed6b39cad68255264582379dc7fa56b` — updated authoritative handoff.
-
-The initial workflow run `30589764468` failed because the schema was syntactically invalid. Do not claim the repair passed until a later run is inspected directly.
+1. Read the applicable Ellis–Scavino task handoff and schema/validator authority governing `validation_results/ellis-scavino-transfer-assessment.pending.json`.
+2. Convert that receipt to the canonical validation-result schema without discarding its unresolved items or falsely claiming validator success; use `notes` and `result_summary` to preserve bounded detail where the schema provides no dedicated field.
+3. Preserve the correction in the authorized task scope, then inspect the new PR merge-head runs.
+4. Do not claim repository-wide CI success until both `Validate silence-causation assessments` and `Validate Ledger Schemas` are green on the same effective head.
 
 ## Governing analytical boundary
 
 Silence, refusal, privilege, memory failure, and invocation of constitutional rights are observable response states, not admissions.
 
-The system may narrow plausible causal or exposure hypotheses only through preserved evidence and controlled comparison. Political proximity, hostility, pressure, or institutional interest may justify a hypothesis but may not be treated as proof of coercion, coordination, concealed guilt, or motive.
+The system may narrow plausible causal or exposure hypotheses only through preserved evidence and controlled comparison. Political proximity, hostility, pressure, or institutional interest may justify preserving a hypothesis but may not be treated as proof of coercion, coordination, concealed guilt, or motive.
 
-Every conclusion must distinguish:
-
-- observed fact;
-- sourced proposition;
-- inference;
-- hypothesis;
-- missing discriminating evidence;
-- disconfirming condition;
-- publication boundary.
+Every conclusion must distinguish observed fact, sourced proposition, inference, hypothesis, missing discriminating evidence, disconfirming condition, and publication boundary.
 
 ## Primary objective
 
-Advance the capability from framework-only status toward an executable, source-custodied question-level assessment of Anthony Fauci's July 29, 2026 HSGAC appearance.
+Advance the capability from framework status toward an executable, source-custodied, question-level assessment of Anthony Fauci's July 29, 2026 HSGAC appearance.
 
-## Required execution sequence
+## Required execution sequence after CI repair
 
-1. **Validate the branch head**
-   - Inspect all current PR workflow runs.
-   - Open jobs, steps, and logs for every failure.
-   - Fix validator, schema, fixture, or workflow defects.
-   - Confirm both the silence-causation workflow and any repository-wide schema validation remain green before claiming CI success.
+1. Capture the official committee hearing page, official video, official transcript when available, exhibits, witness correspondence, process records, relevant pardon instrument, cited prior testimony, and relevant official communications. Prefer government and primary sources.
+2. For each object preserve source authority, retrieval timestamp, canonical locator, media type, byte length where available, SHA-256 where bytes can be captured, completeness, custody path or immutable pointer, and transformation history.
+3. Create an atomic question ledger preserving exact question-turn wording and timestamps, parent turns, embedded premises, requested facts, people, organizations, dates, documents, response text, counsel intervention, refusal basis, response class, and evidence references.
+4. Distinguish complete refusal, partial answer, qualified answer, memory limitation, privilege assertion, constitutional invocation, procedural objection, nonresponsive answer, and interrupted or withdrawn question.
+5. Construct a normalized chronology and participant/authority graph separating formal decision, advisory, funding, scientific-review, communications, records-custody, reporting, shared-representation, political-affiliation, alleged informal-pressure, and documented intermediary edges. Do not infer informal pressure from proximity alone.
+6. Run answered/refused, harmless/exposure-bearing, topic, document, sequence, questioner, administration-era, non-administration, blanket-counsel, malformed/compound, argumentative, privilege-sensitive, memory, and record-access controls before ranking hypotheses.
+7. Preserve and test H1 personal legal exposure; H2 contradiction with prior testimony or public representation; H3 protection of another participant; H4 institutional liability or narrative containment; H5 political pressure or coercion; H6 blanket counsel strategy; H7 defective/ambiguous/compound/hostile framing; H8 privilege/confidentiality/classification/records restriction; H9 genuine memory limitation.
+8. No political-pressure or coercion hypothesis may receive an affirmative evidentiary score without a sourced communication, instruction, threat, offered benefit, intermediary edge, independently corroborated pressure channel, or equivalent direct or strongly reconstructable evidence identifying actor, channel, timing, and nature.
+9. Preserve non-findings exactly. Keep the case at `research_candidate` or `not_assessable` wherever evidence does not authorize a stronger classification. Absence of explanation is not proof of concealment, and Fifth Amendment invocation is not proof an allegation is true.
 
-2. **Capture primary proceeding evidence**
-   - Locate the official committee hearing page, official video, official transcript if available, exhibits, witness correspondence, process records, and cited prior testimony.
-   - Prefer official government sources.
-   - Preserve retrieval authority, retrieval time, canonical locator, media type, byte length where available, SHA-256 where bytes can be captured, completeness status, custody path or immutable pointer, and every transformation.
-   - Do not substitute news summaries for the primary record.
+## Required artifacts
 
-3. **Create the atomic question ledger**
-   - Preserve exact turn wording and timestamps.
-   - Decompose compound questions into atomic propositions without losing the parent turn.
-   - Record questioner, requested fact, embedded premises, cited exhibit, response text, counsel intervention, refusal basis, and response class.
-   - Distinguish complete refusal, partial answer, qualified answer, memory limitation, privilege assertion, procedural objection, and nonresponsive answer.
+Create or complete according to repository conventions:
 
-4. **Construct the normalized chronology and authority graph**
-   - Link each question to relevant events, dates, grants, communications, briefings, public representations, testimony, policies, and records.
-   - Separate contemporaneous knowledge from later-acquired knowledge.
-   - Represent formal authority, advisory authority, funding authority, communications authority, records custody, reporting relationships, shared representation, and alleged informal pressure as distinct edge types.
+- source-receipt manifest;
+- machine-readable atomic question ledger;
+- human-readable question-ledger review;
+- normalized chronology;
+- participant and authority graph;
+- prior-testimony and documentary-conflict map;
+- control-comparison report;
+- updated silence-causation assessment;
+- contradiction-review records;
+- independent-review records;
+- positive, negative, and indeterminate validator tests and fixtures.
 
-5. **Run controls before ranking causes**
-   - answered versus refused;
-   - harmless versus exposure-bearing;
-   - topic and document clusters;
-   - sequence and questioner effects;
-   - first-administration, later-administration, and non-administration actor comparisons;
-   - blanket-counsel-strategy indicators;
-   - malformed, compound, argumentative, or privilege-sensitive question controls.
+Use existing registries, indexes, schemas, naming conventions, and validators. Do not create parallel formats without inspecting repository authority files.
 
-6. **Evaluate bounded hypotheses**
-   - personal legal exposure;
-   - contradiction with prior sworn testimony or public representation;
-   - protection of another participant;
-   - institutional liability or narrative containment;
-   - political pressure or coercion;
-   - blanket counsel strategy;
-   - defective question framing;
-   - privilege, confidentiality, classification, or records restrictions;
-   - genuine memory limitation.
+## Continuity and publication boundary
 
-   No political-pressure score may become affirmative without a sourced communication, instruction, threat, benefit, intermediary edge, corroborated pressure channel, or equivalent direct evidence.
+Update `ERL_MIRROR_HANDOFF.md` and this prompt whenever execution state materially changes, preserving exact commits, run IDs, job and step conclusions, source hashes, custody state, completed artifacts, blockers, and next actions.
 
-7. **Preserve non-findings**
-   - Record exactly what remains unavailable.
-   - Keep the case at `research_candidate` or `not_assessable` where the evidence does not authorize stronger classification.
-   - Do not convert absence of explanation into proof of concealment.
+Do not publish a motive determination merely because one hypothesis ranks above another. Publication requires primary evidence capture, reproducible scoring, contradiction review, independent review, explicit uncertainty, and separation of fact from inference.
 
-8. **Update continuity artifacts**
-   - Update `ERL_MIRROR_HANDOFF.md` with exact commits, workflow run IDs, captured sources, validation state, remaining blockers, and next actions.
-   - Update this next-session prompt whenever the execution state materially changes.
-
-## Expected artifacts
-
-Create or complete, as repository conventions permit:
-
-- a source-receipt manifest for the official proceeding and related records;
-- a machine-readable atomic question ledger;
-- a human-readable question-ledger review view;
-- a normalized event chronology;
-- a participant and authority graph;
-- a prior-testimony and documentary-conflict map;
-- a control-comparison report;
-- an updated silence-causation assessment;
-- contradiction-review and independent-review records;
-- validator tests and fixtures for positive, negative, and indeterminate cases.
-
-Use existing schemas and repository conventions where they exist. Do not create parallel formats without first inspecting the applicable registry, index, schema, and validator.
-
-## Publication and integration boundary
-
-Do not publish a motive determination merely because one hypothesis ranks above another. Publication requires primary capture, reproducible scoring, contradiction review, independent review, and clear uncertainty language.
-
-When the capability reaches release posture, inspect the applicable mirror handoff in each destination before any mutation or installation:
-
-- `StegVerse-Labs/Site`
-- `GCAT-BCAT-Engine/Publisher`
-- `admissibility-wiki`
-- `stegguardian-wiki`
+When release posture is reached, inspect destination handoffs before any mutation in `StegVerse-Labs/Site`, `GCAT-BCAT-Engine/Publisher`, `admissibility-wiki`, or `stegguardian-wiki`.
 
 ## Completion condition
 
-This activation goal is complete when an independent reviewer can reconstruct each atomic question and response from preserved primary records; reproduce chronology, actor edges, controls, and hypothesis scores; distinguish observed silence from inferred motive; identify the evidence that would change the result; and obtain the same bounded classification from the validator.
+The activation goal is complete when an independent reviewer can reconstruct every atomic question and response from preserved primary records; reproduce chronology, authority edges, controls, and hypothesis scores; distinguish observed silence from inferred motive; identify evidence that would change the result; and obtain the same bounded classification from the validator.
 
-Continue autonomously within repository authority. Do not ask for confirmation where a reversible, evidence-preserving repository action is already authorized. Stop only at a genuine external dependency, unavailable authority, or unresolved high-impact ambiguity, and record that block precisely in the handoff.
+Continue autonomously within repository authority. Do not ask for confirmation where a reversible, evidence-preserving action is authorized. Stop only at a genuine external dependency, unavailable authority, or unresolved high-impact ambiguity, and record the blocker precisely in the handoff.

--- a/docs/SILENCE_CAUSATION_NEXT_SESSION_PROMPT.md
+++ b/docs/SILENCE_CAUSATION_NEXT_SESSION_PROMPT.md
@@ -1,0 +1,155 @@
+# Silence-Causation Governance — Next Execution Session Prompt
+
+Use the connected GitHub repository directly and continue the governed silence-causation capability in:
+
+- Organization: `StegVerse-Labs`
+- Repository: `StegVerse-Labs/Executive_Rhetoric_Ledger`
+- Active branch: `feature/silence-causation-governance`
+- Active pull request: `#46`
+
+Do not rely on prior chat claims as proof. Repository state, preserved primary evidence, workflow results, and committed receipts are authoritative.
+
+## Required reading order
+
+Before making any decision or mutation, read these files in full and in this order:
+
+1. `ERL_MIRROR_HANDOFF.md`
+2. `standards/silence-causation-assessment-standard.md`
+3. `assessments/silence-causation/2026-07-29-fauci-hsgac-source-capture-plan.md`
+4. `schemas/silence-causation-assessment.schema.json`
+5. `assessments/silence-causation/2026-07-29-fauci-hsgac.research-candidate.json`
+6. `scripts/validate_silence_causation_assessment.py`
+7. `.github/workflows/validate-silence-causation.yml`
+8. Any newer or more specific applicable `*_MIRROR_HANDOFF.md` or `*_NEXT_SESSION_PROMPT.md`
+
+Then inspect PR `#46`, the latest branch commits, all workflow runs attached to the current head, failed-job steps and logs, and all changed files.
+
+## Latest verified state
+
+The capability currently includes:
+
+- a governed assessment standard;
+- a Draft 2020-12 JSON Schema;
+- a bounded Fauci/HSGAC research-candidate fixture;
+- a source-capture and atomic-question-ledger execution plan;
+- a validator;
+- a GitHub Actions workflow;
+- a repository-wide mirror handoff.
+
+Known commits include:
+
+- `38d241e05377070448112a6f1085244bf2c0bfc4` — repaired malformed JSON Schema;
+- `e027a86b40fe978cb1c3d28017264cc34159fe34` — installed source-capture and atomic-ledger plan;
+- `f3d8bf2f0ed6b39cad68255264582379dc7fa56b` — updated authoritative handoff.
+
+The initial workflow run `30589764468` failed because the schema was syntactically invalid. Do not claim the repair passed until a later run is inspected directly.
+
+## Governing analytical boundary
+
+Silence, refusal, privilege, memory failure, and invocation of constitutional rights are observable response states, not admissions.
+
+The system may narrow plausible causal or exposure hypotheses only through preserved evidence and controlled comparison. Political proximity, hostility, pressure, or institutional interest may justify a hypothesis but may not be treated as proof of coercion, coordination, concealed guilt, or motive.
+
+Every conclusion must distinguish:
+
+- observed fact;
+- sourced proposition;
+- inference;
+- hypothesis;
+- missing discriminating evidence;
+- disconfirming condition;
+- publication boundary.
+
+## Primary objective
+
+Advance the capability from framework-only status toward an executable, source-custodied question-level assessment of Anthony Fauci's July 29, 2026 HSGAC appearance.
+
+## Required execution sequence
+
+1. **Validate the branch head**
+   - Inspect all current PR workflow runs.
+   - Open jobs, steps, and logs for every failure.
+   - Fix validator, schema, fixture, or workflow defects.
+   - Confirm both the silence-causation workflow and any repository-wide schema validation remain green before claiming CI success.
+
+2. **Capture primary proceeding evidence**
+   - Locate the official committee hearing page, official video, official transcript if available, exhibits, witness correspondence, process records, and cited prior testimony.
+   - Prefer official government sources.
+   - Preserve retrieval authority, retrieval time, canonical locator, media type, byte length where available, SHA-256 where bytes can be captured, completeness status, custody path or immutable pointer, and every transformation.
+   - Do not substitute news summaries for the primary record.
+
+3. **Create the atomic question ledger**
+   - Preserve exact turn wording and timestamps.
+   - Decompose compound questions into atomic propositions without losing the parent turn.
+   - Record questioner, requested fact, embedded premises, cited exhibit, response text, counsel intervention, refusal basis, and response class.
+   - Distinguish complete refusal, partial answer, qualified answer, memory limitation, privilege assertion, procedural objection, and nonresponsive answer.
+
+4. **Construct the normalized chronology and authority graph**
+   - Link each question to relevant events, dates, grants, communications, briefings, public representations, testimony, policies, and records.
+   - Separate contemporaneous knowledge from later-acquired knowledge.
+   - Represent formal authority, advisory authority, funding authority, communications authority, records custody, reporting relationships, shared representation, and alleged informal pressure as distinct edge types.
+
+5. **Run controls before ranking causes**
+   - answered versus refused;
+   - harmless versus exposure-bearing;
+   - topic and document clusters;
+   - sequence and questioner effects;
+   - first-administration, later-administration, and non-administration actor comparisons;
+   - blanket-counsel-strategy indicators;
+   - malformed, compound, argumentative, or privilege-sensitive question controls.
+
+6. **Evaluate bounded hypotheses**
+   - personal legal exposure;
+   - contradiction with prior sworn testimony or public representation;
+   - protection of another participant;
+   - institutional liability or narrative containment;
+   - political pressure or coercion;
+   - blanket counsel strategy;
+   - defective question framing;
+   - privilege, confidentiality, classification, or records restrictions;
+   - genuine memory limitation.
+
+   No political-pressure score may become affirmative without a sourced communication, instruction, threat, benefit, intermediary edge, corroborated pressure channel, or equivalent direct evidence.
+
+7. **Preserve non-findings**
+   - Record exactly what remains unavailable.
+   - Keep the case at `research_candidate` or `not_assessable` where the evidence does not authorize stronger classification.
+   - Do not convert absence of explanation into proof of concealment.
+
+8. **Update continuity artifacts**
+   - Update `ERL_MIRROR_HANDOFF.md` with exact commits, workflow run IDs, captured sources, validation state, remaining blockers, and next actions.
+   - Update this next-session prompt whenever the execution state materially changes.
+
+## Expected artifacts
+
+Create or complete, as repository conventions permit:
+
+- a source-receipt manifest for the official proceeding and related records;
+- a machine-readable atomic question ledger;
+- a human-readable question-ledger review view;
+- a normalized event chronology;
+- a participant and authority graph;
+- a prior-testimony and documentary-conflict map;
+- a control-comparison report;
+- an updated silence-causation assessment;
+- contradiction-review and independent-review records;
+- validator tests and fixtures for positive, negative, and indeterminate cases.
+
+Use existing schemas and repository conventions where they exist. Do not create parallel formats without first inspecting the applicable registry, index, schema, and validator.
+
+## Publication and integration boundary
+
+Do not publish a motive determination merely because one hypothesis ranks above another. Publication requires primary capture, reproducible scoring, contradiction review, independent review, and clear uncertainty language.
+
+When the capability reaches release posture, inspect the applicable mirror handoff in each destination before any mutation or installation:
+
+- `StegVerse-Labs/Site`
+- `GCAT-BCAT-Engine/Publisher`
+- `admissibility-wiki`
+- `stegguardian-wiki`
+
+## Completion condition
+
+This activation goal is complete when an independent reviewer can reconstruct each atomic question and response from preserved primary records; reproduce chronology, actor edges, controls, and hypothesis scores; distinguish observed silence from inferred motive; identify the evidence that would change the result; and obtain the same bounded classification from the validator.
+
+Continue autonomously within repository authority. Do not ask for confirmation where a reversible, evidence-preserving repository action is already authorized. Stop only at a genuine external dependency, unavailable authority, or unresolved high-impact ambiguity, and record that block precisely in the handoff.

--- a/schemas/silence-causation-assessment.schema.json
+++ b/schemas/silence-causation-assessment.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/silence-causation-assessment.schema.json",
+  "title": "Silence-Causation Assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["assessment_id", "status", "proceeding", "source_posture", "questions", "events", "participants", "hypotheses", "controls", "classification", "limitations", "review"],
+  "properties": {
+    "assessment_id": {"type": "string", "minLength": 1},
+    "status": {"enum": ["research_candidate", "under_review", "validated", "final"]},
+    "proceeding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "date", "authority", "witness", "venue", "oath_status"],
+      "properties": {
+        "title": {"type": "string"}, "date": {"type": "string", "format": "date"}, "authority": {"type": "string"}, "witness": {"type": "string"}, "venue": {"type": "string"}, "oath_status": {"enum": ["sworn", "unsworn", "unknown"]}, "subpoena_posture": {"type": "string"}, "counsel_present": {"type": ["boolean", "null"]}
+      }
+    },
+    "source_posture": {
+      "type": "object", "required": ["complete_primary_record", "sources"],
+      "properties": {"complete_primary_record": {"type": "boolean"}, "sources": {"type": "array", "items": {"$ref": "#/$defs/source"}}, "missing_primary_objects": {"type": "array", "items": {"type": "string"}}}
+    },
+    "questions": {"type": "array", "items": {"$ref": "#/$defs/question"}},
+    "events": {"type": "array", "items": {"$ref": "#/$defs/event"}},
+    "participants": {"type": "array", "items": {"$ref": "#/$defs/participant"}},
+    "hypotheses": {"type": "array", "items": {"$ref": "#/$defs/hypothesis"}},
+    "controls": {"type": "array", "items": {"type": "object", "required": ["control_id", "status", "description"], "properties": {"control_id": {"type": "string"}, "status": {"enum": ["complete", "partial", "missing", "not_applicable"]}, "description": {"type": "string"}, "result": {"type": "string"}}}},
+    "classification": {"enum": ["not_assessable", "plausible_but_unranked", "ranked_bounded_hypotheses", "single_hypothesis_materially_preferred", "hypothesis_contradicted"]},
+    "limitations": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "review": {"type": "object", "required": ["contradiction_review", "independent_review"], "properties": {"contradiction_review": {"enum": ["not_started", "in_progress", "complete"]}, "independent_review": {"enum": ["unassigned", "assigned", "complete"]}, "reviewer": {"type": ["string", "null"]}}}
+  },
+  "$defs": {
+    "source": {"type": "object", "required": ["source_id", "source_type", "url", "custody_status"], "properties": {"source_id": {"type": "string"}, "source_type": {"type": "string"}, "url": {"type": "string"}, "custody_status": {"enum": ["located", "captured", "hashed", "unavailable"]}, "content_path": {"type": ["string", "null"]}, "sha256": {"type": ["string", "null"]}}},
+    "question": {"type": "object", "required": ["question_id", "atomic", "wording_status", "questioner", "response_class", "linked_events", "linked_participants", "source_ids"], "properties": {"question_id": {"type": "string"}, "atomic": {"type": "boolean"}, "wording_status": {"enum": ["exact", "transcribed", "paraphrased", "not_captured"]}, "exact_wording": {"type": ["string", "null"]}, "questioner": {"type": "string"}, "timestamp_or_location": {"type": ["string", "null"]}, "response_class": {"enum": ["substantive_answer", "partial_answer", "fifth_amendment", "other_privilege", "cannot_recall", "declined", "counsel_intervention", "procedural_objection", "question_withdrawn", "inaudible_or_unresolved"]}, "response_text": {"type": ["string", "null"]}, "refusal_basis": {"type": ["string", "null"]}, "linked_events": {"type": "array", "items": {"type": "string"}}, "linked_participants": {"type": "array", "items": {"type": "string"}}, "source_ids": {"type": "array", "items": {"type": "string"}}}},
+    "event": {"type": "object", "required": ["event_id", "description", "time_dimensions", "source_ids"], "properties": {"event_id": {"type": "string"}, "description": {"type": "string"}, "time_dimensions": {"type": "object"}, "source_ids": {"type": "array", "items": {"type": "string"}}}},
+    "participant": {"type": "object", "required": ["participant_id", "name", "roles", "edges"], "properties": {"participant_id": {"type": "string"}, "name": {"type": "string"}, "roles": {"type": "array", "items": {"type": "string"}}, "edges": {"type": "array", "items": {"type": "object", "required": ["edge_type", "target", "evidence_status"], "properties": {"edge_type": {"type": "string"}, "target": {"type": "string"}, "evidence_status": {"enum": ["documented", "reported", "hypothesized", "unknown"]}, "source_ids": {"type": "array", "items": {"type": "string"}}}}}},
+    "hypothesis": {"type": "object", "required": ["hypothesis_id", "class", "statement", "supporting_evidence", "contrary_evidence", "assumptions", "discriminating_evidence", "score"], "properties": {"hypothesis_id": {"type": "string"}, "class": {"enum": ["personal_legal_exposure", "prior_statement_conflict", "protection_of_other_actor", "institutional_liability_or_reputation", "blanket_counsel_strategy", "political_pressure_or_coercion", "question_defect_or_hostile_premise", "privilege_security_or_confidentiality", "memory_or_record_limit", "other_bounded_hypothesis"]}, "statement": {"type": "string"}, "supporting_evidence": {"type": "array", "items": {"type": "string"}}, "contrary_evidence": {"type": "array", "items": {"type": "string"}}, "assumptions": {"type": "array", "items": {"type": "string"}}, "discriminating_evidence": {"type": "array", "items": {"type": "string"}}, "score": {"type": "object", "required": ["evidence_support", "pattern_fit", "document_conflict_fit", "authority_network_fit", "alternative_explanation_penalty", "missing_evidence_penalty", "bounded_total"], "properties": {"evidence_support": {"type": "integer", "minimum": 0, "maximum": 4}, "pattern_fit": {"type": "integer", "minimum": 0, "maximum": 4}, "document_conflict_fit": {"type": "integer", "minimum": 0, "maximum": 4}, "authority_network_fit": {"type": "integer", "minimum": 0, "maximum": 4}, "alternative_explanation_penalty": {"type": "integer", "minimum": 0, "maximum": 4}, "missing_evidence_penalty": {"type": "integer", "minimum": 0, "maximum": 4}, "bounded_total": {"type": "integer", "minimum": -8, "maximum": 16}}}}
+  }
+}

--- a/schemas/silence-causation-assessment.schema.json
+++ b/schemas/silence-causation-assessment.schema.json
@@ -4,7 +4,20 @@
   "title": "Silence-Causation Assessment",
   "type": "object",
   "additionalProperties": false,
-  "required": ["assessment_id", "status", "proceeding", "source_posture", "questions", "events", "participants", "hypotheses", "controls", "classification", "limitations", "review"],
+  "required": [
+    "assessment_id",
+    "status",
+    "proceeding",
+    "source_posture",
+    "questions",
+    "events",
+    "participants",
+    "hypotheses",
+    "controls",
+    "classification",
+    "limitations",
+    "review"
+  ],
   "properties": {
     "assessment_id": {"type": "string", "minLength": 1},
     "status": {"enum": ["research_candidate", "under_review", "validated", "final"]},
@@ -13,27 +26,142 @@
       "additionalProperties": false,
       "required": ["title", "date", "authority", "witness", "venue", "oath_status"],
       "properties": {
-        "title": {"type": "string"}, "date": {"type": "string", "format": "date"}, "authority": {"type": "string"}, "witness": {"type": "string"}, "venue": {"type": "string"}, "oath_status": {"enum": ["sworn", "unsworn", "unknown"]}, "subpoena_posture": {"type": "string"}, "counsel_present": {"type": ["boolean", "null"]}
+        "title": {"type": "string"},
+        "date": {"type": "string", "format": "date"},
+        "authority": {"type": "string"},
+        "witness": {"type": "string"},
+        "venue": {"type": "string"},
+        "oath_status": {"enum": ["sworn", "unsworn", "unknown"]},
+        "subpoena_posture": {"type": "string"},
+        "counsel_present": {"type": ["boolean", "null"]}
       }
     },
     "source_posture": {
-      "type": "object", "required": ["complete_primary_record", "sources"],
-      "properties": {"complete_primary_record": {"type": "boolean"}, "sources": {"type": "array", "items": {"$ref": "#/$defs/source"}}, "missing_primary_objects": {"type": "array", "items": {"type": "string"}}}
+      "type": "object",
+      "required": ["complete_primary_record", "sources"],
+      "properties": {
+        "complete_primary_record": {"type": "boolean"},
+        "sources": {"type": "array", "items": {"$ref": "#/$defs/source"}},
+        "missing_primary_objects": {"type": "array", "items": {"type": "string"}}
+      }
     },
     "questions": {"type": "array", "items": {"$ref": "#/$defs/question"}},
     "events": {"type": "array", "items": {"$ref": "#/$defs/event"}},
     "participants": {"type": "array", "items": {"$ref": "#/$defs/participant"}},
     "hypotheses": {"type": "array", "items": {"$ref": "#/$defs/hypothesis"}},
-    "controls": {"type": "array", "items": {"type": "object", "required": ["control_id", "status", "description"], "properties": {"control_id": {"type": "string"}, "status": {"enum": ["complete", "partial", "missing", "not_applicable"]}, "description": {"type": "string"}, "result": {"type": "string"}}}},
+    "controls": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["control_id", "status", "description"],
+        "properties": {
+          "control_id": {"type": "string"},
+          "status": {"enum": ["complete", "partial", "missing", "not_applicable"]},
+          "description": {"type": "string"},
+          "result": {"type": "string"}
+        }
+      }
+    },
     "classification": {"enum": ["not_assessable", "plausible_but_unranked", "ranked_bounded_hypotheses", "single_hypothesis_materially_preferred", "hypothesis_contradicted"]},
     "limitations": {"type": "array", "minItems": 1, "items": {"type": "string"}},
-    "review": {"type": "object", "required": ["contradiction_review", "independent_review"], "properties": {"contradiction_review": {"enum": ["not_started", "in_progress", "complete"]}, "independent_review": {"enum": ["unassigned", "assigned", "complete"]}, "reviewer": {"type": ["string", "null"]}}}
+    "review": {
+      "type": "object",
+      "required": ["contradiction_review", "independent_review"],
+      "properties": {
+        "contradiction_review": {"enum": ["not_started", "in_progress", "complete"]},
+        "independent_review": {"enum": ["unassigned", "assigned", "complete"]},
+        "reviewer": {"type": ["string", "null"]}
+      }
+    }
   },
   "$defs": {
-    "source": {"type": "object", "required": ["source_id", "source_type", "url", "custody_status"], "properties": {"source_id": {"type": "string"}, "source_type": {"type": "string"}, "url": {"type": "string"}, "custody_status": {"enum": ["located", "captured", "hashed", "unavailable"]}, "content_path": {"type": ["string", "null"]}, "sha256": {"type": ["string", "null"]}}},
-    "question": {"type": "object", "required": ["question_id", "atomic", "wording_status", "questioner", "response_class", "linked_events", "linked_participants", "source_ids"], "properties": {"question_id": {"type": "string"}, "atomic": {"type": "boolean"}, "wording_status": {"enum": ["exact", "transcribed", "paraphrased", "not_captured"]}, "exact_wording": {"type": ["string", "null"]}, "questioner": {"type": "string"}, "timestamp_or_location": {"type": ["string", "null"]}, "response_class": {"enum": ["substantive_answer", "partial_answer", "fifth_amendment", "other_privilege", "cannot_recall", "declined", "counsel_intervention", "procedural_objection", "question_withdrawn", "inaudible_or_unresolved"]}, "response_text": {"type": ["string", "null"]}, "refusal_basis": {"type": ["string", "null"]}, "linked_events": {"type": "array", "items": {"type": "string"}}, "linked_participants": {"type": "array", "items": {"type": "string"}}, "source_ids": {"type": "array", "items": {"type": "string"}}}},
-    "event": {"type": "object", "required": ["event_id", "description", "time_dimensions", "source_ids"], "properties": {"event_id": {"type": "string"}, "description": {"type": "string"}, "time_dimensions": {"type": "object"}, "source_ids": {"type": "array", "items": {"type": "string"}}}},
-    "participant": {"type": "object", "required": ["participant_id", "name", "roles", "edges"], "properties": {"participant_id": {"type": "string"}, "name": {"type": "string"}, "roles": {"type": "array", "items": {"type": "string"}}, "edges": {"type": "array", "items": {"type": "object", "required": ["edge_type", "target", "evidence_status"], "properties": {"edge_type": {"type": "string"}, "target": {"type": "string"}, "evidence_status": {"enum": ["documented", "reported", "hypothesized", "unknown"]}, "source_ids": {"type": "array", "items": {"type": "string"}}}}}},
-    "hypothesis": {"type": "object", "required": ["hypothesis_id", "class", "statement", "supporting_evidence", "contrary_evidence", "assumptions", "discriminating_evidence", "score"], "properties": {"hypothesis_id": {"type": "string"}, "class": {"enum": ["personal_legal_exposure", "prior_statement_conflict", "protection_of_other_actor", "institutional_liability_or_reputation", "blanket_counsel_strategy", "political_pressure_or_coercion", "question_defect_or_hostile_premise", "privilege_security_or_confidentiality", "memory_or_record_limit", "other_bounded_hypothesis"]}, "statement": {"type": "string"}, "supporting_evidence": {"type": "array", "items": {"type": "string"}}, "contrary_evidence": {"type": "array", "items": {"type": "string"}}, "assumptions": {"type": "array", "items": {"type": "string"}}, "discriminating_evidence": {"type": "array", "items": {"type": "string"}}, "score": {"type": "object", "required": ["evidence_support", "pattern_fit", "document_conflict_fit", "authority_network_fit", "alternative_explanation_penalty", "missing_evidence_penalty", "bounded_total"], "properties": {"evidence_support": {"type": "integer", "minimum": 0, "maximum": 4}, "pattern_fit": {"type": "integer", "minimum": 0, "maximum": 4}, "document_conflict_fit": {"type": "integer", "minimum": 0, "maximum": 4}, "authority_network_fit": {"type": "integer", "minimum": 0, "maximum": 4}, "alternative_explanation_penalty": {"type": "integer", "minimum": 0, "maximum": 4}, "missing_evidence_penalty": {"type": "integer", "minimum": 0, "maximum": 4}, "bounded_total": {"type": "integer", "minimum": -8, "maximum": 16}}}}
+    "source": {
+      "type": "object",
+      "required": ["source_id", "source_type", "url", "custody_status"],
+      "properties": {
+        "source_id": {"type": "string"},
+        "source_type": {"type": "string"},
+        "url": {"type": "string"},
+        "custody_status": {"enum": ["located", "captured", "hashed", "unavailable"]},
+        "content_path": {"type": ["string", "null"]},
+        "sha256": {"type": ["string", "null"]}
+      }
+    },
+    "question": {
+      "type": "object",
+      "required": ["question_id", "atomic", "wording_status", "questioner", "response_class", "linked_events", "linked_participants", "source_ids"],
+      "properties": {
+        "question_id": {"type": "string"},
+        "atomic": {"type": "boolean"},
+        "wording_status": {"enum": ["exact", "transcribed", "paraphrased", "not_captured"]},
+        "exact_wording": {"type": ["string", "null"]},
+        "questioner": {"type": "string"},
+        "timestamp_or_location": {"type": ["string", "null"]},
+        "response_class": {"enum": ["substantive_answer", "partial_answer", "fifth_amendment", "other_privilege", "cannot_recall", "declined", "counsel_intervention", "procedural_objection", "question_withdrawn", "inaudible_or_unresolved"]},
+        "response_text": {"type": ["string", "null"]},
+        "refusal_basis": {"type": ["string", "null"]},
+        "linked_events": {"type": "array", "items": {"type": "string"}},
+        "linked_participants": {"type": "array", "items": {"type": "string"}},
+        "source_ids": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "event": {
+      "type": "object",
+      "required": ["event_id", "description", "time_dimensions", "source_ids"],
+      "properties": {
+        "event_id": {"type": "string"},
+        "description": {"type": "string"},
+        "time_dimensions": {"type": "object"},
+        "source_ids": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "participant": {
+      "type": "object",
+      "required": ["participant_id", "name", "roles", "edges"],
+      "properties": {
+        "participant_id": {"type": "string"},
+        "name": {"type": "string"},
+        "roles": {"type": "array", "items": {"type": "string"}},
+        "edges": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["edge_type", "target", "evidence_status"],
+            "properties": {
+              "edge_type": {"type": "string"},
+              "target": {"type": "string"},
+              "evidence_status": {"enum": ["documented", "reported", "hypothesized", "unknown"]},
+              "source_ids": {"type": "array", "items": {"type": "string"}}
+            }
+          }
+        }
+      }
+    },
+    "hypothesis": {
+      "type": "object",
+      "required": ["hypothesis_id", "class", "statement", "supporting_evidence", "contrary_evidence", "assumptions", "discriminating_evidence", "score"],
+      "properties": {
+        "hypothesis_id": {"type": "string"},
+        "class": {"enum": ["personal_legal_exposure", "prior_statement_conflict", "protection_of_other_actor", "institutional_liability_or_reputation", "blanket_counsel_strategy", "political_pressure_or_coercion", "question_defect_or_hostile_premise", "privilege_security_or_confidentiality", "memory_or_record_limit", "other_bounded_hypothesis"]},
+        "statement": {"type": "string"},
+        "supporting_evidence": {"type": "array", "items": {"type": "string"}},
+        "contrary_evidence": {"type": "array", "items": {"type": "string"}},
+        "assumptions": {"type": "array", "items": {"type": "string"}},
+        "discriminating_evidence": {"type": "array", "items": {"type": "string"}},
+        "score": {
+          "type": "object",
+          "required": ["evidence_support", "pattern_fit", "document_conflict_fit", "authority_network_fit", "alternative_explanation_penalty", "missing_evidence_penalty", "bounded_total"],
+          "properties": {
+            "evidence_support": {"type": "integer", "minimum": 0, "maximum": 4},
+            "pattern_fit": {"type": "integer", "minimum": 0, "maximum": 4},
+            "document_conflict_fit": {"type": "integer", "minimum": 0, "maximum": 4},
+            "authority_network_fit": {"type": "integer", "minimum": 0, "maximum": 4},
+            "alternative_explanation_penalty": {"type": "integer", "minimum": 0, "maximum": 4},
+            "missing_evidence_penalty": {"type": "integer", "minimum": 0, "maximum": 4},
+            "bounded_total": {"type": "integer", "minimum": -8, "maximum": 16}
+          }
+        }
+      }
+    }
   }
 }

--- a/scripts/validate_silence_causation_assessment.py
+++ b/scripts/validate_silence_causation_assessment.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Validate ERL silence-causation assessments and governance invariants."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    import jsonschema
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("jsonschema is required: pip install jsonschema") from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "silence-causation-assessment.schema.json"
+ASSESSMENTS = ROOT / "assessments" / "silence-causation"
+
+
+def bounded_total(score: dict[str, int]) -> int:
+    return (
+        score["evidence_support"]
+        + score["pattern_fit"]
+        + score["document_conflict_fit"]
+        + score["authority_network_fit"]
+        - score["alternative_explanation_penalty"]
+        - score["missing_evidence_penalty"]
+    )
+
+
+def validate_governance(data: dict) -> list[str]:
+    errors: list[str] = []
+    complete = data["source_posture"]["complete_primary_record"]
+    questions = data["questions"]
+
+    if not complete and data["classification"] not in {"not_assessable", "plausible_but_unranked"}:
+        errors.append("Incomplete primary record cannot support ranked or preferred hypotheses.")
+
+    if data["classification"] == "single_hypothesis_materially_preferred":
+        if data["review"]["contradiction_review"] != "complete":
+            errors.append("Preferred hypothesis requires complete contradiction review.")
+        if data["review"]["independent_review"] != "complete":
+            errors.append("Preferred hypothesis requires complete independent review.")
+        if not questions:
+            errors.append("Preferred hypothesis requires an atomic question ledger.")
+
+    for hypothesis in data["hypotheses"]:
+        expected = bounded_total(hypothesis["score"])
+        actual = hypothesis["score"]["bounded_total"]
+        if expected != actual:
+            errors.append(f"{hypothesis['hypothesis_id']}: bounded_total {actual} != computed {expected}")
+        if hypothesis["class"] == "political_pressure_or_coercion" and not hypothesis["supporting_evidence"]:
+            if actual > 0:
+                errors.append(f"{hypothesis['hypothesis_id']}: unsupported coercion hypothesis cannot score above zero")
+
+    for participant in data["participants"]:
+        for edge in participant["edges"]:
+            if edge["evidence_status"] in {"hypothesized", "unknown"} and edge.get("source_ids"):
+                errors.append(f"{participant['participant_id']}: unknown/hypothesized edge must not cite sources as proof")
+
+    return errors
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    files = sorted(ASSESSMENTS.glob("*.json"))
+    if not files:
+        print("No silence-causation assessments found.", file=sys.stderr)
+        return 1
+
+    failures = 0
+    for path in files:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        try:
+            jsonschema.Draft202012Validator(schema, format_checker=jsonschema.FormatChecker()).validate(data)
+        except jsonschema.ValidationError as exc:
+            failures += 1
+            print(f"FAIL {path}: schema: {exc.message}")
+            continue
+        governance_errors = validate_governance(data)
+        if governance_errors:
+            failures += 1
+            for error in governance_errors:
+                print(f"FAIL {path}: governance: {error}")
+        else:
+            print(f"PASS {path}")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/standards/silence-causation-assessment-standard.md
+++ b/standards/silence-causation-assessment-standard.md
@@ -1,0 +1,161 @@
+# Silence-Causation Assessment Standard
+
+## Purpose
+
+This standard governs analysis of testimony, interviews, depositions, oversight appearances, or other proceedings where a person refuses, declines, cannot recall, invokes privilege, invokes a constitutional protection, or answers selectively.
+
+It is designed to answer a bounded question:
+
+> Given the exact question set, observed response pattern, event record, participant graph, prior statements, and available documents, which explanations for silence remain plausible, which are contradicted, and what evidence would discriminate among them?
+
+## Non-admission rule
+
+A refusal is not an admission. A Fifth Amendment invocation is not proof that the premise of a question is true. No assessment may infer guilt, coordination, coercion, deception, or protection of another person solely from silence.
+
+## Required layers
+
+### 1. Proceeding record
+
+Record the proceeding authority, date, venue, witness, oath status, subpoena or invitation posture, counsel presence, and source custody.
+
+### 2. Atomic question ledger
+
+Each compound question must be decomposed into atomic propositions. Every question record must contain:
+
+- exact wording or a source-linked transcription;
+- questioner;
+- timestamp or transcript location;
+- referenced person, event, document, date, and prior statement;
+- response class;
+- response text;
+- stated refusal basis;
+- source receipt.
+
+### 3. Response classes
+
+Allowed response classes:
+
+- `substantive_answer`
+- `partial_answer`
+- `fifth_amendment`
+- `other_privilege`
+- `cannot_recall`
+- `declined`
+- `counsel_intervention`
+- `procedural_objection`
+- `question_withdrawn`
+- `inaudible_or_unresolved`
+
+### 4. Event chronology
+
+Separate physical event time, knowledge time, communication time, decision time, statement time, publication time, testimony time, and later analysis time. Unknown dimensions remain unknown.
+
+### 5. Participant and authority graph
+
+Map role-specific edges, including formal supervision, advisory authority, funding authority, records custody, legal representation, political appointment, communications control, investigatory authority, prosecutorial authority, and documented private contact.
+
+An authority edge does not establish influence over the refusal decision.
+
+### 6. Conflict and exposure mapping
+
+For each atomic question, identify whether each possible answer class could:
+
+- conflict with a preserved document;
+- conflict with prior sworn testimony;
+- expose post-pardon or post-immunity conduct;
+- implicate another actor;
+- reveal institutional decision authority;
+- create civil, criminal, administrative, political, or reputational exposure;
+- waive privilege or create selective-disclosure consequences;
+- remain harmless under the known record.
+
+### 7. Hypothesis register
+
+Default hypothesis classes:
+
+- `personal_legal_exposure`
+- `prior_statement_conflict`
+- `protection_of_other_actor`
+- `institutional_liability_or_reputation`
+- `blanket_counsel_strategy`
+- `political_pressure_or_coercion`
+- `question_defect_or_hostile_premise`
+- `privilege_security_or_confidentiality`
+- `memory_or_record_limit`
+- `other_bounded_hypothesis`
+
+Every hypothesis requires supporting evidence, contrary evidence, assumptions, and a discriminating-evidence request.
+
+### 8. Controls
+
+At minimum, compare:
+
+- answered versus refused questions;
+- harmless versus exposure-bearing questions;
+- questions inside versus outside the pardon or immunity period;
+- questions with versus without documentary predicates;
+- questions naming different actors or administrations;
+- repeated questions phrased differently;
+- blanket invocation patterns versus selective invocation patterns.
+
+### 9. Scoring
+
+Scores are analytic aids, not probabilities of guilt.
+
+Each hypothesis receives integer values from 0 to 4 for:
+
+- `evidence_support`
+- `pattern_fit`
+- `document_conflict_fit`
+- `authority_network_fit`
+- `alternative_explanation_penalty`
+- `missing_evidence_penalty`
+
+The bounded score is:
+
+`support + pattern + document + authority - alternative penalty - missing evidence penalty`
+
+The score must not be converted into a percentage probability unless a separately validated statistical model exists.
+
+### 10. Classification
+
+Allowed classifications:
+
+- `not_assessable`
+- `plausible_but_unranked`
+- `ranked_bounded_hypotheses`
+- `single_hypothesis_materially_preferred`
+- `hypothesis_contradicted`
+
+`single_hypothesis_materially_preferred` requires complete primary question capture, adequate controls, at least one discriminating item of evidence, contradiction review, and independent review.
+
+## Anti-misuse constraints
+
+The assessment must not:
+
+- describe silence as confession;
+- infer private advice or coercion without evidence;
+- treat a reporting relationship as proof of direction;
+- collapse legal, political, reputational, and institutional exposure;
+- score a named person as responsible for pressure without a sourced interaction edge;
+- omit harmless-question controls;
+- publish a final motive determination from an incomplete transcript.
+
+## Initial Fauci test posture
+
+The July 29, 2026 HSGAC appearance is initially classified `not_assessable` at the question-causation level because the repository does not yet contain a complete, source-custodied atomic question ledger. Publicly established facts may be recorded, but motive hypotheses remain bounded and unranked until primary capture is complete.
+
+## Done criteria
+
+A silence-causation assessment is complete only when:
+
+1. the complete proceeding is preserved or bounded omissions are documented;
+2. questions are atomic and source-linked;
+3. responses are classified reproducibly;
+4. chronology and actor edges are sourced;
+5. prior statements and documentary predicates are linked;
+6. controls are populated;
+7. hypotheses include support, contradiction, assumptions, and discriminators;
+8. the schema validates;
+9. contradiction review is complete;
+10. independent review is recorded.


### PR DESCRIPTION
## Summary

Builds the first ERL capability for mapping question-level refusals against events, participants, authority edges, documentary conflicts, controls, and bounded motive hypotheses without treating silence as an admission.

## Included

- repository-wide `ERL_MIRROR_HANDOFF.md`
- silence-causation assessment standard
- JSON Schema
- bounded July 29, 2026 Fauci/HSGAC research-candidate fixture
- validator with governance invariants
- GitHub Actions validation workflow

## Initial test result encoded

The current Fauci case remains `not_assessable` at question-causation level because the exact question ledger and complete primary proceeding record have not yet been captured. The fixture explicitly preserves the political-pressure hypothesis while scoring it below zero because no sourced private pressure edge currently exists.

## Next evidence work

Capture the official video/transcript, atomic question wording, exhibits, prior statements, pardon instrument, counsel correspondence, and harmless-versus-exposure controls. No motive determination is authorized until those records exist and independent review is complete.