### PR TITLE
Generalize governed validation evidence capture

### DIFF
--- a/.github/workflows/capture-validation-evidence.yml
+++ b/.github/workflows/capture-validation-evidence.yml
@@ -1,0 +1,73 @@
+name: Capture Validation Evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      manifest:
+        description: Governed validator manifest path
+        required: true
+        default: validation_manifests/repository-core.json
+      subject_id:
+        description: Optional assessment or repository subject identifier
+        required: false
+        default: Executive_Rhetoric_Ledger
+  workflow_call:
+    inputs:
+      manifest:
+        required: true
+        type: string
+      subject_id:
+        required: false
+        type: string
+        default: Executive_Rhetoric_Ledger
+
+permissions:
+  contents: read
+
+env:
+  EVIDENCE_DIR: validation_evidence/current
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact commit
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install validation dependencies
+        run: python -m pip install --upgrade pip jsonschema
+
+      - name: Capture governed validation evidence
+        id: capture
+        continue-on-error: true
+        run: |
+          python scripts/capture_validation_manifest.py \
+            --manifest "${{ inputs.manifest }}" \
+            --subject-id "${{ inputs.subject_id }}" \
+            --output "$EVIDENCE_DIR"
+
+      - name: Upload evidence before enforcement
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.EVIDENCE_DIR }}
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Enforce receipt conclusion
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          receipt = json.loads(Path("validation_evidence/current/validation-execution-receipt.json").read_text())
+          if receipt["overall_conclusion"] != "success":
+              raise SystemExit("validation evidence receipt is not successful")
+          print("validation evidence receipt conclusion: success")
+          PY

--- a/.github/workflows/validate-validation-evidence.yml
+++ b/.github/workflows/validate-validation-evidence.yml
@@ -1,0 +1,70 @@
+name: Validate Validation Evidence Layer
+
+on:
+  pull_request:
+    paths:
+      - "schemas/validation-evidence-manifest.schema.json"
+      - "schemas/validation-execution-receipt.schema.json"
+      - "validation_manifests/**"
+      - "validation_evidence/fixtures/**"
+      - "scripts/capture_validation_manifest.py"
+      - "scripts/validate_validation_evidence.py"
+      - ".github/workflows/capture-validation-evidence.yml"
+      - ".github/workflows/validate-validation-evidence.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-contract-and-fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact commit
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install schema validator
+        run: python -m pip install --upgrade pip jsonschema
+
+      - name: Validate governed manifest and fixture receipts
+        run: python scripts/validate_validation_evidence.py --fixtures
+
+      - name: Smoke-test manifest-driven capture
+        run: |
+          rm -rf /tmp/validation-evidence-smoke
+          python scripts/capture_validation_manifest.py \
+            --manifest validation_manifests/repository-core.json \
+            --subject-id Executive_Rhetoric_Ledger \
+            --output /tmp/validation-evidence-smoke
+
+      - name: Validate generated smoke receipt
+        run: |
+          python scripts/validate_validation_evidence.py \
+            --manifest validation_manifests/repository-core.json \
+            --receipt /tmp/validation-evidence-smoke/validation-execution-receipt.json
+
+      - name: Upload generated evidence before enforcement
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-evidence-layer-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/validation-evidence-smoke
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Enforce generated receipt conclusion
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          receipt = json.loads(Path('/tmp/validation-evidence-smoke/validation-execution-receipt.json').read_text())
+          if receipt['overall_conclusion'] != 'success':
+              raise SystemExit('generated validation-evidence receipt is not successful')
+          print('generated validation-evidence receipt conclusion: success')
+          PY

--- a/schemas/validation-evidence-manifest.schema.json
+++ b/schemas/validation-evidence-manifest.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/validation-evidence-manifest.schema.json",
+  "title": "Governed Validator Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["manifest_version", "manifest_id", "validators", "authority_boundary"],
+  "properties": {
+    "manifest_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "manifest_id": {"type": "string", "minLength": 1},
+    "description": {"type": "string"},
+    "validators": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "command", "required"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$"},
+          "command": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+          "required": {"type": "boolean"},
+          "working_directory": {"type": "string"},
+          "timeout_seconds": {"type": "integer", "minimum": 1},
+          "evidence_class": {"type": "string"}
+        }
+      }
+    },
+    "authority_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["may_promote_publication", "may_assert_source_completeness", "may_change_factual_confidence"],
+      "properties": {
+        "may_promote_publication": {"const": false},
+        "may_assert_source_completeness": {"const": false},
+        "may_change_factual_confidence": {"const": false}
+      }
+    }
+  }
+}

--- a/schemas/validation-execution-receipt.schema.json
+++ b/schemas/validation-execution-receipt.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/validation-execution-receipt.schema.json",
+  "title": "Validation Execution Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "receipt_type", "manifest_id", "capture_started_at", "capture_completed_at", "execution_environment", "validators", "overall_conclusion", "authority"],
+  "properties": {
+    "schema_version": {"type": "string"},
+    "receipt_type": {"const": "governed-validator-execution-evidence"},
+    "manifest_id": {"type": "string"},
+    "subject_id": {"type": "string"},
+    "capture_started_at": {"type": "string", "format": "date-time"},
+    "capture_completed_at": {"type": "string", "format": "date-time"},
+    "execution_environment": {"type": "object"},
+    "validators": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "command", "started_at", "completed_at", "exit_code", "conclusion", "stdout", "stderr", "log_path", "log_sha256", "log_byte_size"],
+        "properties": {
+          "name": {"type": "string"},
+          "command": {"type": "array", "items": {"type": "string"}},
+          "started_at": {"type": "string", "format": "date-time"},
+          "completed_at": {"type": "string", "format": "date-time"},
+          "exit_code": {"type": "integer"},
+          "conclusion": {"enum": ["success", "failure", "cancelled", "partial", "error"]},
+          "stdout": {"type": "string"},
+          "stderr": {"type": "string"},
+          "log_path": {"type": "string"},
+          "log_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+          "log_byte_size": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "first_failed_validator": {"type": ["string", "null"]},
+    "overall_conclusion": {"enum": ["success", "failure", "cancelled", "partial", "error"]},
+    "activation_effect": {"enum": ["validator-layer-passed", "activation-blocked", "indeterminate"]},
+    "authority": {
+      "type": "object",
+      "required": ["may_promote_publication", "may_assert_primary_source_completion", "may_change_chain_node_confidence"],
+      "properties": {
+        "may_promote_publication": {"const": false},
+        "may_assert_primary_source_completion": {"const": false},
+        "may_change_chain_node_confidence": {"const": false}
+      }
+    },
+    "notes": {"type": "string"}
+  }
+}

--- a/scripts/capture_validation_manifest.py
+++ b/scripts/capture_validation_manifest.py
@@ -46,7 +46,7 @@ def github_environment() -> dict[str, Any]:
         "runner_name": os.getenv("RUNNER_NAME", ""),
         "runner_os": os.getenv("RUNNER_OS", ""),
         "run_url": f"{server}/{repository}/actions/runs/{run_id}" if repository and run_id else "",
-        "attempt_url": f"{server}/{repository}/actions/runs/{run_id}/attempts/{attempt}" if repository and run_id and attempt else ""
+        "attempt_url": f"{server}/{repository}/actions/runs/{run_id}/attempts/{attempt}" if repository and run_id and attempt else "",
     }
 
 
@@ -56,7 +56,14 @@ def run_entry(entry: dict[str, Any], output_dir: Path) -> dict[str, Any]:
     timeout = entry.get("timeout_seconds")
     cwd = entry.get("working_directory", ".")
     try:
-        process = subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=False, timeout=timeout)
+        process = subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
         exit_code = process.returncode
         stdout = process.stdout
         stderr = process.stderr
@@ -66,10 +73,15 @@ def run_entry(entry: dict[str, Any], output_dir: Path) -> dict[str, Any]:
         stdout = exc.stdout or ""
         stderr = (exc.stderr or "") + "\nvalidator timed out"
         conclusion = "error"
+
     completed = utc_now()
-    log_path = output_dir / f"{entry['id']}.log"
+    log_name = f"{entry['id']}.log"
+    log_path = output_dir / log_name
     log_path.write_text(
-        f"command: {' '.join(command)}\nexit_code: {exit_code}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}",
+        f"command: {' '.join(command)}\n"
+        f"exit_code: {exit_code}\n"
+        f"--- stdout ---\n{stdout}\n"
+        f"--- stderr ---\n{stderr}",
         encoding="utf-8",
     )
     return {
@@ -81,7 +93,7 @@ def run_entry(entry: dict[str, Any], output_dir: Path) -> dict[str, Any]:
         "conclusion": conclusion,
         "stdout": stdout,
         "stderr": stderr,
-        "log_path": str(log_path),
+        "log_path": log_name,
         "log_sha256": digest(log_path),
         "log_byte_size": log_path.stat().st_size,
     }
@@ -115,27 +127,56 @@ def main() -> int:
         "capture_completed_at": completed,
         "execution_environment": github_environment(),
         "validators": results,
-        "first_failed_validator": next((r["name"] for r in results if r["exit_code"] != 0), None),
+        "first_failed_validator": next(
+            (result["name"] for result in results if result["exit_code"] != 0),
+            None,
+        ),
         "overall_conclusion": "success" if success else "failure",
         "activation_effect": "validator-layer-passed" if success else "activation-blocked",
         "authority": {
             "may_promote_publication": False,
             "may_assert_primary_source_completion": False,
-            "may_change_chain_node_confidence": False
+            "may_change_chain_node_confidence": False,
         },
-        "notes": "Validator success proves only recorded execution for the identified manifest, commit, and run."
+        "notes": "Validator success proves only recorded execution for the identified manifest, commit, and run.",
     }
     receipt_path = output_dir / "validation-execution-receipt.json"
     receipt_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+
     files = []
     for path in sorted(output_dir.iterdir()):
         if path.is_file():
-            files.append({"path": str(path), "sha256": digest(path), "byte_size": path.stat().st_size})
-    (output_dir / "artifact-manifest.json").write_text(
-        json.dumps({"generated_at": completed, "manifest_id": manifest["manifest_id"], "files": files}, indent=2) + "\n",
+            files.append(
+                {
+                    "path": path.name,
+                    "sha256": digest(path),
+                    "byte_size": path.stat().st_size,
+                }
+            )
+    manifest_path = output_dir / "artifact-manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "generated_at": completed,
+                "manifest_id": manifest["manifest_id"],
+                "files": files,
+            },
+            indent=2,
+        )
+        + "\n",
         encoding="utf-8",
     )
-    print(json.dumps({"overall_conclusion": receipt["overall_conclusion"], "receipt_path": str(receipt_path)}, indent=2))
+
+    print(
+        json.dumps(
+            {
+                "overall_conclusion": receipt["overall_conclusion"],
+                "receipt_path": str(receipt_path),
+                "manifest_path": str(manifest_path),
+            },
+            indent=2,
+        )
+    )
     return 0
 
 

--- a/scripts/capture_validation_manifest.py
+++ b/scripts/capture_validation_manifest.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Execute a governed validator manifest and emit durable evidence before enforcement."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def digest(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def github_environment() -> dict[str, Any]:
+    server = os.getenv("GITHUB_SERVER_URL", "https://github.com")
+    repository = os.getenv("GITHUB_REPOSITORY", "")
+    run_id = os.getenv("GITHUB_RUN_ID", "")
+    attempt = os.getenv("GITHUB_RUN_ATTEMPT", "")
+    return {
+        "repository": repository,
+        "workflow": os.getenv("GITHUB_WORKFLOW", ""),
+        "workflow_ref": os.getenv("GITHUB_WORKFLOW_REF", ""),
+        "event_name": os.getenv("GITHUB_EVENT_NAME", ""),
+        "head_branch": os.getenv("GITHUB_REF_NAME", ""),
+        "head_ref": os.getenv("GITHUB_REF", ""),
+        "head_commit": os.getenv("GITHUB_SHA", ""),
+        "run_id": run_id,
+        "run_number": os.getenv("GITHUB_RUN_NUMBER", ""),
+        "run_attempt": attempt,
+        "job_id_environment": os.getenv("GITHUB_JOB", ""),
+        "actor": os.getenv("GITHUB_ACTOR", ""),
+        "runner_name": os.getenv("RUNNER_NAME", ""),
+        "runner_os": os.getenv("RUNNER_OS", ""),
+        "run_url": f"{server}/{repository}/actions/runs/{run_id}" if repository and run_id else "",
+        "attempt_url": f"{server}/{repository}/actions/runs/{run_id}/attempts/{attempt}" if repository and run_id and attempt else ""
+    }
+
+
+def run_entry(entry: dict[str, Any], output_dir: Path) -> dict[str, Any]:
+    started = utc_now()
+    command = entry["command"]
+    timeout = entry.get("timeout_seconds")
+    cwd = entry.get("working_directory", ".")
+    try:
+        process = subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=False, timeout=timeout)
+        exit_code = process.returncode
+        stdout = process.stdout
+        stderr = process.stderr
+        conclusion = "success" if exit_code == 0 else "failure"
+    except subprocess.TimeoutExpired as exc:
+        exit_code = 124
+        stdout = exc.stdout or ""
+        stderr = (exc.stderr or "") + "\nvalidator timed out"
+        conclusion = "error"
+    completed = utc_now()
+    log_path = output_dir / f"{entry['id']}.log"
+    log_path.write_text(
+        f"command: {' '.join(command)}\nexit_code: {exit_code}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}",
+        encoding="utf-8",
+    )
+    return {
+        "name": entry["id"],
+        "command": command,
+        "started_at": started,
+        "completed_at": completed,
+        "exit_code": exit_code,
+        "conclusion": conclusion,
+        "stdout": stdout,
+        "stderr": stderr,
+        "log_path": str(log_path),
+        "log_sha256": digest(log_path),
+        "log_byte_size": log_path.stat().st_size,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--output", default="validation_evidence/current")
+    parser.add_argument("--subject-id", default="")
+    args = parser.parse_args()
+
+    manifest = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    started = utc_now()
+    results = [run_entry(entry, output_dir) for entry in manifest["validators"]]
+    completed = utc_now()
+    required_failures = {
+        entry["id"] for entry in manifest["validators"] if entry.get("required", True)
+    } & {result["name"] for result in results if result["exit_code"] != 0}
+    success = not required_failures
+
+    receipt = {
+        "schema_version": "1.0.0",
+        "receipt_type": "governed-validator-execution-evidence",
+        "manifest_id": manifest["manifest_id"],
+        "subject_id": args.subject_id,
+        "capture_started_at": started,
+        "capture_completed_at": completed,
+        "execution_environment": github_environment(),
+        "validators": results,
+        "first_failed_validator": next((r["name"] for r in results if r["exit_code"] != 0), None),
+        "overall_conclusion": "success" if success else "failure",
+        "activation_effect": "validator-layer-passed" if success else "activation-blocked",
+        "authority": {
+            "may_promote_publication": False,
+            "may_assert_primary_source_completion": False,
+            "may_change_chain_node_confidence": False
+        },
+        "notes": "Validator success proves only recorded execution for the identified manifest, commit, and run."
+    }
+    receipt_path = output_dir / "validation-execution-receipt.json"
+    receipt_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    files = []
+    for path in sorted(output_dir.iterdir()):
+        if path.is_file():
+            files.append({"path": str(path), "sha256": digest(path), "byte_size": path.stat().st_size})
+    (output_dir / "artifact-manifest.json").write_text(
+        json.dumps({"generated_at": completed, "manifest_id": manifest["manifest_id"], "files": files}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps({"overall_conclusion": receipt["overall_conclusion"], "receipt_path": str(receipt_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_validation_evidence.py
+++ b/scripts/validate_validation_evidence.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Validate governed validator manifests, execution receipts, and fixture expectations."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_SCHEMA = ROOT / "schemas/validation-evidence-manifest.schema.json"
+RECEIPT_SCHEMA = ROOT / "schemas/validation-execution-receipt.schema.json"
+FIXTURE_ROOT = ROOT / "validation_fixtures/validation-evidence"
+
+
+def load(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_json(instance: Any, schema_path: Path, label: str) -> list[str]:
+    validator = Draft202012Validator(load(schema_path), format_checker=FormatChecker())
+    return [f"{label}: {error.message}" for error in sorted(validator.iter_errors(instance), key=lambda e: list(e.path))]
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def validate_receipt_semantics(receipt: dict[str, Any], path: Path) -> list[str]:
+    errors: list[str] = []
+    validators = receipt.get("validators", [])
+    required_failures = [entry for entry in validators if entry.get("required", True) and entry.get("exit_code") != 0]
+    expected = "failure" if required_failures else "success"
+    if receipt.get("overall_conclusion") in {"success", "failure"} and receipt.get("overall_conclusion") != expected:
+        errors.append(f"{path}: overall_conclusion disagrees with required validator outcomes")
+    authority = receipt.get("authority", {})
+    if any(authority.get(key) is not False for key in (
+        "may_promote_publication",
+        "may_assert_primary_source_completion",
+        "may_change_chain_node_confidence",
+    )):
+        errors.append(f"{path}: authority boundary must remain false")
+    for entry in validators:
+        log_path = entry.get("log_path")
+        if log_path and Path(log_path).is_absolute():
+            errors.append(f"{path}: log_path must be artifact-relative")
+    return errors
+
+
+def validate_fixtures() -> list[str]:
+    errors: list[str] = []
+    index_path = FIXTURE_ROOT / "fixture-index.json"
+    index = load(index_path)
+    for fixture in index["fixtures"]:
+        fixture_path = FIXTURE_ROOT / fixture["path"]
+        payload = load(fixture_path)
+        errors.extend(validate_json(payload, RECEIPT_SCHEMA, fixture["id"]))
+        errors.extend(validate_receipt_semantics(payload, fixture_path))
+        if payload.get("overall_conclusion") != fixture["expected_conclusion"]:
+            errors.append(f"{fixture['id']}: expected {fixture['expected_conclusion']} but found {payload.get('overall_conclusion')}")
+        if fixture.get("expected_activation_effect") and payload.get("activation_effect") != fixture["expected_activation_effect"]:
+            errors.append(f"{fixture['id']}: activation_effect mismatch")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", default="validation_manifests/repository-core.json")
+    parser.add_argument("--receipt")
+    parser.add_argument("--fixtures", action="store_true")
+    args = parser.parse_args()
+
+    errors: list[str] = []
+    manifest_path = ROOT / args.manifest
+    errors.extend(validate_json(load(manifest_path), MANIFEST_SCHEMA, str(manifest_path)))
+
+    if args.receipt:
+        receipt_path = ROOT / args.receipt
+        receipt = load(receipt_path)
+        errors.extend(validate_json(receipt, RECEIPT_SCHEMA, str(receipt_path)))
+        errors.extend(validate_receipt_semantics(receipt, receipt_path))
+
+    if args.fixtures:
+        errors.extend(validate_fixtures())
+
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}")
+        return 1
+
+    print(f"PASS: validation evidence contracts verified; manifest_sha256={sha256(manifest_path)}")
+    print("NOTE: contract validity does not establish source completeness, factual truth, admissibility, or publication authority")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation_fixtures/validation-evidence/cancelled.json
+++ b/validation_fixtures/validation-evidence/cancelled.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0.0",
+  "receipt_type": "governed-validator-execution-evidence",
+  "manifest_id": "fixture-cancelled",
+  "subject_id": "fixture",
+  "capture_started_at": "2026-07-31T21:59:00Z",
+  "capture_completed_at": "2026-07-31T21:59:00Z",
+  "execution_environment": {"run_id": "103", "run_attempt": "1", "head_commit": "dddddddddddddddddddddddddddddddddddddddd"},
+  "validators": [{"name": "cancelled", "command": ["python", "-c", "print('not-run')"], "required": true, "started_at": "2026-07-31T21:59:00Z", "completed_at": "2026-07-31T21:59:00Z", "exit_code": 130, "conclusion": "cancelled", "stdout": "", "stderr": "workflow cancelled\n", "log_path": "cancelled.log", "log_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "log_byte_size": 19}],
+  "first_failed_validator": "cancelled",
+  "overall_conclusion": "cancelled",
+  "activation_effect": "indeterminate",
+  "authority": {"may_promote_publication": false, "may_assert_primary_source_completion": false, "may_change_chain_node_confidence": false},
+  "notes": "Cancellation is distinct from validator failure and cannot activate anything."
+}

--- a/validation_fixtures/validation-evidence/failure.json
+++ b/validation_fixtures/validation-evidence/failure.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0.0",
+  "receipt_type": "governed-validator-execution-evidence",
+  "manifest_id": "fixture-failure",
+  "subject_id": "fixture",
+  "capture_started_at": "2026-07-31T21:59:00Z",
+  "capture_completed_at": "2026-07-31T21:59:01Z",
+  "execution_environment": {"run_id": "101", "run_attempt": "1", "head_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+  "validators": [{"name": "fail", "command": ["python", "-c", "raise SystemExit(1)"], "required": true, "started_at": "2026-07-31T21:59:00Z", "completed_at": "2026-07-31T21:59:01Z", "exit_code": 1, "conclusion": "failure", "stdout": "", "stderr": "failed\n", "log_path": "fail.log", "log_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "log_byte_size": 7}],
+  "first_failed_validator": "fail",
+  "overall_conclusion": "failure",
+  "activation_effect": "activation-blocked",
+  "authority": {"may_promote_publication": false, "may_assert_primary_source_completion": false, "may_change_chain_node_confidence": false},
+  "notes": "Negative fixture only."
+}

--- a/validation_fixtures/validation-evidence/fixture-index.json
+++ b/validation_fixtures/validation-evidence/fixture-index.json
@@ -1,0 +1,10 @@
+{
+  "fixture_version": "1.0.0",
+  "fixtures": [
+    {"id": "success", "path": "success.json", "expected_conclusion": "success", "expected_activation_effect": "validator-layer-passed"},
+    {"id": "failure", "path": "failure.json", "expected_conclusion": "failure", "expected_activation_effect": "activation-blocked"},
+    {"id": "partial", "path": "partial.json", "expected_conclusion": "partial", "expected_activation_effect": "indeterminate"},
+    {"id": "cancelled", "path": "cancelled.json", "expected_conclusion": "cancelled", "expected_activation_effect": "indeterminate"},
+    {"id": "rerun", "path": "rerun.json", "expected_conclusion": "success", "expected_activation_effect": "validator-layer-passed"}
+  ]
+}

--- a/validation_fixtures/validation-evidence/partial.json
+++ b/validation_fixtures/validation-evidence/partial.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0.0",
+  "receipt_type": "governed-validator-execution-evidence",
+  "manifest_id": "fixture-partial",
+  "subject_id": "fixture",
+  "capture_started_at": "2026-07-31T21:59:00Z",
+  "capture_completed_at": "2026-07-31T21:59:01Z",
+  "execution_environment": {"run_id": "102", "run_attempt": "1", "head_commit": "cccccccccccccccccccccccccccccccccccccccc"},
+  "validators": [{"name": "completed", "command": ["python", "-c", "print('ok')"], "required": true, "started_at": "2026-07-31T21:59:00Z", "completed_at": "2026-07-31T21:59:01Z", "exit_code": 0, "conclusion": "success", "stdout": "ok\n", "stderr": "", "log_path": "completed.log", "log_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "log_byte_size": 3}],
+  "first_failed_validator": null,
+  "overall_conclusion": "partial",
+  "activation_effect": "indeterminate",
+  "authority": {"may_promote_publication": false, "may_assert_primary_source_completion": false, "may_change_chain_node_confidence": false},
+  "notes": "Partial fixture represents an incomplete planned validator set and cannot activate anything."
+}

--- a/validation_fixtures/validation-evidence/rerun.json
+++ b/validation_fixtures/validation-evidence/rerun.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0.0",
+  "receipt_type": "governed-validator-execution-evidence",
+  "manifest_id": "fixture-rerun",
+  "subject_id": "fixture",
+  "capture_started_at": "2026-07-31T21:59:00Z",
+  "capture_completed_at": "2026-07-31T21:59:01Z",
+  "execution_environment": {"run_id": "104", "run_attempt": "2", "head_commit": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
+  "validators": [{"name": "pass-after-rerun", "command": ["python", "-c", "print('ok')"], "required": true, "started_at": "2026-07-31T21:59:00Z", "completed_at": "2026-07-31T21:59:01Z", "exit_code": 0, "conclusion": "success", "stdout": "ok\n", "stderr": "", "log_path": "pass-after-rerun.log", "log_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "log_byte_size": 3}],
+  "first_failed_validator": null,
+  "overall_conclusion": "success",
+  "activation_effect": "validator-layer-passed",
+  "authority": {"may_promote_publication": false, "may_assert_primary_source_completion": false, "may_change_chain_node_confidence": false},
+  "notes": "Successful rerun fixture; run_attempt preserves succession without erasing earlier failure evidence."
+}

--- a/validation_fixtures/validation-evidence/success.json
+++ b/validation_fixtures/validation-evidence/success.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1.0.0",
+  "receipt_type": "governed-validator-execution-evidence",
+  "manifest_id": "fixture-success",
+  "subject_id": "fixture",
+  "capture_started_at": "2026-07-31T21:59:00Z",
+  "capture_completed_at": "2026-07-31T21:59:01Z",
+  "execution_environment": {"run_id": "100", "run_attempt": "1", "head_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+  "validators": [{"name": "pass", "command": ["python", "-c", "print('ok')"], "required": true, "started_at": "2026-07-31T21:59:00Z", "completed_at": "2026-07-31T21:59:01Z", "exit_code": 0, "conclusion": "success", "stdout": "ok\n", "stderr": "", "log_path": "pass.log", "log_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "log_byte_size": 3}],
+  "first_failed_validator": null,
+  "overall_conclusion": "success",
+  "activation_effect": "validator-layer-passed",
+  "authority": {"may_promote_publication": false, "may_assert_primary_source_completion": false, "may_change_chain_node_confidence": false},
+  "notes": "Positive fixture only."
+}

--- a/validation_manifests/repository-core.json
+++ b/validation_manifests/repository-core.json
@@ -1,0 +1,36 @@
+{
+  "manifest_version": "1.0.0",
+  "manifest_id": "ERL-REPOSITORY-CORE-VALIDATION",
+  "description": "Repository-wide governed validator set. Execution success does not promote factual or publication status.",
+  "validators": [
+    {
+      "id": "assessment_trees",
+      "command": ["python", "scripts/validate_assessment_trees.py"],
+      "required": true,
+      "working_directory": ".",
+      "timeout_seconds": 900,
+      "evidence_class": "repository-structure"
+    },
+    {
+      "id": "primary_record_intake",
+      "command": ["python", "scripts/validate_primary_record_intake.py"],
+      "required": true,
+      "working_directory": ".",
+      "timeout_seconds": 900,
+      "evidence_class": "intake-structure"
+    },
+    {
+      "id": "activation_validation",
+      "command": ["python", "scripts/run_activation_validation.py"],
+      "required": true,
+      "working_directory": ".",
+      "timeout_seconds": 1800,
+      "evidence_class": "combined-activation"
+    }
+  ],
+  "authority_boundary": {
+    "may_promote_publication": false,
+    "may_assert_source_completeness": false,
+    "may_change_factual_confidence": false
+  }
+}


### PR DESCRIPTION
## Scope

Implements Lane 2 from issue #49 on a fresh branch from current `main`.

### Added
- generic governed-validator-manifest schema;
- generic validation-execution-receipt schema;
- repository-core validator manifest;
- manifest-driven evidence capture engine;
- reusable `workflow_dispatch` / `workflow_call` evidence workflow.

### Preserved boundaries
- does not modify or replace the active Ellis–Scavino case-specific workflow;
- does not supersede the Ellis–Scavino pending receipt;
- does not promote publication, source completeness, or factual confidence;
- uploads evidence before enforcing receipt success.

### Remaining before review readiness
- receipt/manifest validator;
- positive, negative, partial, cancelled, and rerun fixtures;
- integration analysis for duplicate validator execution;
- native artifact review from Lane 1.

Coordinates with #49.