### PR TITLE
Validate durable task-state automation for ERL multi-angle investigation

### DIFF
--- a/task-state/README.md
+++ b/task-state/README.md
@@ -1,0 +1,7 @@
+# Durable task state
+
+Task-state registries assign every unresolved action to a named repository, issue, automation lane, or human-authority boundary. Registries must pass `scripts/validate_task_state_registry.py` and use only governed states.
+
+Current registry:
+
+- `ERL-2026-07-24-MULTIANGLE-001.json` — Issue #45 continuation state for the linked shooting, line-of-fire, and AI-minimization investigation.


### PR DESCRIPTION
Runs the newly installed task-state validator against `task-state/ERL-2026-07-24-MULTIANGLE-001.json` through the PR-triggered workflow. The only branch delta is a task-state README used to exercise the path filter and document the canonical registry.