### PR TITLE
Add directional DPOI evidence parameters to recurring discovery

### DIFF
--- a/config/recurring-searches.example.json
+++ b/config/recurring-searches.example.json
@@ -29,31 +29,67 @@
   "searches": [
     {
       "search_id": "captured-topic-refresh",
-      "query_template": "Refresh existing ledger topics for new official actions, corrections, litigation, oversight, and measurable outcomes.",
+      "query_template": "Refresh existing ledger topics for new official actions, corrections, litigation, oversight, measurable outcomes, and evidence that strengthens, weakens, or disambiguates unresolved DPOI state.",
       "discovery_class": "captured-topic-refresh",
       "priority": "critical",
-      "enabled": true
+      "enabled": true,
+      "dpoi_search_parameters": {
+        "evidence_directions": ["strengthen", "weaken", "disambiguate"],
+        "strengthen_terms": ["confirmed", "corroborated", "substantiated", "admitted", "verified", "consistent with"],
+        "weaken_terms": ["retracted", "dismissed", "contradicted", "unsubstantiated", "no evidence", "incorrect"],
+        "disambiguation_terms": ["timeline", "chronology", "authority", "jurisdiction", "scope", "definition", "records", "testimony", "metadata"],
+        "state_dimensions": ["current-evidence-state", "authority", "timeline", "identity", "causation", "scope"],
+        "no_result_effect": "no-update",
+        "candidate_only": true
+      }
     },
     {
       "search_id": "new-federal-enforcement-incidents",
-      "query_template": "Find newly reported federal enforcement incidents involving use of force, detention, constitutional claims, or changes to investigative responsibility.",
+      "query_template": "Find newly reported federal enforcement incidents involving use of force, detention, constitutional claims, changes to investigative responsibility, and evidence capable of strengthening, weakening, or clarifying related DPOIs.",
       "discovery_class": "new-incident",
       "priority": "high",
-      "enabled": true
+      "enabled": true,
+      "dpoi_search_parameters": {
+        "evidence_directions": ["strengthen", "weaken", "disambiguate"],
+        "strengthen_terms": ["confirmed", "charged", "filed", "documented", "body camera", "official record"],
+        "weaken_terms": ["cleared", "dismissed", "misidentified", "false report", "no violation", "not involved"],
+        "disambiguation_terms": ["incident report", "agency responsibility", "jurisdiction", "sequence", "timestamp", "identity", "chain of command"],
+        "state_dimensions": ["identity", "authority", "timeline", "jurisdiction", "conduct", "outcome"],
+        "no_result_effect": "no-update",
+        "candidate_only": true
+      }
     },
     {
       "search_id": "accountability-chain-contradictions",
-      "query_template": "Find contradictions between public statements, internal guidance, agency practice, court records, congressional oversight, and later policy implementation.",
+      "query_template": "Find evidence that confirms or contradicts public statements, internal guidance, agency practice, court records, congressional oversight, later implementation, and unresolved DPOI assumptions; prioritize records that disambiguate who knew, decided, directed, executed, or retained custody.",
       "discovery_class": "contradiction-discovery",
       "priority": "high",
-      "enabled": true
+      "enabled": true,
+      "dpoi_search_parameters": {
+        "evidence_directions": ["strengthen", "weaken", "disambiguate"],
+        "strengthen_terms": ["corroborated", "consistent", "confirmed", "matches", "authenticated", "under oath"],
+        "weaken_terms": ["contradiction", "inconsistent", "recanted", "corrected", "disputed", "unsupported"],
+        "disambiguation_terms": ["who authorized", "who directed", "who executed", "who knew", "custodian", "delegation", "email metadata", "records retention"],
+        "state_dimensions": ["authority", "knowledge", "execution", "records-custody", "channel-purpose", "timeline"],
+        "no_result_effect": "no-update",
+        "candidate_only": true
+      }
     },
     {
       "search_id": "historical-accountability-controls",
-      "query_template": "Find historical controls and precedents for comparable enforcement, civil-rights investigation, agency self-investigation, and executive intervention.",
+      "query_template": "Find historical controls and precedents for comparable enforcement, civil-rights investigation, agency self-investigation, executive intervention, and DPOI-relevant alternative explanations that can strengthen, weaken, or disambiguate the current interpretation.",
       "discovery_class": "control-discovery",
       "priority": "medium",
-      "enabled": true
+      "enabled": true,
+      "dpoi_search_parameters": {
+        "evidence_directions": ["strengthen", "weaken", "disambiguate"],
+        "strengthen_terms": ["precedent", "same pattern", "repeated", "consistent practice", "historical match"],
+        "weaken_terms": ["exception", "different authority", "different procedure", "noncomparable", "changed policy"],
+        "disambiguation_terms": ["historical control", "baseline", "standard practice", "policy in force", "authority at time", "comparison period"],
+        "state_dimensions": ["baseline", "alternative-explanation", "policy-context", "authority", "timeline", "comparability"],
+        "no_result_effect": "no-update",
+        "candidate_only": true
+      }
     }
   ],
   "review_boundary": {
@@ -61,5 +97,5 @@
     "automation_may_publish": false,
     "required_review_states": ["candidate-generated", "source-posture-reviewed", "ledger-review-required"]
   },
-  "notes": "Automation creates discovery candidates only. It may not convert reporting into established fact or promote candidates into reviewed ledger receipts."
+  "notes": "Automation creates discovery candidates only. Directional DPOI parameters identify potentially strengthening, weakening, or disambiguating evidence for review; they do not change a DPOI state automatically, and a zero-result search produces no evidentiary update."
 }

--- a/discovery_cycles/generated/ERL-RECURRING-DISCOVERY-BASELINE-001--20260720-060000.json
+++ b/discovery_cycles/generated/ERL-RECURRING-DISCOVERY-BASELINE-001--20260720-060000.json
@@ -31,27 +31,63 @@
   "queries": [
     {
       "query_id": "captured-topic-refresh",
-      "query_text": "Refresh existing ledger topics for new official actions, corrections, litigation, oversight, and measurable outcomes.",
+      "query_text": "Refresh existing ledger topics for new official actions, corrections, litigation, oversight, measurable outcomes, and evidence that strengthens, weakens, or disambiguates unresolved DPOI state.",
       "discovery_class": "captured-topic-refresh",
-      "status": "planned"
+      "status": "planned",
+      "dpoi_search_parameters": {
+        "evidence_directions": ["strengthen", "weaken", "disambiguate"],
+        "strengthen_terms": ["confirmed", "corroborated", "substantiated", "admitted", "verified", "consistent with"],
+        "weaken_terms": ["retracted", "dismissed", "contradicted", "unsubstantiated", "no evidence", "incorrect"],
+        "disambiguation_terms": ["timeline", "chronology", "authority", "jurisdiction", "scope", "definition", "records", "testimony", "metadata"],
+        "state_dimensions": ["current-evidence-state", "authority", "timeline", "identity", "causation", "scope"],
+        "no_result_effect": "no-update",
+        "candidate_only": true
+      }
     },
     {
       "query_id": "new-federal-enforcement-incidents",
-      "query_text": "Find newly reported federal enforcement incidents involving use of force, detention, constitutional claims, or changes to investigative responsibility.",
+      "query_text": "Find newly reported federal enforcement incidents involving use of force, detention, constitutional claims, changes to investigative responsibility, and evidence capable of strengthening, weakening, or clarifying related DPOIs.",
       "discovery_class": "new-incident",
-      "status": "planned"
+      "status": "planned",
+      "dpoi_search_parameters": {
+        "evidence_directions": ["strengthen", "weaken", "disambiguate"],
+        "strengthen_terms": ["confirmed", "charged", "filed", "documented", "body camera", "official record"],
+        "weaken_terms": ["cleared", "dismissed", "misidentified", "false report", "no violation", "not involved"],
+        "disambiguation_terms": ["incident report", "agency responsibility", "jurisdiction", "sequence", "timestamp", "identity", "chain of command"],
+        "state_dimensions": ["identity", "authority", "timeline", "jurisdiction", "conduct", "outcome"],
+        "no_result_effect": "no-update",
+        "candidate_only": true
+      }
     },
     {
       "query_id": "accountability-chain-contradictions",
-      "query_text": "Find contradictions between public statements, internal guidance, agency practice, court records, congressional oversight, and later policy implementation.",
+      "query_text": "Find evidence that confirms or contradicts public statements, internal guidance, agency practice, court records, congressional oversight, later implementation, and unresolved DPOI assumptions; prioritize records that disambiguate who knew, decided, directed, executed, or retained custody.",
       "discovery_class": "contradiction-discovery",
-      "status": "planned"
+      "status": "planned",
+      "dpoi_search_parameters": {
+        "evidence_directions": ["strengthen", "weaken", "disambiguate"],
+        "strengthen_terms": ["corroborated", "consistent", "confirmed", "matches", "authenticated", "under oath"],
+        "weaken_terms": ["contradiction", "inconsistent", "recanted", "corrected", "disputed", "unsupported"],
+        "disambiguation_terms": ["who authorized", "who directed", "who executed", "who knew", "custodian", "delegation", "email metadata", "records retention"],
+        "state_dimensions": ["authority", "knowledge", "execution", "records-custody", "channel-purpose", "timeline"],
+        "no_result_effect": "no-update",
+        "candidate_only": true
+      }
     },
     {
       "query_id": "historical-accountability-controls",
-      "query_text": "Find historical controls and precedents for comparable enforcement, civil-rights investigation, agency self-investigation, and executive intervention.",
+      "query_text": "Find historical controls and precedents for comparable enforcement, civil-rights investigation, agency self-investigation, executive intervention, and DPOI-relevant alternative explanations that can strengthen, weaken, or disambiguate the current interpretation.",
       "discovery_class": "control-discovery",
-      "status": "planned"
+      "status": "planned",
+      "dpoi_search_parameters": {
+        "evidence_directions": ["strengthen", "weaken", "disambiguate"],
+        "strengthen_terms": ["precedent", "same pattern", "repeated", "consistent practice", "historical match"],
+        "weaken_terms": ["exception", "different authority", "different procedure", "noncomparable", "changed policy"],
+        "disambiguation_terms": ["historical control", "baseline", "standard practice", "policy in force", "authority at time", "comparison period"],
+        "state_dimensions": ["baseline", "alternative-explanation", "policy-context", "authority", "timeline", "comparability"],
+        "no_result_effect": "no-update",
+        "candidate_only": true
+      }
     }
   ],
   "candidate_outputs": {
@@ -60,12 +96,13 @@
     "adjacency_links": [],
     "control_candidates": [],
     "contradictions": [],
-    "outcome_updates": []
+    "outcome_updates": [],
+    "dpoi_evidence_candidates": []
   },
   "review_boundary": {
     "automation_may_propose": true,
     "automation_may_publish": false,
     "required_review_states": ["candidate-generated", "source-posture-reviewed", "ledger-review-required"]
   },
-  "notes": "Generated from recurring-search configuration. Planned queries are candidates only and require governed review before publication or ledger promotion."
+  "notes": "Generated from recurring-search configuration. DPOI directional parameters can identify evidence candidates that may strengthen, weaken, or disambiguate a data point of interest, but automation may not change DPOI state or treat a zero-result search as disproof."
 }

--- a/docs/DPOI_DIRECTIONAL_DISCOVERY.md
+++ b/docs/DPOI_DIRECTIONAL_DISCOVERY.md
@@ -1,0 +1,31 @@
+# DPOI Directional Discovery
+
+ERL recurring discovery may use Data Points of Interest (DPOIs) to focus searches on evidence that could strengthen, weaken, or disambiguate the current evidence state.
+
+## Governing rule
+
+A discovery result is a candidate signal, not a finding. Automation may identify why a result is potentially relevant to a DPOI, but it may not change the DPOI's evidentiary state without governed review and source custody.
+
+A zero-result search has `no_result_effect: no-update`. Absence of a discovered result is not disproof unless a separate coverage-completeness contract establishes that the relevant source universe and time range were exhaustively observed.
+
+## Category search parameters
+
+Every enabled recurring search carries `dpoi_search_parameters`:
+
+- `evidence_directions`: which directions the search is intended to test: `strengthen`, `weaken`, `disambiguate`.
+- `strengthen_terms`: terms that may indicate corroboration, confirmation, admission, authentication, or another support-bearing record.
+- `weaken_terms`: terms that may indicate contradiction, correction, dismissal, retraction, non-involvement, or another countervailing record.
+- `disambiguation_terms`: terms targeting uncertainty in timeline, identity, authority, jurisdiction, scope, definition, records custody, channel purpose, or comparable state dimensions.
+- `state_dimensions`: the specific parts of the current DPOI state the search may clarify.
+- `no_result_effect`: fixed to `no-update`.
+- `candidate_only`: fixed to `true`.
+
+## Interpretation
+
+Directional term matches are search and routing aids. They do not determine truth value. A single candidate can carry more than one direction after review—for example, a record can weaken one causal explanation while strengthening a narrower authority-chain explanation.
+
+The recurring discovery-cycle manifest preserves these parameters with each planned query so downstream discovery, source capture, clustering, contradiction analysis, and review can explain why an item was collected and which unresolved state dimensions it could affect.
+
+## Source-family integration boundary
+
+Issue #51 / `ERL-OSINT-API-001` owns `config/source-families.json`, `schemas/source-family.schema.json`, `scripts/discover_source_family_links.py`, `scripts/validate_source_family_discovery.py`, and `.github/workflows/run-recurring-discovery.yml` through its active claim window. That lane must integrate the DPOI directional parameters into candidate receipts when it next changes those owned files, without adding promotion authority or treating zero-result coverage as negative evidence.

--- a/schemas/discovery-cycle.schema.json
+++ b/schemas/discovery-cycle.schema.json
@@ -40,7 +40,7 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["query_id", "query_text", "discovery_class", "status", "dpoi_search_parameters"],
+        "required": ["query_id", "query_text", "discovery_class", "status"],
         "properties": {
           "query_id": {"type": "string", "minLength": 1},
           "query_text": {"type": "string", "minLength": 1},

--- a/schemas/discovery-cycle.schema.json
+++ b/schemas/discovery-cycle.schema.json
@@ -4,23 +4,10 @@
   "title": "Political Reality Discovery Cycle",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "cycle_id",
-    "cycle_status",
-    "started_at",
-    "scope",
-    "discovery_classes",
-    "source_classes",
-    "queries",
-    "candidate_outputs",
-    "review_boundary"
-  ],
+  "required": ["cycle_id", "cycle_status", "started_at", "scope", "discovery_classes", "source_classes", "queries", "candidate_outputs", "review_boundary"],
   "properties": {
     "cycle_id": {"type": "string", "minLength": 1},
-    "cycle_status": {
-      "type": "string",
-      "enum": ["planned", "running", "completed", "blocked", "superseded"]
-    },
+    "cycle_status": {"type": "string", "enum": ["planned", "running", "completed", "blocked", "superseded"]},
     "started_at": {"type": "string", "minLength": 1},
     "completed_at": {"type": "string"},
     "scope": {
@@ -39,41 +26,13 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "enum": [
-          "captured-topic-refresh",
-          "adjacent-incident",
-          "new-incident",
-          "historical-backfill",
-          "control-discovery",
-          "contradiction-discovery",
-          "outcome-refresh"
-        ]
-      }
+      "items": {"type": "string", "enum": ["captured-topic-refresh", "adjacent-incident", "new-incident", "historical-backfill", "control-discovery", "contradiction-discovery", "outcome-refresh"]}
     },
     "source_classes": {
       "type": "array",
       "minItems": 2,
       "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "enum": [
-          "primary-legal-record",
-          "official-government",
-          "court-record",
-          "legislative-oversight",
-          "original-media",
-          "local-reporting",
-          "national-reporting",
-          "international-reporting",
-          "partisan-or-ideological-reporting",
-          "advocacy-record",
-          "academic-or-expert",
-          "affected-person-or-witness",
-          "historical-archive"
-        ]
-      }
+      "items": {"type": "string", "enum": ["primary-legal-record", "official-government", "court-record", "legislative-oversight", "original-media", "local-reporting", "national-reporting", "international-reporting", "partisan-or-ideological-reporting", "advocacy-record", "academic-or-expert", "affected-person-or-witness", "historical-archive"]}
     },
     "queries": {
       "type": "array",
@@ -81,13 +40,27 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["query_id", "query_text", "discovery_class", "status"],
+        "required": ["query_id", "query_text", "discovery_class", "status", "dpoi_search_parameters"],
         "properties": {
           "query_id": {"type": "string", "minLength": 1},
           "query_text": {"type": "string", "minLength": 1},
           "discovery_class": {"type": "string"},
           "status": {"type": "string", "enum": ["planned", "executed", "failed", "superseded"]},
-          "result_count": {"type": "integer", "minimum": 0}
+          "result_count": {"type": "integer", "minimum": 0},
+          "dpoi_search_parameters": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["evidence_directions", "strengthen_terms", "weaken_terms", "disambiguation_terms", "state_dimensions", "no_result_effect", "candidate_only"],
+            "properties": {
+              "evidence_directions": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "enum": ["strengthen", "weaken", "disambiguate"]}},
+              "strengthen_terms": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 2}},
+              "weaken_terms": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 2}},
+              "disambiguation_terms": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 2}},
+              "state_dimensions": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 2}},
+              "no_result_effect": {"const": "no-update"},
+              "candidate_only": {"const": true}
+            }
+          }
         }
       }
     },
@@ -101,7 +74,8 @@
         "adjacency_links": {"type": "array", "items": {"type": "string"}},
         "control_candidates": {"type": "array", "items": {"type": "string"}},
         "contradictions": {"type": "array", "items": {"type": "string"}},
-        "outcome_updates": {"type": "array", "items": {"type": "string"}}
+        "outcome_updates": {"type": "array", "items": {"type": "string"}},
+        "dpoi_evidence_candidates": {"type": "array", "items": {"type": "string"}}
       }
     },
     "review_boundary": {
@@ -111,11 +85,7 @@
       "properties": {
         "automation_may_propose": {"type": "boolean", "const": true},
         "automation_may_publish": {"type": "boolean", "const": false},
-        "required_review_states": {
-          "type": "array",
-          "minItems": 1,
-          "items": {"type": "string", "minLength": 1}
-        }
+        "required_review_states": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
       }
     },
     "supersedes_cycle_id": {"type": "string"},

--- a/schemas/recurring-search-config.schema.json
+++ b/schemas/recurring-search-config.schema.json
@@ -50,7 +50,7 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["search_id", "query_template", "discovery_class", "priority"],
+        "required": ["search_id", "query_template", "discovery_class", "priority", "dpoi_search_parameters"],
         "properties": {
           "search_id": {"type": "string", "minLength": 1},
           "query_template": {"type": "string", "minLength": 1},
@@ -59,7 +59,26 @@
             "enum": ["captured-topic-refresh", "adjacent-incident", "new-incident", "historical-backfill", "control-discovery", "contradiction-discovery", "outcome-refresh"]
           },
           "priority": {"type": "string", "enum": ["critical", "high", "medium", "low"]},
-          "enabled": {"type": "boolean", "default": true}
+          "enabled": {"type": "boolean", "default": true},
+          "dpoi_search_parameters": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["evidence_directions", "strengthen_terms", "weaken_terms", "disambiguation_terms", "state_dimensions", "no_result_effect", "candidate_only"],
+            "properties": {
+              "evidence_directions": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {"type": "string", "enum": ["strengthen", "weaken", "disambiguate"]}
+              },
+              "strengthen_terms": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 2}},
+              "weaken_terms": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 2}},
+              "disambiguation_terms": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 2}},
+              "state_dimensions": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 2}},
+              "no_result_effect": {"const": "no-update"},
+              "candidate_only": {"const": true}
+            }
+          }
         }
       }
     },

--- a/scripts/generate_discovery_cycle.py
+++ b/scripts/generate_discovery_cycle.py
@@ -38,6 +38,7 @@ def build_cycle(config: dict, started_at: str) -> dict:
             "query_text": item["query_template"],
             "discovery_class": item["discovery_class"],
             "status": "planned",
+            "dpoi_search_parameters": item["dpoi_search_parameters"],
         }
         for item in enabled_searches
     ]
@@ -57,9 +58,10 @@ def build_cycle(config: dict, started_at: str) -> dict:
             "control_candidates": [],
             "contradictions": [],
             "outcome_updates": [],
+            "dpoi_evidence_candidates": [],
         },
         "review_boundary": config["review_boundary"],
-        "notes": "Generated from recurring-search configuration. Planned queries are candidates only and require governed review before publication or ledger promotion.",
+        "notes": "Generated from recurring-search configuration. DPOI directional parameters can identify evidence candidates that may strengthen, weaken, or disambiguate a data point of interest, but automation may not change DPOI state or treat a zero-result search as disproof.",
     }
 
 


### PR DESCRIPTION
Adds governed DPOI category-search parameters so recurring discovery explicitly looks for evidence that may strengthen, weaken, or disambiguate a Data Point of Interest while preserving candidate-only authority.

Key boundaries:
- directional matches do not change DPOI state automatically;
- zero-result searches have `no-update` evidentiary effect absent independent coverage-completeness proof;
- historical discovery-cycle receipts remain schema-compatible;
- Issue #51 retains ownership of source-family crawler files and has a durable integration requirement for machine-readable directional candidate receipts.

Merged to `main` as `5a513639798dc55b8166f0489c325b117d4bf5fa`. Main validation run `31188450324` passed all 40 stages. Continuation and crawler-side DPOI receipt enrichment are recorded in `docs/OSINT_SESSION_CONSOLIDATION_MIRROR_HANDOFF.md`, `coordination/osint-session-tasks.json`, `coordination/dpoi-directional-session-receipt.json`, and Issue #51.