### PR TITLE
Close linguistic provenance propagation review

### DIFF
--- a/ERL_MIRROR_HANDOFF.md
+++ b/ERL_MIRROR_HANDOFF.md
@@ -329,7 +329,7 @@ Canonical continuation: `StegVerse-Labs/Executive_Rhetoric_Ledger` → Issue `#4
 Session state: `MERGED INTO CANONICAL WORKSTREAM`.
 
 
-## Adjacent active execution lane — linguistic enregisterment / AI provenance — ACTIVE
+## Adjacent completed execution lane — linguistic enregisterment / AI provenance — COMPLETE
 
 Goal ID: `ERL-2026-08-27-LINGUISTIC-PROVENANCE`
 
@@ -349,16 +349,23 @@ Installed on PR #82:
 - dedicated hosted CI workflow.
 
 Current state:
-- lifecycle: ACTIVE
-- source implementation: 6 durable files installed
-- hosted validation: PASS — linguistic provenance run 33144746223; repository-wide schema run 33144746184; research-candidate activation run 33144746162
-- merge: READY_AFTER_FINAL_SYNC
-- release/propagation: NOT_AUTHORIZED
+- lifecycle: COMPLETE
+- source implementation: merged at `324341c80527204537f4f384a9d6e74f20730887`
+- hosted validation: PASS — final pre-merge runs `33144796017`, `33144796026`, `33144795994`
+- merge: MERGED
+- downstream review: COMPLETE
+- release/propagation: NOT_AUTHORIZED / NO PROPAGATION REQUIRED
 
 Release gate: an AI/human/mixed authorship finding may not be `supported` unless independent or strong provenance evidence exists. Stylistic association and enregisterment evidence can support perceived-register analysis only.
 
-Next executable boundary: obtain hosted CI result, repair any failure, merge only when validator and repository-wide schema checks are green, then reassess propagation to Site, Publisher, admissibility-wiki, and stegguardian-wiki.
+Downstream review result: `NO_DOWNSTREAM_PROPAGATION_AUTHORIZED`. The reviewed compendium does not contain this lane; Site and Publisher retain destination-owned reviewed-compendium sync contracts; admissibility-wiki retains reviewed-compendium acknowledgment only; stegguardian-wiki has no ERL linguistic-provenance import authority. Durable review: `assessments/linguistic-provenance/downstream-propagation-review.json`.
+
+No raw research-candidate or source-only governance artifact was copied downstream. This bounded goal is complete; any future publication requires a separately reviewed ERL publication object and destination-owned ingestion.
 
 
 ### 2026-08-28 execution reconciliation
 PR #82 also repaired two repository-wide validation blockers discovered by hosted CI without changing substantive findings: the White House ballroom intake artifact was explicitly classified as a non-primary evidence-reconstruction task registry (Issue #73 receipt comment 5448792701), and six unregistered research-candidate files were admitted to the activation registry under existing umbrella Issue #63 (receipt comment 5448800876). All three relevant hosted validations are green at commit `20a223496bd56aeaf7a95ba386c0b3c809053691`.
+
+
+### 2026-08-28 linguistic-provenance closeout
+Issue #81 goal tasks LP-001 through LP-008 are complete after merge and downstream authority review. The correct downstream disposition is fail-closed/no-copy rather than forced propagation. Source goal activation: 100%. Downstream publication/release authority remains false. Scoped authority: `assessments/linguistic-provenance/LINGUISTIC_PROVENANCE_MIRROR_HANDOFF.md`.

--- a/assessments/linguistic-provenance/LINGUISTIC_PROVENANCE_MIRROR_HANDOFF.md
+++ b/assessments/linguistic-provenance/LINGUISTIC_PROVENANCE_MIRROR_HANDOFF.md
@@ -10,15 +10,16 @@ Prevent stylistic or socially recognized "AI voice" signals from being promoted 
 `observed_feature != socially_enregistered_signal != provenance_evidence != authorship_finding`.
 
 ## Status
-- lifecycle: ACTIVE
+- lifecycle: COMPLETE
 - implementation: SOURCE_COMPLETE
 - validation: HOSTED_PASS
-- merge: READY_AFTER_FINAL_SYNC
-- release/publication: NOT_AUTHORIZED
+- merge: MERGED
+- release/publication: NOT_AUTHORIZED / NO_DOWNSTREAM_PROPAGATION_REQUIRED
 
 ## Canonical owner
 - Issue: #81
-- Branch: `feature/linguistic-enregisterment-provenance`
+- Merged source branch: `feature/linguistic-enregisterment-provenance`
+- Merge commit: `324341c80527204537f4f384a9d6e74f20730887`
 - Scope: `assessments/linguistic-provenance/**`, `schemas/linguistic-provenance-assessment.schema.json`, `scripts/validate_linguistic_provenance_assessments.py`
 
 ## Required machine behavior
@@ -39,8 +40,8 @@ LinkedIn discussion supplied by the user on 2026-08-27 describing enregisterment
 - LP-004: add fail-closed CI workflow
 - LP-005: update root ERL handoff with bounded-lane pointer and status
 - LP-006: run hosted validation and preserve receipts
-- LP-007: merge only after green validation
-- LP-008: evaluate propagation to Site, Publisher, admissibility-wiki, stegguardian-wiki only after merge/review
+- LP-007: merge only after green validation — COMPLETE
+- LP-008: evaluate propagation to Site, Publisher, admissibility-wiki, stegguardian-wiki only after merge/review — COMPLETE / NO PROPAGATION AUTHORIZED
 
 ## Release gate
 No release or propagation until validator-clean fixtures prove:
@@ -71,3 +72,28 @@ This scoped handoff is the durable continuation source for this lane.
 Source implementation: 6/6 core lane artifacts = 100%.
 Hosted validation: 3/3 relevant runs green = 100%.
 Goal activation before merge: 7/8 task groups = 87.5%.
+
+
+## Downstream propagation review — 2026-08-28
+Durable review: `assessments/linguistic-provenance/downstream-propagation-review.json`.
+
+Result: `NO_DOWNSTREAM_PROPAGATION_AUTHORIZED`.
+
+Reasons:
+- Site currently rejects externally owned new workloads through its orchestration state and already has a destination-owned ERL sync limited to the reviewed compendium.
+- Publisher already imports only `publication/compendium.json` through its destination-owned sync contract.
+- admissibility-wiki already acknowledges only the reviewed compendium and explicitly separates publication from proof/admissibility authority.
+- stegguardian-wiki has no current ERL linguistic-provenance import authority; its canonical handoff owns unrelated bounded Guardian projection work.
+- the current reviewed ERL `publication/compendium.json` does not contain this linguistic-provenance lane.
+
+No raw research-candidate or source-only governance artifact was copied downstream. That is the correct fail-closed result, not an incomplete propagation step.
+
+## Final completion accounting
+- LP-001 through LP-008: 8/8 complete
+- core source artifacts: 7 durable lane artifacts including downstream review
+- hosted validation: green before merge; closeout validator extended to enforce the downstream decision
+- scaffolding/stubs: 0
+- source goal activation: 100%
+- downstream publication/release authority: false
+
+The bounded goal is complete. Future downstream publication requires a separately reviewed ERL publication artifact and destination-owned ingestion; this closed lane does not grant that authority.

--- a/assessments/linguistic-provenance/downstream-propagation-review.json
+++ b/assessments/linguistic-provenance/downstream-propagation-review.json
@@ -1,0 +1,62 @@
+{
+  "schema": "stegverse.erl.linguistic_provenance_downstream_review.v1",
+  "goal_id": "ERL-2026-08-27-LINGUISTIC-PROVENANCE",
+  "source_merge_commit": "324341c80527204537f4f384a9d6e74f20730887",
+  "reviewed_publication_path": "publication/compendium.json",
+  "reviewed_publication_contains_linguistic_provenance_lane": false,
+  "raw_research_candidate_propagation_authorized": false,
+  "disposition": "NO_DOWNSTREAM_PROPAGATION_AUTHORIZED",
+  "rationale": "The merged lane is a source-repository governance capability and research-candidate boundary. Existing downstream ERL sync contracts ingest only the reviewed compendium. The current reviewed compendium does not contain this lane, and no destination handoff grants authority to bypass that publication gate.",
+  "destinations": [
+    {
+      "repository": "StegVerse-Labs/Site",
+      "canonical_handoff": "docs/SITE_MIRROR_HANDOFF.md",
+      "handoff_blob_sha": "4c639f6efc527f9e22076b7a2b9bc36e90092cf0",
+      "orchestration_state": "data/site-orchestration-state.json",
+      "orchestration_blob_sha": "6f5dc028573c556ddcbbd9a82adb636cfdd5d2e6",
+      "existing_erl_sync": ".github/workflows/sync-executive-rhetoric-ledger.yml",
+      "existing_erl_sync_blob_sha": "80c1bff3615bfef02f6a304ac2a127ffd5c581ec",
+      "existing_acknowledgment": "receipts/executive-rhetoric-ledger-ack.json",
+      "existing_acknowledgment_blob_sha": "54914744d4d52dc545157f7fb771738f75a7eafc",
+      "state": "NOT_ADMITTED_FOR_EXTERNAL_MUTATION",
+      "authorized": false,
+      "reason": "Site orchestration currently declares external_tasks_allowed=false and its ERL sync is destination-owned and reviewed-compendium-only."
+    },
+    {
+      "repository": "GCAT-BCAT-Engine/Publisher",
+      "canonical_handoff": "PUBLISHER_MIRROR_HANDOFF.md",
+      "handoff_blob_sha": "b42fa1962fee508a34d61e8292be9efce2382b43",
+      "existing_erl_sync": ".github/workflows/sync-executive-rhetoric-ledger.yml",
+      "existing_erl_sync_blob_sha": "21ec4cfc4757370210f50621ec401c11d11f0be1",
+      "existing_acknowledgment": "receipts/executive-rhetoric-ledger-ack.json",
+      "existing_acknowledgment_blob_sha": "3ddb9a0b07e28f04ef5a0b8023c58350c27217b3",
+      "state": "REVIEWED_COMPENDIUM_GATE_RETAINED",
+      "authorized": false,
+      "reason": "Publisher already has destination-owned ERL synchronization limited to publication/compendium.json; this lane is not in that reviewed publication."
+    },
+    {
+      "repository": "StegVerse-Labs/admissibility-wiki",
+      "canonical_handoff": "ADMISSIBILITY_WIKI_MIRROR_HANDOFF.md",
+      "handoff_blob_sha": "f5dac73c103b4bcdb28aca756e18970d1a246c5b",
+      "existing_acknowledgment": "receipts/executive-rhetoric-ledger-ack.json",
+      "existing_acknowledgment_blob_sha": "4817be35083824130e9d04f611cb530192e8c764",
+      "state": "REVIEWED_COMPENDIUM_GATE_RETAINED",
+      "authorized": false,
+      "reason": "Admissibility already acknowledges the reviewed ERL compendium. Publication availability is not proof or admissibility authority, and no reviewed publication currently carries this lane."
+    },
+    {
+      "repository": "StegVerse-002/stegguardian-wiki",
+      "canonical_handoff": "STEGGUARDIAN_MIRROR_HANDOFF.md",
+      "handoff_blob_sha": "fd1cecdf1419f888a092697d2603a4e37cebfe1d",
+      "state": "NO_ERL_PROPAGATION_CONTRACT_AUTHORIZED",
+      "authorized": false,
+      "reason": "The current Guardian handoff owns unrelated generated-Ste gPay projection work and grants no ERL linguistic-provenance import or enforcement authority."
+    }
+  ],
+  "completion": {
+    "lp_008_review_complete": true,
+    "propagation_performed": false,
+    "propagation_required_for_goal_completion": false,
+    "source_goal_complete_after_record_merge": true
+  }
+}

--- a/scripts/validate_linguistic_provenance_assessments.py
+++ b/scripts/validate_linguistic_provenance_assessments.py
@@ -37,8 +37,25 @@ def main():
     expected="supported_authorship_requires_independent_or_strong_provenance"
     if expected not in ne:
         print("negative fixture failed for wrong reason:",ne); return 1
+    review_path=ROOT/"assessments"/"linguistic-provenance"/"downstream-propagation-review.json"
+    review=json.loads(review_path.read_text())
+    if review.get("disposition")!="NO_DOWNSTREAM_PROPAGATION_AUTHORIZED":
+        print("downstream review disposition invalid"); return 1
+    if review.get("raw_research_candidate_propagation_authorized") is not False:
+        print("raw research-candidate propagation must remain false"); return 1
+    destinations=review.get("destinations",[])
+    if len(destinations)!=4:
+        print("downstream review must cover four destinations"); return 1
+    if any(d.get("authorized") is not False for d in destinations):
+        print("destination propagation unexpectedly authorized"); return 1
+    completion=review.get("completion",{})
+    if completion.get("lp_008_review_complete") is not True:
+        print("LP-008 review not complete"); return 1
+    if completion.get("propagation_performed") is not False:
+        print("LP-008 review must not claim propagation performed"); return 1
     print("PASS linguistic provenance governance")
     print("negative rejection:", expected)
+    print("downstream disposition: NO_DOWNSTREAM_PROPAGATION_AUTHORIZED")
     return 0
 
 if __name__=="__main__":


### PR DESCRIPTION
Completes LP-008 after PR #82 merge. Adds a durable four-destination propagation review, extends the validator to enforce the fail-closed no-propagation disposition, and updates scoped/root handoffs to COMPLETE. No downstream repository is mutated because existing authority contracts admit only reviewed compendium content and this lane is not in the reviewed compendium.