### PR TITLE
Add historical and current cyber-sabotage research lane

### DIFF
--- a/ERL_MIRROR_HANDOFF.md
+++ b/ERL_MIRROR_HANDOFF.md
@@ -294,6 +294,22 @@ Completion requires a reviewer-reproducible project-by-project and funding-sourc
 
 No Site, Publisher, admissibility-wiki, stegguardian-wiki, or master-records propagation is authorized for this finding until the project-level allocation is reconstructed and reviewed.
 
+## Adjacent network and cyber-physical sabotage lineage — 2026-09-02
+
+- candidate: `research-candidates/2026-network-cyberphysical-sabotage-lineage.md`
+- record ID: `ERL-CYBER-SABOTAGE-LINEAGE-001`
+- acquisition queue: `config/network-cyberphysical-sabotage-source-queue.v1.json`
+- activation registry group: `ERL-RC-CYBER-SABOTAGE-LINEAGE-2026`
+- durable coordination owner: Issue `#63`
+- status: `research_candidate` / `RESEARCH_ACTIVE_NOT_ASSESSABLE`
+- installed scope: historical and continuing current-attack reconstruction across espionage, disruption, sabotage, cyber-physical sabotage, accidental spillover, coercion, internal/external boundary crossing, telemetry deception, physical effect, and proposition-relative attribution
+- initial historical seeds: disputed 1982 Soviet pipeline account; 1986 Hanover Hacker control; 1988 Morris worm; 2000 Maroochy Shire; 2003 Davis-Besse; 2007 Estonia; 2007–2010 Stuxnet
+- current source posture: official CISA advisory indexes are discovery inputs only; incident classification and attribution require incident-specific custody and independent review
+- finding, attribution, prevention-effectiveness, and publication authority: false
+- next executable task: acquire/hash seed sources and build proposition-level incident packets before comparison or publication
+
+This adjacent lane does not modify the Fauci/HSGAC active-goal denominator or authorize Site, Publisher, admissibility-wiki, or stegguardian-wiki propagation.
+
 ## Automation
 
 - `validate-silence-causation.yml`: active fail-closed case validation

--- a/config/network-cyberphysical-sabotage-source-queue.v1.json
+++ b/config/network-cyberphysical-sabotage-source-queue.v1.json
@@ -1,0 +1,93 @@
+{
+  "queue_version": "stegverse.erl.network-cyberphysical-sabotage-source-queue/v1",
+  "goal_id": "ERL-CYBER-SABOTAGE-LINEAGE-001",
+  "created_at": "2026-09-02T00:00:00Z",
+  "credential_authority": "TV/TVC",
+  "credential_requirement": "NONE",
+  "github_token_runtime_authority": "NONE",
+  "network_policy": "PUBLIC_HTTPS_ONLY_NO_AUTH",
+  "finding_authority": "NONE",
+  "items": [
+    {
+      "source_id": "ERL-CYBER-WEB-HISTORY-CERN",
+      "evidence_class": "official-historical-record",
+      "url": "https://web30.web.cern.ch/web-history.html",
+      "allowed_hosts": ["web30.web.cern.ch", "home.cern"],
+      "destination": "assessments/network-sabotage/evidence/official-records/ERL-CYBER-WEB-HISTORY-CERN.native",
+      "state": "READY",
+      "purpose": "Bound the invention and public availability of the World Wide Web separately from pre-Web Internet incidents"
+    },
+    {
+      "source_id": "ERL-CYBER-CUCKOOS-EGG-LBNL",
+      "evidence_class": "institutional-historical-record",
+      "url": "https://csafellows.lbl.gov/movies-with-a-connection-to-lbnl",
+      "allowed_hosts": ["csafellows.lbl.gov", "lbl.gov"],
+      "destination": "assessments/network-sabotage/evidence/official-records/ERL-CYBER-CUCKOOS-EGG-LBNL.native",
+      "state": "READY",
+      "purpose": "Seed the 1986 cross-border network-espionage control case without classifying it as sabotage"
+    },
+    {
+      "source_id": "ERL-CYBER-MORRIS-GAO-06-672",
+      "evidence_class": "official-government-report",
+      "url": "https://www.gao.gov/assets/gao-06-672.pdf",
+      "allowed_hosts": ["www.gao.gov", "gao.gov"],
+      "destination": "assessments/network-sabotage/evidence/official-records/ERL-CYBER-MORRIS-GAO-06-672.native.pdf",
+      "state": "READY",
+      "purpose": "Establish the documented scale and disruption class of the 1988 Morris worm"
+    },
+    {
+      "source_id": "ERL-CYBER-ICS-HISTORY-NIST-SP800-82R1",
+      "evidence_class": "official-technical-guidance",
+      "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r1.pdf",
+      "allowed_hosts": ["nvlpubs.nist.gov", "nist.gov"],
+      "destination": "assessments/network-sabotage/evidence/official-records/ERL-CYBER-ICS-HISTORY-NIST-SP800-82R1.native.pdf",
+      "state": "READY",
+      "purpose": "Seed authoritative reconstruction of Maroochy Shire and pre-Stuxnet industrial-control incidents"
+    },
+    {
+      "source_id": "ERL-CYBER-ICS-CURRENT-NIST-SP800-82R3",
+      "evidence_class": "official-technical-guidance",
+      "url": "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-82r3.pdf",
+      "allowed_hosts": ["nvlpubs.nist.gov", "nist.gov"],
+      "destination": "assessments/network-sabotage/evidence/official-records/ERL-CYBER-ICS-CURRENT-NIST-SP800-82R3.native.pdf",
+      "state": "READY",
+      "purpose": "Provide the current operational-technology security vocabulary and control context"
+    },
+    {
+      "source_id": "ERL-CYBER-ESTONIA-NATO",
+      "evidence_class": "official-intergovernmental-record",
+      "url": "https://www.nato.int/en/what-we-do/deterrence-and-defence/cyber-defence",
+      "allowed_hosts": ["www.nato.int", "nato.int"],
+      "destination": "assessments/network-sabotage/evidence/official-records/ERL-CYBER-ESTONIA-NATO.native",
+      "state": "READY",
+      "purpose": "Seed the 2007 Estonia disruption chronology and NATO response while preserving attribution limits"
+    },
+    {
+      "source_id": "ERL-CYBER-STUXNET-2007-REUTERS",
+      "evidence_class": "authoritative-secondary-reporting",
+      "url": "https://www.reuters.com/article/technology/researchers-say-stuxnet-was-deployed-against-iran-in-2007-idUSBRE91P0PP/",
+      "allowed_hosts": ["www.reuters.com", "reuters.com"],
+      "destination": "assessments/network-sabotage/evidence/contemporaneous-reporting/ERL-CYBER-STUXNET-2007-REUTERS.native",
+      "state": "READY",
+      "purpose": "Locate the Symantec Stuxnet 0.5 evidence and bound earliest-known deployment claims"
+    },
+    {
+      "source_id": "ERL-CYBER-CISA-ICS-ADVISORIES",
+      "evidence_class": "official-current-advisory-index",
+      "url": "https://www.cisa.gov/news-events/ics-advisories",
+      "allowed_hosts": ["www.cisa.gov", "cisa.gov"],
+      "destination": "assessments/network-sabotage/evidence/current-advisories/ERL-CYBER-CISA-ICS-ADVISORIES.native",
+      "state": "READY",
+      "purpose": "Discover current industrial-control vulnerabilities and incident leads without converting advisories into incident findings"
+    },
+    {
+      "source_id": "ERL-CYBER-CISA-CYBER-ADVISORIES",
+      "evidence_class": "official-current-advisory-index",
+      "url": "https://www.cisa.gov/news-events/cybersecurity-advisories",
+      "allowed_hosts": ["www.cisa.gov", "cisa.gov"],
+      "destination": "assessments/network-sabotage/evidence/current-advisories/ERL-CYBER-CISA-CYBER-ADVISORIES.native",
+      "state": "READY",
+      "purpose": "Discover current state and non-state destructive-operation leads with later incident-specific source acquisition required"
+    }
+  ]
+}

--- a/coordination/research-candidate-activation-registry.v1.json
+++ b/coordination/research-candidate-activation-registry.v1.json
@@ -371,6 +371,23 @@
       "terminal_condition": "Primary-source custody, longitudinal child-health analysis, regulatory-boundary reconstruction, political/commercial benefit chronology, counterfactual testing, and independent review support an explicit governed terminal transition.",
       "candidate_layer_finding_authorized": false,
       "candidate_layer_publication_authorized": false
+    },
+    {
+      "group_id": "ERL-RC-CYBER-SABOTAGE-LINEAGE-2026",
+      "title": "Historical and current network and cyber-physical sabotage lineage",
+      "candidate_paths": [
+        "research-candidates/2026-network-cyberphysical-sabotage-lineage.md"
+      ],
+      "active": true,
+      "state": "RESEARCH_ACTIVE_NOT_ASSESSABLE",
+      "durable_owner": "issue:63",
+      "artifact_paths": [
+        "config/network-cyberphysical-sabotage-source-queue.v1.json"
+      ],
+      "next_executable_task": "Acquire and hash the seed sources, create proposition-level incident packets, and normalize external entry, internal execution, commanded state, observed state, physical effects, and attribution ceilings.",
+      "terminal_condition": "Historical seeds and continuing current-attack intake are independently reconstructed and reviewed, or the candidate receives an explicit governed supersession, merge, or closure decision.",
+      "candidate_layer_finding_authorized": false,
+      "candidate_layer_publication_authorized": false
     }
   ]
 }

--- a/research-candidates/2026-network-cyberphysical-sabotage-lineage.md
+++ b/research-candidates/2026-network-cyberphysical-sabotage-lineage.md
@@ -1,0 +1,159 @@
+# Network and Cyber-Physical Sabotage Lineage — Research Candidate
+
+```yaml
+record_id: "ERL-CYBER-SABOTAGE-LINEAGE-001"
+status: "research_candidate"
+date_opened: "2026-09-02"
+historical_reconstruction_complete: false
+current_attack_monitor_active: false
+state_attribution_finding_authorized: false
+causal_finding_authorized: false
+publication_authorized: false
+```
+
+## Research purpose
+
+Build a source-custodied, continuously reviewable history of network and cyber-physical sabotage from early computer-network incidents through current attacks. The workstream must distinguish external network entry from internal execution, espionage from sabotage, intended damage from accidental propagation, and public attribution from independently established state responsibility.
+
+This candidate preserves an initial research structure and source-acquisition queue. It is not a completed incident catalogue or a finding that any named government conducted an operation.
+
+## Governing distinctions
+
+The research must keep the following event classes separate:
+
+- `espionage`: unauthorized collection or access whose established objective is information acquisition;
+- `disruption`: loss or degradation of availability without established destructive intent;
+- `sabotage`: intentional impairment, destruction, or manipulation of a system or dependent process;
+- `cyber_physical_sabotage`: sabotage in which digital action changes or damages a physical process or object;
+- `accidental_spillover`: harmful propagation or effect beyond the intended target or without an established sabotage objective;
+- `influence_or_coercion`: digital disruption used to create political, military, economic, or public-pressure effects;
+- `unresolved`: the available evidence does not yet discriminate among the preceding classes.
+
+`Internal` and `external` describe where a transition occurs, not who is trustworthy. A single operation may begin through an external supplier or public network, enter a private or air-gapped environment, propagate internally, and terminate in a physical controller.
+
+## Seed chronology requiring source reconstruction
+
+| Period | Incident | Initial candidate class | Evidentiary boundary |
+|---|---|---|---|
+| 1982 | Alleged CIA-compromised Soviet pipeline-control software | disputed supply-chain cyber-physical sabotage | The software-sabotage and explosion account is contested and must not be presented as established without corroborating primary records. |
+| 1986–1987 | Hanover Hacker / Cuckoo's Egg intrusions | espionage control case | Establishes early cross-border network espionage; it is not itself an industrial-sabotage event. KGB direction, payment, and formal relationship require claim-specific sourcing. |
+| 1988 | Morris worm | accidental or recklessly propagated network disruption | Widespread Internet impairment does not by itself establish an intent to sabotage physical systems. |
+| 2000 | Maroochy Shire sewage-control incident | insider-enabled cyber-physical sabotage | Confirm the actor, access path, command mechanism, environmental release, and judicial record independently. |
+| 2003 | Davis-Besse SQL Slammer intrusion | accidental external-to-internal spillover | Private-network and safety-monitor disruption are relevant even though targeted destructive intent and physical damage were not established. |
+| 2007 | Estonia distributed denial-of-service attacks | national-scale external disruption/coercion candidate | Preserve effects and government responses separately from individual, proxy, and state-attribution claims. |
+| 2007–2010 | Stuxnet / Operation Olympic Games | targeted cyber-physical sabotage candidate | Separate earliest recovered code, alleged delivery, Natanz execution, physical effects, telemetry deception, spillover, and U.S./Israeli attribution. Official acknowledgment remains distinct from journalistic or technical attribution. |
+| Current | Newly reported state and non-state operations | rolling intake only | No current incident enters the chronology as sabotage or state-attributed merely because an alert, vendor, government, or media source uses that label. |
+
+The chronology is deliberately non-exhaustive. Each seed is a research target, not a promoted ERL finding.
+
+## Required incident model
+
+Every incident record should preserve, when available:
+
+1. event time, discovery time, disclosure time, and attribution time;
+2. initiating actor, operator, sponsor, beneficiary, and alleged state relationship as separate fields;
+3. external entry path, trust-boundary crossings, internal propagation, and terminal execution point;
+4. exploited identity, credential, supplier, software, protocol, removable-media, or physical-access path;
+5. human-directed versus autonomous actions;
+6. intended target, affected systems, spillover population, and dependent physical processes;
+7. commanded state, observed state, independently measured state, and any telemetry deception;
+8. confidentiality, integrity, availability, safety, environmental, economic, military, and physical effects;
+9. source class, native custody, hash, provenance, corrections, contradictions, and missing evidence;
+10. attribution confidence by proposition rather than a single incident-wide confidence label.
+
+## Core research questions
+
+1. Which incident is the earliest independently reconstructable case in each governed class?
+2. When did attacks move from information theft or network denial into autonomous manipulation of physical state?
+3. Which operations crossed from public or supplier networks into private, segmented, or air-gapped systems?
+4. Which attacks depended on valid internal credentials or technically valid commands that lacked legitimate transition authority?
+5. Which incidents manipulated monitoring or operator perception in addition to execution?
+6. How often did destructive effects result from deliberate targeting versus uncontrolled propagation?
+7. How have state actors used contractors, criminal proxies, insiders, suppliers, or compromised third parties?
+8. Which public attributions were later confirmed, narrowed, contradicted, withdrawn, or left unresolved?
+9. What present attack patterns reproduce the transition structure of earlier incidents even when tooling and targets differ?
+10. Which controls would have detected or denied the illegitimate transition, and which claims about prevention remain untested?
+
+## Historical-to-current comparison dimensions
+
+The comparative output must not rank incidents using a single severity score. It should produce proposition-relative comparisons across:
+
+- reach: local, organizational, sectoral, national, or transnational;
+- boundary: external-only, internal-only, supply-chain, hybrid, or air-gap crossing;
+- action: observe, collect, deny, alter, destroy, deceive, or coerce;
+- autonomy: operator-at-keyboard, scripted, self-propagating, target-selective, or process-autonomous;
+- consequence: data loss, service interruption, environmental release, equipment degradation, injury risk, or strategic effect;
+- observability: overt, delayed, covert, false-normal, or independently observable;
+- attribution posture: unknown, alleged, technically associated, officially attributed, judicially established, or acknowledged;
+- evidence posture: primary-custodied, authoritative-secondary, technical reconstruction, contested, or missing.
+
+## Current-attack intake
+
+Current monitoring should begin with official and authoritative advisory streams, then acquire the underlying incident-specific records. Advisories are discovery leads and threat-context sources; they do not independently establish that a particular intrusion caused sabotage or that the named state controlled every observed action.
+
+The initial machine-readable acquisition queue is:
+
+`config/network-cyberphysical-sabotage-source-queue.v1.json`
+
+Priority current lanes:
+
+- industrial-control and operational-technology advisories;
+- destructive malware and wiper operations;
+- critical-infrastructure intrusions with credible process effects;
+- telecommunications, satellite, positioning, maritime, energy, water, transportation, healthcare, and nuclear-system incidents;
+- supply-chain compromises capable of crossing organizational trust boundaries;
+- attacks that falsify telemetry, provenance, logs, safety state, or operator-visible status;
+- state, proxy, contractor, insider, and criminal-role separation;
+- corrections to earlier public attribution or impact claims.
+
+## Source and custody policy
+
+Evidence should be physically separated into future namespaces for official records, technical analyses, judicial records, contemporaneous reporting, retrospective reporting, contested accounts, and derived comparisons. A secondary account may locate a primary object but may not inherit primary-source status.
+
+Minimum preferred source order:
+
+1. native government, court, regulator, operator, or incident-response records;
+2. contemporaneous technical artifacts and reproducible reverse engineering;
+3. named, attributable reporting based on direct participants or documents;
+4. scholarly historical reconstruction;
+5. retrospective summaries used only as discovery leads.
+
+Current web content must be captured with retrieval time, native bytes or a governed immutable receipt, source identity, and later correction checks. Publication date and event date must remain separate.
+
+## StegVerse governance relevance
+
+This lane may test whether an incident exploited one or more of these separations:
+
+```text
+network admission != execution authority
+internal presence != trusted identity
+valid command syntax != legitimate state transition
+commanded state != independently observed state
+successful delivery != authorized receipt
+single-channel telemetry != reconstructable evidence
+```
+
+The research may compare incident structures with Interlock/InTr, transition-table, receipt, independent-observation, and reconstruction controls. It must not claim that a StegVerse control would have prevented an incident until the historical transition path is reconstructed and the proposed control is tested against that path.
+
+## First executable research slice
+
+1. Acquire and hash the authoritative seed sources in the configured queue.
+2. Create one proposition-level incident packet for each historical seed.
+3. Mark disputed, accidental, espionage-only, and sabotage cases distinctly.
+4. Normalize boundary crossings and commanded/observed/physical states.
+5. Add current incidents only through dated candidate packets with explicit attribution and effect ceilings.
+6. Perform an independent chronology and classification review before any public comparison.
+
+## Promotion boundary
+
+This candidate does not authorize claims that:
+
+- the alleged 1982 Soviet pipeline event was caused by CIA-modified software;
+- every harmful worm or outage was sabotage;
+- network intrusion proves physical-process access;
+- technical association proves state direction;
+- Stuxnet attribution has been formally acknowledged by the alleged states;
+- an advisory proves a current attack occurred as initially described;
+- a proposed governance control would necessarily have prevented a historical operation.
+
+Promotion requires source custody, incident-level contradiction review, proposition-relative attribution, explicit separation of observed effects from inferred objectives, current-event correction monitoring, and independent reconstruction.


### PR DESCRIPTION
## Summary

Adds a governed ERL research-candidate lane for reconstructing historical and current network and cyber-physical sabotage.

- separates espionage, disruption, sabotage, cyber-physical sabotage, accidental spillover, and coercion
- seeds the disputed 1982 pipeline account, Hanover Hacker, Morris worm, Maroochy Shire, Davis-Besse, Estonia, and Stuxnet
- installs a public-source acquisition queue for authoritative historical and current advisory inputs
- registers the active candidate under Issue #63 and updates the root mirror handoff
- keeps attribution, causal, prevention-effectiveness, publication, and downstream propagation authority false

## Validation

- `python scripts/validate_research_candidate_activation.py` — PASS: 21 groups, 22 candidate files, 21 active groups
- source queue JSON parse — PASS
- full branch `git diff --check` — PASS

## Boundaries

This PR creates research intake and comparison structure only. It does not promote an incident finding or authorize Site, Publisher, admissibility-wiki, or stegguardian-wiki propagation.