### PR TITLE
Add independent AI economic transparency research lane

### DIFF
--- a/.github/workflows/validate-ai-economic-transparency.yml
+++ b/.github/workflows/validate-ai-economic-transparency.yml
@@ -1,0 +1,42 @@
+name: Validate AI economic transparency
+
+on:
+  push:
+    paths:
+      - "docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md"
+      - "research-candidates/2026-09-03-ai-economic-transparency-elevated-usage.md"
+      - "task-state/ERL-AI-ECON-TRANSPARENCY-001.json"
+      - "standards/ai-economic-transparency.v1.md"
+      - "schemas/ai-economic-transparency-observation.schema.json"
+      - "config/ai-economic-transparency-source-queue.v1.json"
+      - "scripts/validate_ai_economic_transparency.py"
+      - "tests/test_ai_economic_transparency.py"
+      - "tests/fixtures/ai-economic-transparency/**"
+      - ".github/workflows/validate-ai-economic-transparency.yml"
+  pull_request:
+    paths:
+      - "docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md"
+      - "research-candidates/2026-09-03-ai-economic-transparency-elevated-usage.md"
+      - "task-state/ERL-AI-ECON-TRANSPARENCY-001.json"
+      - "standards/ai-economic-transparency.v1.md"
+      - "schemas/ai-economic-transparency-observation.schema.json"
+      - "config/ai-economic-transparency-source-queue.v1.json"
+      - "scripts/validate_ai_economic_transparency.py"
+      - "tests/test_ai_economic_transparency.py"
+      - "tests/fixtures/ai-economic-transparency/**"
+      - ".github/workflows/validate-ai-economic-transparency.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run unit tests
+        run: python -m unittest tests/test_ai_economic_transparency.py
+      - name: Validate fixtures
+        run: |
+          python scripts/validate_ai_economic_transparency.py tests/fixtures/ai-economic-transparency/direct.json
+          python scripts/validate_ai_economic_transparency.py tests/fixtures/ai-economic-transparency/incomplete-unknown.json

--- a/ERL_MIRROR_HANDOFF.md
+++ b/ERL_MIRROR_HANDOFF.md
@@ -633,3 +633,40 @@ Governing distinction: readiness/preparation language must not be promoted into 
 Next executable boundary: custody exact U.S./NATO primary statements, reconstruct the dated threat-assessment chronology, admit linked incidents proposition-by-proposition, map Article 4/5 authority and response thresholds, and perform contradiction/independent review.
 
 No Site, Publisher, admissibility-wiki, stegguardian-wiki, tag, release, or publication propagation is authorized from this research-candidate state.
+
+
+## Adjacent active execution lane — AI economic transparency / elevated-usage cost sensitivity — ACTIVE
+
+Goal ID: `ERL-AI-ECON-TRANSPARENCY-001`
+
+Canonical owner: Issue `#93`.
+
+Scoped handoff:
+`docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md`
+
+Research candidate:
+`research-candidates/2026-09-03-ai-economic-transparency-elevated-usage.md`
+
+Research axes:
+- `ACTUAL_COST_DISCLOSURE_BURDEN`
+- `COST_SCALE_SENSITIVITY`
+
+The lane independently evaluates how difficult it is to discover or exactly reconstruct literal request-attributable AI inference cost and how unresolved cost variance compounds at elevated usage. Its primary decision contexts are enterprise, agentic, batch, automated, public-sector procurement, and other materially scaled workloads rather than casual low-volume use.
+
+`GCAT-BCAT-Engine/workflows` SV-COST artifacts are admissible upstream evidence inputs, but ERL does not inherit SV-COST conclusions. Rate cards are not treated as literal request-cost evidence unless the actual metered quantities and all material billing rules make the request cost exactly reconstructable.
+
+Current implementation:
+- bounded handoff: installed
+- research candidate: installed and registered
+- methodology: installed
+- observation schema: installed
+- provider source/research queue: installed
+- deterministic validator/tests/fixtures: installed
+- dedicated hosted validation workflow: installed
+- provider disclosure protocols: pending execution
+- elevated-usage empirical sensitivity calculations: pending
+- contradiction review: pending
+- independent review: pending
+- activation/publication: not authorized
+
+No Site, Publisher, admissibility-wiki, stegguardian-wiki, tag, release, or publication propagation is authorized from this research-candidate state.

--- a/config/ai-economic-transparency-source-queue.v1.json
+++ b/config/ai-economic-transparency-source-queue.v1.json
@@ -1,0 +1,47 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-source-queue/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "policy": {
+    "independent_reconstruction_required": true,
+    "inherit_upstream_conclusions": false,
+    "final_score_requires_protocol_complete": true,
+    "unknown_cost_must_remain_unknown": true
+  },
+  "providers": [
+    {
+      "provider": "openai",
+      "model_seed": "gpt-5.6-sol",
+      "state": "QUEUED",
+      "upstream_evidence": "GCAT-BCAT-Engine/workflows:openai-ui-candidate-observation-2026-09-03.json",
+      "next": "Reconstruct immediate request surface, official pricing, available usage/billing surfaces, material pricing rules, and elevated-usage sensitivity."
+    },
+    {
+      "provider": "anthropic",
+      "model_seed": "claude-opus-5",
+      "state": "QUEUED",
+      "upstream_evidence": "GCAT-BCAT-Engine/workflows:anthropic-ui-candidate-observation-2026-09-03.json",
+      "next": "Reconstruct immediate request surface, official pricing, available usage/billing surfaces, material pricing rules, and elevated-usage sensitivity."
+    },
+    {
+      "provider": "deepseek",
+      "model_seed": null,
+      "state": "QUEUED_MODEL_IDENTITY_UNRESOLVED",
+      "upstream_evidence": "GCAT-BCAT-Engine/workflows:deepseek-ui-candidate-observation-2026-09-03.json",
+      "next": "Resolve model identity where possible, then reconstruct pricing/usage surfaces and elevated-usage sensitivity."
+    },
+    {
+      "provider": "zai",
+      "model_seed": "GLM-5.3-Flash",
+      "state": "QUEUED",
+      "upstream_evidence": "GCAT-BCAT-Engine/workflows:glm-hosted-ui-candidate-observation-2026-09-03.json",
+      "next": "Reconstruct immediate request surface, official pricing, available usage/billing surfaces, material pricing rules, and elevated-usage sensitivity."
+    },
+    {
+      "provider": "perplexity",
+      "model_seed": null,
+      "state": "QUEUED_SUPPLEMENTAL",
+      "upstream_evidence": "GCAT-BCAT-Engine/workflows:perplexity-ui-candidate-observation-2026-09-03.json",
+      "next": "Resolve model/version where possible and apply the same protocol as a supplemental comparator."
+    }
+  ]
+}

--- a/coordination/research-candidate-activation-registry.v1.json
+++ b/coordination/research-candidate-activation-registry.v1.json
@@ -406,6 +406,29 @@
       "terminal_condition": "Primary-source custody, chronology reconstruction, contradiction review, proposition-relative attribution, authority mapping, and independent review support an explicit governed promotion, supersession, merge, or closure decision.",
       "candidate_layer_finding_authorized": false,
       "candidate_layer_publication_authorized": false
+    },
+    {
+      "group_id": "ERL-RC-AI-ECON-TRANSPARENCY-2026",
+      "title": "AI literal-cost transparency and elevated-usage sensitivity",
+      "candidate_paths": [
+        "research-candidates/2026-09-03-ai-economic-transparency-elevated-usage.md"
+      ],
+      "active": true,
+      "state": "RESEARCH_ACTIVE_NOT_ASSESSABLE",
+      "durable_owner": "issue:93",
+      "artifact_paths": [
+        "docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md",
+        "task-state/ERL-AI-ECON-TRANSPARENCY-001.json",
+        "standards/ai-economic-transparency.v1.md",
+        "schemas/ai-economic-transparency-observation.schema.json",
+        "config/ai-economic-transparency-source-queue.v1.json",
+        "scripts/validate_ai_economic_transparency.py",
+        "tests/test_ai_economic_transparency.py"
+      ],
+      "next_executable_task": "Execute the independent disclosure-burden protocol for the initial provider set, preserve research steps and barriers, then calculate elevated-usage sensitivity only from exact or bounded evidence.",
+      "terminal_condition": "Machine-valid provider protocols, scale-sensitivity calculations, contradiction review, and independent review support an explicit governed promotion, supersession, merge, or closure decision.",
+      "candidate_layer_finding_authorized": false,
+      "candidate_layer_publication_authorized": false
     }
   ]
 }

--- a/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
+++ b/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
@@ -195,11 +195,11 @@ Publication remains separately gated.
 - research objective: ESTABLISHED
 - bounded handoff: COMPLETE
 - durable owner: Issue #93
-- methodology: PENDING INSTALLATION
-- schema: PENDING INSTALLATION
-- research queue: PENDING INSTALLATION
-- validator: PENDING
-- fixtures: PENDING
+- methodology: INSTALLED
+- schema: INSTALLED
+- research queue: INSTALLED
+- validator: INSTALLED
+- fixtures: INSTALLED
 - provider protocol execution: NOT STARTED
 - scale-sensitivity calculations: NOT STARTED
 - contradiction review: PENDING
@@ -211,13 +211,6 @@ Publication remains separately gated.
 
 Destination: `StegVerse-Labs/Executive_Rhetoric_Ledger`
 
-- `research-candidates/2026-09-03-ai-economic-transparency-elevated-usage.md`
-- `task-state/ERL-AI-ECON-TRANSPARENCY-001.json`
-- `standards/ai-economic-transparency.v1.md`
-- `schemas/ai-economic-transparency-observation.schema.json`
-- `config/ai-economic-transparency-source-queue.v1.json`
-- `scripts/validate_ai_economic_transparency.py`
-- `tests/test_ai_economic_transparency.py`
 - provider research logs under `research-data/ai-economic-transparency/`
 - workload/sensitivity calculation module
 - contradiction-review record
@@ -247,9 +240,9 @@ Initial activation denominator: 10 capability groups.
 9. contradiction/independent review
 10. activation receipt
 
-Current completion: 1/10 = 10%.
+Current completion: 6/10 = 60%.
 
-Developed files: 1.
+Developed files: 12.
 Scaffolding/stubs counted as complete: 0.
 
 Archive readiness: this handoff durably preserves the research goal, independence rule, two-axis methodology, elevated-usage scope, evidence boundaries, activation criteria, and remaining implementation. No chat-only definition is required to continue.

--- a/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
+++ b/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
@@ -1,0 +1,255 @@
+# ERL AI Economic Transparency Mirror Handoff
+
+## Authority
+
+Bounded source of truth for the independent AI economic-transparency research program in `StegVerse-Labs/Executive_Rhetoric_Ledger`.
+
+- repository-wide authority: `ERL_MIRROR_HANDOFF.md`
+- research-candidate activation authority: `docs/RESEARCH_CANDIDATE_ACTIVATION_MIRROR_HANDOFF.md`
+- bounded owner: Issue #93
+- branch: `research/ai-economic-transparency`
+- goal ID: `ERL-AI-ECON-TRANSPARENCY-001`
+- publication authorized: false
+- candidate-layer finding authorized: false
+
+This handoff controls only the AI economic-transparency research lane. It does not alter other ERL research programs or the source SV-COST experiment.
+
+## Research purpose
+
+Independently determine how transparent AI providers are about the literal economic consequence of inference at elevated usage, and how uncertainty in that cost changes comparative provider selection at operational scale.
+
+The primary population of interest is not casual low-volume use. The study is designed for usage levels where small per-request or per-token differences compound materially, including:
+
+- enterprise inference;
+- agentic systems;
+- batch processing;
+- high-frequency automation;
+- public-sector procurement;
+- research infrastructure;
+- other recurring or high-volume deployments.
+
+## Independence boundary
+
+`GCAT-BCAT-Engine/workflows` SV-COST observations are admissible evidence inputs.
+
+They are not inherited conclusions.
+
+ERL must independently reconstruct:
+- provider/model identity where possible;
+- advertised price surfaces;
+- actual request-cost observability;
+- usage-meter observability;
+- all material cost determinants;
+- discovery burden;
+- literal-cost reconstructability;
+- cost uncertainty at scale;
+- comparative economic consequence.
+
+The ERL paper must remain reproducible without relying on conclusions stated in SV-COST handoffs.
+
+## Research axes
+
+### ACTUAL_COST_DISCLOSURE_BURDEN
+
+Measures how much research is required to discover or exactly reconstruct literal request-attributable cost.
+
+Ordinal scale, lower is more transparent:
+
+```text
+0 DIRECT
+1 ONE_STEP_DERIVABLE
+2 MULTI_SOURCE_DERIVABLE
+3 ACCOUNT_GATED
+4 SUPPORT_OR_EXTERNAL_RESEARCH_REQUIRED
+5 NON_RECONSTRUCTABLE
+```
+
+A provider must not receive rating 5 merely because an initial consumer surface omits cost. Rating 5 requires completion of the governed discovery protocol.
+
+### COST_SCALE_SENSITIVITY
+
+Measures how economically material unresolved cost variance becomes as usage scales.
+
+The scale-sensitivity calculation must preserve workload assumptions and must not convert unknown cost into a fabricated point estimate.
+
+Required comparison scenarios should include, where data permit:
+- per 1,000 equivalent requests;
+- per 100,000 equivalent requests;
+- per 1,000,000 equivalent requests;
+- token-normalized or workload-normalized equivalents when request shape differs materially;
+- monthly and annualized operational views where justified.
+
+When exact cost is unavailable, ERL may report bounded uncertainty or unresolved exposure, but must preserve the unknown explicitly.
+
+## Research protocol
+
+For each provider/model:
+
+1. Preserve exact model/version identity if exposed.
+2. Preserve the relevant inference observation or bounded test artifact.
+3. Inspect the immediate request/result surface for literal request cost or exact usage.
+4. Inspect provider-controlled pricing documentation.
+5. Inspect provider-controlled account, usage, billing, quota, or administrative surfaces available to the evaluator.
+6. Record each additional research/navigation step required.
+7. Identify every material pricing component, multiplier, discount, quota rule, cache rule, time-of-day rule, subscription allocation rule, or other factor that can alter actual cost.
+8. Attempt exact request-cost reconstruction.
+9. Measure discovery-step count and elapsed research time.
+10. Classify disclosure burden only after the required discovery path is complete.
+11. Apply standardized elevated-usage scenarios.
+12. Preserve unresolved components and sensitivity ranges.
+13. Perform contradiction review and independent review before promotion.
+
+## Core evidence fields
+
+- provider
+- model/version
+- advertised_rate_present
+- advertised_rate_surface
+- actual_request_cost_directly_exposed
+- request_usage_directly_exposed
+- all_material_cost_components_disclosed
+- provider_surfaces_consulted
+- research_steps_required
+- research_minutes
+- account_or_privilege_required
+- support_required
+- external_research_required
+- unresolved_cost_components
+- reconstructable_actual_cost
+- disclosure_burden_rating
+- workload_basis
+- scale_scenarios
+- known_cost_components
+- unresolved_cost_exposure
+- scale_sensitivity_state
+- evidence_refs
+- contradiction_refs
+- independent_review_state
+
+## Claim boundaries
+
+- published rate card != literal request-attributable cost
+- advertised unit price != complete economic consequence
+- consumer subscription price != request-level cost
+- qualitative quota warning != quantitative cost
+- model output correctness != economic transparency
+- opacity != proven intent
+- missing cost evidence != zero cost
+- unresolved cost != estimated cost
+- large usage multiplier != proof that hidden cost exists; it measures the consequence if unresolved variance exists
+
+A finding that a presentation is misleading or deceptive requires evidence that material cost information presented or omitted creates a materially inaccurate representation of the economic consequence. Intent is a separate proposition and is not inferred from opacity alone.
+
+## Source relationships
+
+Primary upstream evidence candidate:
+- `GCAT-BCAT-Engine/workflows`
+- experiment: `SV-COST-ELEVEN-LANE-RESULTS-001`
+- companion research objective: `SV-COST-TRANSPARENCY-001`
+
+Initial provider set:
+- OpenAI
+- Anthropic
+- DeepSeek
+- Z.ai / GLM Hosted
+- Perplexity as supplemental comparator
+
+ERL may add providers if the same research protocol can be applied without changing already-scored methodology.
+
+## Installed implementation
+
+This lane must contain:
+- this bounded handoff;
+- research candidate;
+- task state;
+- research standard;
+- machine-readable observation schema;
+- source/research queue;
+- deterministic validator;
+- fixtures;
+- comparative workload model;
+- provider research logs;
+- contradiction review;
+- independent review;
+- paper manuscript/appendix package.
+
+## Activation criteria
+
+Activation requires:
+
+1. bounded handoff and durable owner;
+2. candidate registered in the machine-enforced ERL activation registry;
+3. formal methodology and schema;
+4. deterministic validator and fixtures;
+5. source/research queue for the initial provider set;
+6. at least one complete provider disclosure protocol;
+7. reproducible elevated-usage scale calculation;
+8. contradiction review;
+9. independent review;
+10. no unresolved schema/validation failures.
+
+Publication remains separately gated.
+
+## Current state
+
+- research objective: ESTABLISHED
+- bounded handoff: COMPLETE
+- durable owner: Issue #93
+- methodology: PENDING INSTALLATION
+- schema: PENDING INSTALLATION
+- research queue: PENDING INSTALLATION
+- validator: PENDING
+- fixtures: PENDING
+- provider protocol execution: NOT STARTED
+- scale-sensitivity calculations: NOT STARTED
+- contradiction review: PENDING
+- independent review: PENDING
+- activation: NOT CLAIMED
+- publication: NOT AUTHORIZED
+
+## Remaining files/modules to install
+
+Destination: `StegVerse-Labs/Executive_Rhetoric_Ledger`
+
+- `research-candidates/2026-09-03-ai-economic-transparency-elevated-usage.md`
+- `task-state/ERL-AI-ECON-TRANSPARENCY-001.json`
+- `standards/ai-economic-transparency.v1.md`
+- `schemas/ai-economic-transparency-observation.schema.json`
+- `config/ai-economic-transparency-source-queue.v1.json`
+- `scripts/validate_ai_economic_transparency.py`
+- `tests/test_ai_economic_transparency.py`
+- provider research logs under `research-data/ai-economic-transparency/`
+- workload/sensitivity calculation module
+- contradiction-review record
+- independent-review record
+- companion paper manuscript
+
+When this research reaches release/tag posture, verify whether pertinent results or methodology should propagate to:
+- `StegVerse-Labs/Site`
+- `GCAT-BCAT-Engine/Publisher`
+- `StegVerse-Labs/admissibility-wiki`
+- `StegVerse-Labs/stegguardian-wiki`
+
+No propagation is authorized yet.
+
+## Completion accounting
+
+Initial activation denominator: 10 capability groups.
+
+1. authority/handoff
+2. candidate/registry
+3. methodology
+4. schema
+5. source/research queue
+6. validator/fixtures
+7. provider protocol evidence
+8. scale-sensitivity calculations
+9. contradiction/independent review
+10. activation receipt
+
+Current completion: 1/10 = 10%.
+
+Developed files: 1.
+Scaffolding/stubs counted as complete: 0.
+
+Archive readiness: this handoff durably preserves the research goal, independence rule, two-axis methodology, elevated-usage scope, evidence boundaries, activation criteria, and remaining implementation. No chat-only definition is required to continue.

--- a/research-candidates/2026-09-03-ai-economic-transparency-elevated-usage.md
+++ b/research-candidates/2026-09-03-ai-economic-transparency-elevated-usage.md
@@ -1,0 +1,61 @@
+# AI economic transparency at elevated usage — research candidate
+
+Date: 2026-09-03
+Status: `research_candidate`
+Goal: `ERL-AI-ECON-TRANSPARENCY-001`
+Owner: Issue #93
+Bounded handoff: `docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md`
+Activation authorized: `false`
+Publication authorized: `false`
+
+## Candidate proposition
+
+AI providers differ materially in how much effort is required to discover or exactly reconstruct the literal economic cost of inference, and that disclosure burden becomes increasingly consequential as workload volume rises.
+
+## Study population
+
+Primary intended comparison population:
+- enterprise inference;
+- agentic workloads;
+- batch inference;
+- high-frequency automated use;
+- public-sector procurement;
+- other usage where small unit-cost variance compounds materially.
+
+Casual consumer usage is not the principal decision context for this research.
+
+## Research questions
+
+1. Can an evaluator determine the literal request-attributable cost of one inference?
+2. How many research/navigation steps and how much elapsed effort are required?
+3. Which material pricing components are visible on the initial price surface, and which appear only elsewhere?
+4. Does exact reconstruction require account, billing, administrative, support, or external-research access?
+5. How does unresolved cost variance scale at 1K, 100K, and 1M equivalent requests?
+6. Does provider ranking change when disclosure burden and scale sensitivity are considered alongside raw unit pricing?
+
+## Required controls
+
+- preserve identical or normalized workload definitions;
+- do not equate advertised unit rates to literal request cost;
+- do not assign zero cost to unknown components;
+- do not infer provider intent from opacity;
+- preserve provider/model version uncertainty;
+- preserve subscription and API economics as separate surfaces where applicable;
+- independently reconstruct findings in ERL rather than importing SV-COST conclusions.
+
+## Initial evidence seed
+
+SV-COST provider observations may be used as upstream evidence candidates:
+- OpenAI
+- Anthropic
+- DeepSeek
+- Z.ai / GLM Hosted
+- Perplexity supplemental comparator
+
+These inputs establish only what the supplied observation surfaces actually showed. They do not establish final ERL transparency scores.
+
+## Promotion boundary
+
+Promotion requires machine-valid provider observations, completed discovery protocols, scale-sensitivity calculations, contradiction review, and independent review.
+
+No comparative ranking or deceptive-pricing finding is authorized at candidate stage.

--- a/schemas/ai-economic-transparency-observation.schema.json
+++ b/schemas/ai-economic-transparency-observation.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "stegverse.erl.ai-economic-transparency-observation.v1",
+  "title": "ERL AI Economic Transparency Observation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "task_id",
+    "provider",
+    "protocol_complete",
+    "actual_request_cost_directly_exposed",
+    "request_usage_directly_exposed",
+    "research_steps_required",
+    "provider_surfaces_consulted",
+    "account_or_privilege_required",
+    "support_required",
+    "external_research_required",
+    "reconstructable_actual_cost",
+    "unresolved_cost_components",
+    "disclosure_burden_rating",
+    "scale_sensitivity_state",
+    "activation_authorized"
+  ],
+  "properties": {
+    "schema": {
+      "const": "stegverse.erl.ai-economic-transparency-observation/v1"
+    },
+    "task_id": {
+      "const": "ERL-AI-ECON-TRANSPARENCY-001"
+    },
+    "provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "model": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "protocol_complete": {
+      "type": "boolean"
+    },
+    "advertised_rate_present": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "advertised_rate_surface": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "actual_request_cost_directly_exposed": {
+      "type": "boolean"
+    },
+    "request_usage_directly_exposed": {
+      "type": "boolean"
+    },
+    "all_material_cost_components_disclosed": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "research_steps_required": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "research_minutes": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "provider_surfaces_consulted": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "account_or_privilege_required": {
+      "type": "boolean"
+    },
+    "support_required": {
+      "type": "boolean"
+    },
+    "external_research_required": {
+      "type": "boolean"
+    },
+    "reconstructable_actual_cost": {
+      "type": "boolean"
+    },
+    "literal_request_cost_usd": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "unresolved_cost_components": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "disclosure_burden_rating": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 5
+    },
+    "workload_basis": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "scale_scenarios": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "equivalent_requests",
+          "state"
+        ],
+        "properties": {
+          "equivalent_requests": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "state": {
+            "enum": [
+              "EXACT",
+              "BOUNDED",
+              "UNBOUNDED_UNKNOWN",
+              "NOT_APPLICABLE"
+            ]
+          },
+          "known_total_cost_usd": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "lower_bound_usd": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "upper_bound_usd": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "minimum": 0
+          }
+        }
+      }
+    },
+    "scale_sensitivity_state": {
+      "enum": [
+        "NOT_CALCULATED",
+        "EXACT",
+        "BOUNDED",
+        "UNBOUNDED_UNKNOWN",
+        "MIXED"
+      ]
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "contradiction_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "independent_review_state": {
+      "enum": [
+        "PENDING",
+        "PASS",
+        "REVISE",
+        "REJECT"
+      ]
+    },
+    "activation_authorized": {
+      "const": false
+    }
+  }
+}

--- a/scripts/validate_ai_economic_transparency.py
+++ b/scripts/validate_ai_economic_transparency.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+REQUIRED = {
+    "schema","task_id","provider","protocol_complete",
+    "actual_request_cost_directly_exposed","request_usage_directly_exposed",
+    "research_steps_required","provider_surfaces_consulted",
+    "account_or_privilege_required","support_required","external_research_required",
+    "reconstructable_actual_cost","unresolved_cost_components",
+    "disclosure_burden_rating","scale_sensitivity_state","activation_authorized"
+}
+
+def validate(obj):
+    errors = []
+    missing = sorted(REQUIRED - set(obj))
+    if missing:
+        errors.append("missing:" + ",".join(missing))
+        return errors
+
+    if obj["schema"] != "stegverse.erl.ai-economic-transparency-observation/v1":
+        errors.append("schema")
+    if obj["task_id"] != "ERL-AI-ECON-TRANSPARENCY-001":
+        errors.append("task_id")
+    if obj["activation_authorized"] is not False:
+        errors.append("activation_authorized_must_be_false")
+    if not isinstance(obj["research_steps_required"], int) or obj["research_steps_required"] < 0:
+        errors.append("research_steps_required")
+    rating = obj["disclosure_burden_rating"]
+    if rating is not None and (not isinstance(rating, int) or rating < 0 or rating > 5):
+        errors.append("disclosure_burden_rating")
+    if rating == 5 and obj["protocol_complete"] is not True:
+        errors.append("rating_5_requires_protocol_complete")
+    if rating is not None and obj["protocol_complete"] is not True and rating != 0:
+        errors.append("final_rating_requires_protocol_complete")
+    if obj["actual_request_cost_directly_exposed"] is True and rating not in (None, 0):
+        errors.append("direct_cost_conflicts_with_rating")
+    if obj["reconstructable_actual_cost"] is False and obj.get("literal_request_cost_usd") is not None:
+        errors.append("literal_cost_without_reconstructability")
+
+    scenarios = obj.get("scale_scenarios", [])
+    allowed_states = {"EXACT","BOUNDED","UNBOUNDED_UNKNOWN","NOT_APPLICABLE"}
+    for i, s in enumerate(scenarios):
+        if s.get("state") not in allowed_states:
+            errors.append(f"scale_scenarios[{i}].state")
+            continue
+        state=s["state"]
+        if state=="EXACT" and s.get("known_total_cost_usd") is None:
+            errors.append(f"scale_scenarios[{i}].exact_missing_total")
+        if state=="BOUNDED":
+            lo=s.get("lower_bound_usd"); hi=s.get("upper_bound_usd")
+            if lo is None or hi is None or hi < lo:
+                errors.append(f"scale_scenarios[{i}].invalid_bounds")
+        if state=="UNBOUNDED_UNKNOWN" and any(s.get(k) is not None for k in ("known_total_cost_usd","lower_bound_usd","upper_bound_usd")):
+            errors.append(f"scale_scenarios[{i}].unknown_has_numeric_claim")
+    return errors
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: validate_ai_economic_transparency.py <json>", file=sys.stderr)
+        return 2
+    obj=json.loads(Path(sys.argv[1]).read_text())
+    errors=validate(obj)
+    if errors:
+        print(json.dumps({"valid":False,"errors":errors}, separators=(",",":")))
+        return 1
+    print('{"valid":true,"errors":[]}')
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/standards/ai-economic-transparency.v1.md
+++ b/standards/ai-economic-transparency.v1.md
@@ -1,0 +1,82 @@
+# ERL AI Economic Transparency Standard v1
+
+## Purpose
+
+Define a reproducible method for evaluating literal inference-cost transparency and the economic importance of cost uncertainty under elevated usage.
+
+## Axis A — ACTUAL_COST_DISCLOSURE_BURDEN
+
+Lower is more transparent.
+
+| Score | State | Required evidence |
+|---:|---|---|
+| 0 | DIRECT | Literal request-attributable cost exposed at the request/receipt surface. |
+| 1 | ONE_STEP_DERIVABLE | Exact request usage plus one public version-bound pricing artifact reconstructs cost. |
+| 2 | MULTI_SOURCE_DERIVABLE | Exact cost is reconstructable only by combining multiple provider-controlled surfaces/rules. |
+| 3 | ACCOUNT_GATED | Reconstruction requires authenticated billing/admin/account surfaces beyond the ordinary request surface. |
+| 4 | SUPPORT_OR_EXTERNAL_RESEARCH_REQUIRED | Reconstruction requires support or substantial research beyond ordinary provider self-service surfaces. |
+| 5 | NON_RECONSTRUCTABLE | Governed discovery protocol completed and literal request-attributable cost remains non-reconstructable. |
+
+A score of 5 requires protocol completion. Initial opacity alone is not sufficient.
+
+## Axis B — COST_SCALE_SENSITIVITY
+
+This axis records how known or unresolved cost components behave across elevated usage.
+
+Required scenarios, where the workload definition supports them:
+- 1,000 equivalent requests;
+- 100,000 equivalent requests;
+- 1,000,000 equivalent requests.
+
+If request shape varies, use a documented normalized workload basis such as input/output tokens, compute seconds, or another reproducible denominator.
+
+For exact per-request cost `c` and workload count `n`:
+
+`known_total_cost = c * n`
+
+For bounded unresolved per-request exposure `[l,u]`:
+
+`scale_exposure = [l*n, u*n]`
+
+If no defensible bound exists, preserve `UNBOUNDED_UNKNOWN`; do not invent one.
+
+## Discovery protocol
+
+1. Capture immediate request/result cost and usage surfaces.
+2. Capture provider-controlled pricing documentation.
+3. Capture provider-controlled usage/billing/account surfaces available to evaluator.
+4. Record every material pricing rule affecting literal cost.
+5. Record navigation/research steps and elapsed minutes.
+6. Record access barriers.
+7. Attempt exact reconstruction.
+8. Record unresolved components.
+9. Assign disclosure burden only after protocol completion.
+10. Calculate elevated-usage consequences only from exact or bounded evidence.
+
+## Material cost components
+
+Examples include input/output token rates, cache rates, reasoning-token treatment, batch discounts, peak/off-peak rules, model routing, minimum charges, subscription quota allocation, tool/search charges, storage/network charges, and other provider-documented components that affect the literal economic consequence.
+
+This list is non-exclusive. Evidence determines applicability.
+
+## Independence rule
+
+SV-COST artifacts may be cited as source observations. ERL must separately validate the evidence path and compute its own ratings.
+
+## Findings discipline
+
+- `rate_card_present` does not equal `actual_cost_reconstructable`.
+- `cost_unknown` does not equal `cost_high`.
+- `cost_unknown` does not equal `cost_zero`.
+- `opaque_surface` does not prove intent.
+- a misleading/deceptive-effect finding requires evidence of a materially inaccurate pricing impression, not merely missing metadata.
+- intent-based findings require separate direct or reconstructable evidence.
+
+## Release gate
+
+Provider rankings and paper conclusions require:
+- validator-clean observations;
+- completed protocols for compared providers;
+- reproducible scale calculations;
+- contradiction review;
+- independent review.

--- a/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
+++ b/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
@@ -1,7 +1,7 @@
 {
   "schema": "stegverse.erl.task-state/v1",
   "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
-  "state": "RESEARCH_ACTIVE_NOT_ASSESSABLE",
+  "state": "RESEARCH_ACTIVE_IMPLEMENTATION_READY_PROTOCOL_EXECUTION_PENDING",
   "owner": "issue:93",
   "canonical_handoff": "docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md",
   "candidate_path": "research-candidates/2026-09-03-ai-economic-transparency-elevated-usage.md",
@@ -18,5 +18,9 @@
   },
   "activation_authorized": false,
   "publication_authorized": false,
-  "next_executable_task": "Install methodology, schema, research queue, validator and fixtures, then execute the independent provider disclosure protocol beginning with the initial provider set."
+  "next_executable_task": "Execute the independent provider disclosure protocol for OpenAI, Anthropic, DeepSeek, Z.ai/GLM Hosted, and supplemental Perplexity; preserve provider research logs and calculate elevated-usage sensitivity only from exact or bounded evidence.",
+  "implementation_completion_percent": 60,
+  "validator_state": "INSTALLED",
+  "fixture_state": "INSTALLED",
+  "activation_registry_group": "ERL-RC-AI-ECON-TRANSPARENCY-2026"
 }

--- a/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
+++ b/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
@@ -1,0 +1,22 @@
+{
+  "schema": "stegverse.erl.task-state/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "state": "RESEARCH_ACTIVE_NOT_ASSESSABLE",
+  "owner": "issue:93",
+  "canonical_handoff": "docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md",
+  "candidate_path": "research-candidates/2026-09-03-ai-economic-transparency-elevated-usage.md",
+  "research_axes": [
+    "ACTUAL_COST_DISCLOSURE_BURDEN",
+    "COST_SCALE_SENSITIVITY"
+  ],
+  "source_experiment_relationship": {
+    "repository": "GCAT-BCAT-Engine/workflows",
+    "experiment": "SV-COST-ELEVEN-LANE-RESULTS-001",
+    "companion_objective": "SV-COST-TRANSPARENCY-001",
+    "evidence_inputs_allowed": true,
+    "conclusions_inherited": false
+  },
+  "activation_authorized": false,
+  "publication_authorized": false,
+  "next_executable_task": "Install methodology, schema, research queue, validator and fixtures, then execute the independent provider disclosure protocol beginning with the initial provider set."
+}

--- a/tests/fixtures/ai-economic-transparency/direct.json
+++ b/tests/fixtures/ai-economic-transparency/direct.json
@@ -1,0 +1,55 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-observation/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "provider": "fixture-direct",
+  "model": "fixture-v1",
+  "protocol_complete": true,
+  "advertised_rate_present": true,
+  "advertised_rate_surface": "fixture",
+  "actual_request_cost_directly_exposed": true,
+  "request_usage_directly_exposed": true,
+  "all_material_cost_components_disclosed": true,
+  "research_steps_required": 0,
+  "research_minutes": 0,
+  "provider_surfaces_consulted": [
+    "request"
+  ],
+  "account_or_privilege_required": false,
+  "support_required": false,
+  "external_research_required": false,
+  "reconstructable_actual_cost": true,
+  "literal_request_cost_usd": 0.01,
+  "unresolved_cost_components": [],
+  "disclosure_burden_rating": 0,
+  "workload_basis": "equivalent_request",
+  "scale_scenarios": [
+    {
+      "equivalent_requests": 1000,
+      "state": "EXACT",
+      "known_total_cost_usd": 10,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 100000,
+      "state": "EXACT",
+      "known_total_cost_usd": 1000,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 1000000,
+      "state": "EXACT",
+      "known_total_cost_usd": 10000,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    }
+  ],
+  "scale_sensitivity_state": "EXACT",
+  "evidence_refs": [
+    "fixture"
+  ],
+  "contradiction_refs": [],
+  "independent_review_state": "PENDING",
+  "activation_authorized": false
+}

--- a/tests/fixtures/ai-economic-transparency/incomplete-unknown.json
+++ b/tests/fixtures/ai-economic-transparency/incomplete-unknown.json
@@ -1,0 +1,43 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-observation/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "provider": "fixture-incomplete",
+  "model": null,
+  "protocol_complete": false,
+  "advertised_rate_present": null,
+  "advertised_rate_surface": null,
+  "actual_request_cost_directly_exposed": false,
+  "request_usage_directly_exposed": false,
+  "all_material_cost_components_disclosed": null,
+  "research_steps_required": 1,
+  "research_minutes": null,
+  "provider_surfaces_consulted": [
+    "request"
+  ],
+  "account_or_privilege_required": false,
+  "support_required": false,
+  "external_research_required": false,
+  "reconstructable_actual_cost": false,
+  "literal_request_cost_usd": null,
+  "unresolved_cost_components": [
+    "literal request-attributable cost"
+  ],
+  "disclosure_burden_rating": null,
+  "workload_basis": "equivalent_request",
+  "scale_scenarios": [
+    {
+      "equivalent_requests": 1000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    }
+  ],
+  "scale_sensitivity_state": "UNBOUNDED_UNKNOWN",
+  "evidence_refs": [
+    "fixture"
+  ],
+  "contradiction_refs": [],
+  "independent_review_state": "PENDING",
+  "activation_authorized": false
+}

--- a/tests/test_ai_economic_transparency.py
+++ b/tests/test_ai_economic_transparency.py
@@ -1,0 +1,56 @@
+import importlib.util
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("validator", ROOT / "scripts" / "validate_ai_economic_transparency.py")
+validator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(validator)
+
+def base():
+    return {
+        "schema":"stegverse.erl.ai-economic-transparency-observation/v1",
+        "task_id":"ERL-AI-ECON-TRANSPARENCY-001",
+        "provider":"example",
+        "model":None,
+        "protocol_complete":False,
+        "actual_request_cost_directly_exposed":False,
+        "request_usage_directly_exposed":False,
+        "research_steps_required":1,
+        "provider_surfaces_consulted":["request"],
+        "account_or_privilege_required":False,
+        "support_required":False,
+        "external_research_required":False,
+        "reconstructable_actual_cost":False,
+        "literal_request_cost_usd":None,
+        "unresolved_cost_components":["request cost"],
+        "disclosure_burden_rating":None,
+        "scale_scenarios":[
+            {"equivalent_requests":1000,"state":"UNBOUNDED_UNKNOWN","known_total_cost_usd":None,"lower_bound_usd":None,"upper_bound_usd":None}
+        ],
+        "scale_sensitivity_state":"UNBOUNDED_UNKNOWN",
+        "activation_authorized":False
+    }
+
+class TestTransparencyValidator(unittest.TestCase):
+    def test_incomplete_unscored_valid(self):
+        self.assertEqual(validator.validate(base()), [])
+
+    def test_rating_five_requires_complete_protocol(self):
+        o=base(); o["disclosure_burden_rating"]=5
+        self.assertIn("rating_5_requires_protocol_complete", validator.validate(o))
+
+    def test_complete_nonreconstructable_can_rate_five(self):
+        o=base(); o["protocol_complete"]=True; o["disclosure_burden_rating"]=5
+        self.assertEqual(validator.validate(o), [])
+
+    def test_unknown_scale_cannot_claim_numeric_total(self):
+        o=base(); o["scale_scenarios"][0]["known_total_cost_usd"]=10
+        self.assertTrue(any("unknown_has_numeric_claim" in e for e in validator.validate(o)))
+
+    def test_exact_scale_requires_total(self):
+        o=base(); o["scale_scenarios"][0]["state"]="EXACT"
+        self.assertTrue(any("exact_missing_total" in e for e in validator.validate(o)))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #93.

Adds ERL-AI-ECON-TRANSPARENCY-001 as an independent research-candidate lane focused on literal request-cost disclosure burden and elevated-usage cost sensitivity. SV-COST artifacts are admissible evidence inputs, but conclusions are not inherited.

Installed: bounded mirror handoff, research candidate, task state, methodology, schema, source queue, deterministic validator/tests/fixtures, dedicated validation workflow, activation-registry entry, and root-handoff linkage.

No provider ranking, deceptive-pricing finding, activation, release, or publication is claimed by this implementation.