### PR TITLE
Add AI economic transparency review and paper execution surfaces

### DIFF
--- a/.github/workflows/validate-ai-economic-transparency.yml
+++ b/.github/workflows/validate-ai-economic-transparency.yml
@@ -15,6 +15,11 @@ on:
       - "tests/test_ai_cost_scale_sensitivity.py"
       - "schemas/ai-economic-transparency-research-log.schema.json"
       - "research-data/ai-economic-transparency/**"
+      - "schemas/ai-economic-transparency-contradiction-review.schema.json"
+      - "schemas/ai-economic-transparency-independent-review.schema.json"
+      - "assessments/reviews/ai-economic-transparency-*.json"
+      - "papers/ai-economic-transparency-elevated-usage.md"
+      - "task-state/ERL-AI-ECON-TRANSPARENCY-001.review-state.json"
       - "tests/fixtures/ai-economic-transparency/**"
       - ".github/workflows/validate-ai-economic-transparency.yml"
   pull_request:

--- a/assessments/reviews/ai-economic-transparency-contradiction-review.template.json
+++ b/assessments/reviews/ai-economic-transparency-contradiction-review.template.json
@@ -1,0 +1,7 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-contradiction-review/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "state": "PENDING",
+  "provider_reviews": [],
+  "promotion_authorized": false
+}

--- a/assessments/reviews/ai-economic-transparency-independent-review.template.json
+++ b/assessments/reviews/ai-economic-transparency-independent-review.template.json
@@ -1,0 +1,11 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-independent-review/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "state": "PENDING",
+  "review_scope": [],
+  "reviewer_independence": "PENDING",
+  "findings": [],
+  "required_revisions": [],
+  "activation_recommendation": "PENDING",
+  "publication_recommendation": "PENDING"
+}

--- a/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
+++ b/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
@@ -202,8 +202,8 @@ Publication remains separately gated.
 - fixtures: INSTALLED
 - provider protocol execution: IN PROGRESS — public-source logs installed for all five initial providers
 - scale-sensitivity calculation engine: INSTALLED; empirical provider calculations pending exact/bounded request-cost evidence
-- contradiction review: PENDING
-- independent review: PENDING
+- contradiction review execution: PENDING; schema/template installed
+- independent review execution: PENDING; schema/template installed
 - activation: NOT CLAIMED
 - publication: NOT AUTHORIZED
 
@@ -211,9 +211,6 @@ Publication remains separately gated.
 
 Destination: `StegVerse-Labs/Executive_Rhetoric_Ledger`
 
-- contradiction-review record
-- independent-review record
-- companion paper manuscript
 
 When this research reaches release/tag posture, verify whether pertinent results or methodology should propagate to:
 - `StegVerse-Labs/Site`
@@ -240,7 +237,7 @@ Initial activation denominator: 10 capability groups.
 
 Current completion: 6/10 = 60%.
 
-Developed files: 21.
+Developed files: 27.
 Scaffolding/stubs counted as complete: 0.
 
 Archive readiness: this handoff durably preserves the research goal, independence rule, two-axis methodology, elevated-usage scope, evidence boundaries, activation criteria, and remaining implementation. No chat-only definition is required to continue.
@@ -270,3 +267,23 @@ Research-progress posture:
 - Perplexity: official Agent API documentation defines a per-response cost object including total cost and component costs. Authentic SV-RECON Agent API execution remains unobserved.
 
 These are research-progress observations, not provider rankings or final transparency findings.
+
+
+## 2026-09-03 review/paper execution surfaces
+
+Issue: #97
+
+Evidence-independent review and publication-preparation machinery is now installed:
+- contradiction-review schema and pending template;
+- independent-review schema and pending template;
+- machine-readable review state;
+- companion paper manuscript with complete scope, independence boundary, methodology, evidence hierarchy, claims discipline, scale equations, limitations, and publication gate.
+
+The paper deliberately leaves Results, Contradiction Review, and Independent Review pending. Installing these surfaces does not satisfy capability group 9 and does not authorize activation or publication.
+
+At this point the remaining substantive machine work is evidence-dependent:
+1. complete at least one provider disclosure protocol from authentic request-level evidence or a governed exhausted-surface determination;
+2. generate exact or bounded elevated-usage calculations from that evidence;
+3. execute contradiction review;
+4. execute independent review;
+5. emit activation receipt only if all gates pass.

--- a/papers/ai-economic-transparency-elevated-usage.md
+++ b/papers/ai-economic-transparency-elevated-usage.md
@@ -1,0 +1,146 @@
+# Literal AI Cost Transparency at Elevated Usage
+
+Status: research manuscript — methods complete, empirical results pending
+Research program: ERL-AI-ECON-TRANSPARENCY-001
+Repository: StegVerse-Labs/Executive_Rhetoric_Ledger
+
+## Abstract
+
+This study evaluates whether the literal economic consequence of AI inference is directly observable or independently reconstructable, how much research effort is required to obtain that information, and how unresolved cost uncertainty compounds at elevated usage. The study is designed for enterprise, agentic, batch, automated, procurement, and other materially scaled workloads rather than casual low-volume use.
+
+Empirical provider rankings and comparative conclusions are intentionally withheld until provider disclosure protocols, scale calculations, contradiction review, and independent review are complete.
+
+## Research questions
+
+1. Can a reasonable evaluator determine the literal request-attributable cost of an AI inference?
+2. How much navigation, documentation research, privilege escalation, or support interaction is required?
+3. Which material cost determinants are absent from the initially advertised pricing surface?
+4. Is exact request usage exposed?
+5. Is the actual cost directly reported, exactly reconstructable, bounded, or unresolved?
+6. How does cost uncertainty change at 1,000, 100,000, and 1,000,000 equivalent requests?
+7. Does provider selection change when transparency burden and cost uncertainty are considered alongside nominal rate cards?
+
+## Scope
+
+The study focuses on operationally material usage levels. It does not assume that the same transparency burden has equal consequence for casual use.
+
+Initial providers:
+- OpenAI
+- Anthropic
+- DeepSeek
+- Z.ai / GLM Hosted
+- Perplexity as a supplemental comparator
+
+Additional providers may be admitted only under the same methodology.
+
+## Independence
+
+Upstream SV-COST artifacts may be admitted as evidence inputs. ERL independently reconstructs pricing, usage, cost determinants, disclosure burden, and scale sensitivity. No upstream conclusion is inherited.
+
+## Metric 1 — ACTUAL_COST_DISCLOSURE_BURDEN
+
+0 DIRECT
+1 ONE_STEP_DERIVABLE
+2 MULTI_SOURCE_DERIVABLE
+3 ACCOUNT_GATED
+4 SUPPORT_OR_EXTERNAL_RESEARCH_REQUIRED
+5 NON_RECONSTRUCTABLE
+
+A score of 5 requires completion of the governed discovery protocol. Initial opacity alone is insufficient.
+
+## Metric 2 — COST_SCALE_SENSITIVITY
+
+Exact cost:
+known_total_cost = exact_request_cost × equivalent_request_count
+
+Bounded cost:
+lower_total = lower_request_bound × equivalent_request_count
+upper_total = upper_request_bound × equivalent_request_count
+
+Unknown cost:
+UNBOUNDED_UNKNOWN remains unknown at every scale. The study does not manufacture a numeric estimate.
+
+## Provider protocol
+
+For each provider:
+1. preserve model/version identity where exposed;
+2. preserve a bounded inference observation;
+3. inspect the immediate request/result surface;
+4. inspect official pricing documentation;
+5. inspect official usage/billing/account surfaces available to the evaluator;
+6. record every additional discovery step;
+7. enumerate all material cost rules;
+8. attempt exact request-cost reconstruction;
+9. measure discovery steps and elapsed research time;
+10. classify disclosure burden only after protocol completion;
+11. calculate elevated-usage consequences from exact or bounded evidence only;
+12. conduct contradiction review;
+13. conduct independent review.
+
+## Evidence hierarchy
+
+Highest-value evidence includes:
+- direct request receipts containing literal cost;
+- direct request receipts containing exact usage plus complete, version-bound provider pricing;
+- official billing/usage records attributable to one request;
+- official provider pricing and billing rules;
+- preserved provider UI observations.
+
+Secondary sources may locate evidence but do not substitute for decisive provider-controlled or direct transactional evidence when those are required.
+
+## Claims discipline
+
+A published rate card is not treated as literal request-cost evidence by itself.
+
+Unknown cost is not treated as zero or as high.
+
+Opacity does not establish intent.
+
+A misleading or deceptive-effect finding requires evidence that presented or omitted material cost information creates a materially inaccurate representation of economic consequence.
+
+Intent-based findings require separate evidence.
+
+## Elevated-usage interpretation
+
+The economic relevance of small unit-cost differences increases with repeated use. The study therefore reports standardized workload scenarios rather than treating one consumer prompt as the principal decision environment.
+
+Comparative results will distinguish:
+- exact cost;
+- bounded cost;
+- unresolved exposure;
+- discovery burden;
+- privilege/account barriers;
+- pricing-rule complexity;
+- sensitivity to caching, tools, context, time, routing, or other documented modifiers.
+
+## Results
+
+Pending provider protocol completion.
+
+No ranking is authorized at this stage.
+
+## Contradiction review
+
+Pending.
+
+## Independent review
+
+Pending.
+
+## Limitations
+
+The study distinguishes consumer product surfaces from API/enterprise surfaces where their billing models differ. A provider may be transparent in one channel and opaque in another. Results must therefore remain surface-specific.
+
+Pricing can change over time. Every final result must preserve observation date and pricing-document version or retrieval date.
+
+The study cannot infer undisclosed costs merely from the existence of unresolved variables.
+
+## Publication gate
+
+Publication requires:
+- completed provider protocols for the compared set;
+- validator-clean observations;
+- reproducible scale calculations;
+- contradiction review;
+- independent review;
+- explicit ERL activation/publication decision.

--- a/schemas/ai-economic-transparency-contradiction-review.schema.json
+++ b/schemas/ai-economic-transparency-contradiction-review.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "stegverse.erl.ai-economic-transparency-contradiction-review.v1",
+  "title": "ERL AI Economic Transparency Contradiction Review",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "task_id",
+    "state",
+    "provider_reviews",
+    "promotion_authorized"
+  ],
+  "properties": {
+    "schema": {
+      "const": "stegverse.erl.ai-economic-transparency-contradiction-review/v1"
+    },
+    "task_id": {
+      "const": "ERL-AI-ECON-TRANSPARENCY-001"
+    },
+    "state": {
+      "enum": [
+        "PENDING",
+        "IN_PROGRESS",
+        "COMPLETE"
+      ]
+    },
+    "provider_reviews": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "provider",
+          "observation_ref",
+          "contradictions",
+          "result"
+        ],
+        "properties": {
+          "provider": {
+            "type": "string"
+          },
+          "observation_ref": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "contradictions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "claim",
+                "counterevidence_ref",
+                "effect"
+              ],
+              "properties": {
+                "claim": {
+                  "type": "string"
+                },
+                "counterevidence_ref": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "effect": {
+                  "enum": [
+                    "NONE",
+                    "NARROWS",
+                    "REQUIRES_REVISION",
+                    "INVALIDATES"
+                  ]
+                }
+              }
+            }
+          },
+          "result": {
+            "enum": [
+              "PENDING",
+              "NO_MATERIAL_CONTRADICTION",
+              "REVISE",
+              "REJECT"
+            ]
+          }
+        }
+      }
+    },
+    "promotion_authorized": {
+      "const": false
+    }
+  }
+}

--- a/schemas/ai-economic-transparency-independent-review.schema.json
+++ b/schemas/ai-economic-transparency-independent-review.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "stegverse.erl.ai-economic-transparency-independent-review.v1",
+  "title": "ERL AI Economic Transparency Independent Review",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "task_id",
+    "state",
+    "review_scope",
+    "reviewer_independence",
+    "findings",
+    "activation_recommendation",
+    "publication_recommendation"
+  ],
+  "properties": {
+    "schema": {
+      "const": "stegverse.erl.ai-economic-transparency-independent-review/v1"
+    },
+    "task_id": {
+      "const": "ERL-AI-ECON-TRANSPARENCY-001"
+    },
+    "state": {
+      "enum": [
+        "PENDING",
+        "IN_PROGRESS",
+        "COMPLETE"
+      ]
+    },
+    "review_scope": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "reviewer_independence": {
+      "type": "string"
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "required_revisions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "activation_recommendation": {
+      "enum": [
+        "PENDING",
+        "APPROVE",
+        "REVISE",
+        "REJECT"
+      ]
+    },
+    "publication_recommendation": {
+      "enum": [
+        "PENDING",
+        "APPROVE",
+        "REVISE",
+        "REJECT"
+      ]
+    }
+  }
+}

--- a/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
+++ b/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
@@ -18,12 +18,15 @@
   },
   "activation_authorized": false,
   "publication_authorized": false,
-  "next_executable_task": "Continue each provider disclosure protocol to an authentic request-level cost/usage receipt or a governed exhausted-surface terminal state. Then generate exact/bounded scale scenarios and begin contradiction review.",
+  "next_executable_task": "Complete provider disclosure protocols from authentic request-level evidence or governed exhausted-surface determinations; then run scale calculations, contradiction review, independent review, and only then consider activation.",
   "implementation_completion_percent": 60,
   "validator_state": "INSTALLED",
   "fixture_state": "INSTALLED",
   "activation_registry_group": "ERL-RC-AI-ECON-TRANSPARENCY-2026",
   "scale_sensitivity_engine": "scripts/calculate_ai_cost_scale_sensitivity.py",
   "scale_sensitivity_engine_state": "INSTALLED_TESTED_SOURCE_PENDING_HOSTED_VALIDATION",
-  "provider_research_log_state": "5_OF_5_INITIAL_PUBLIC_SOURCE_LOGS_INSTALLED_PROTOCOLS_INCOMPLETE"
+  "provider_research_log_state": "5_OF_5_INITIAL_PUBLIC_SOURCE_LOGS_INSTALLED_PROTOCOLS_INCOMPLETE",
+  "review_execution_surfaces_state": "INSTALLED_PENDING_EMPIRICAL_EXECUTION",
+  "paper_manuscript": "papers/ai-economic-transparency-elevated-usage.md",
+  "paper_state": "METHODS_COMPLETE_RESULTS_PENDING"
 }

--- a/task-state/ERL-AI-ECON-TRANSPARENCY-001.review-state.json
+++ b/task-state/ERL-AI-ECON-TRANSPARENCY-001.review-state.json
@@ -1,0 +1,9 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-review-state/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "contradiction_review_state": "PENDING_PROVIDER_PROTOCOL_COMPLETION",
+  "independent_review_state": "PENDING_CONTRADICTION_REVIEW",
+  "paper_state": "METHODS_COMPLETE_RESULTS_PENDING",
+  "activation_authorized": false,
+  "publication_authorized": false
+}


### PR DESCRIPTION
Closes #97.

Installs the remaining evidence-independent ERL-AI-ECON-TRANSPARENCY-001 review/paper machinery: contradiction-review schema/template, independent-review schema/template, machine-readable review state, companion paper manuscript, task/handoff updates, and validation coverage.

Results/reviews remain pending empirical provider protocols. No activation or publication is claimed.