### PR TITLE
Reconcile exhausted consumer cost surfaces into ERL

### DIFF
--- a/config/ai-economic-transparency-source-queue.v1.json
+++ b/config/ai-economic-transparency-source-queue.v1.json
@@ -5,48 +5,63 @@
     "independent_reconstruction_required": true,
     "inherit_upstream_conclusions": false,
     "final_score_requires_protocol_complete": true,
-    "unknown_cost_must_remain_unknown": true
+    "unknown_cost_must_remain_unknown": true,
+    "repeat_capture_rule": "DO_NOT_REPEAT_EXHAUSTED_CONSUMER_SURFACE_RESEARCH_UNLESS_MATERIAL_UI_OR_PROVIDER_DISCLOSURE_CHANGE_IS_OBSERVED",
+    "surface_separation": "CONSUMER_NON_ACCOUNT_ATTRIBUTED_AND_API_ENTERPRISE_SURFACES_MUST_BE_SCORED_SEPARATELY"
   },
   "providers": [
     {
       "provider": "openai",
       "model_seed": "gpt-5.6-sol",
-      "state": "PUBLIC_DOCS_ACQUIRED_PROTOCOL_IN_PROGRESS",
+      "state": "CONSUMER_SURFACE_EXHAUSTED_API_DOCS_AVAILABLE_REQUEST_RECEIPT_UNOBSERVED",
       "upstream_evidence": "GCAT-BCAT-Engine/workflows:openai-ui-candidate-observation-2026-09-03.json",
-      "next": "Obtain authentic request-level usage/cost evidence or exhaust accessible account/billing surfaces; then complete rating and scale scenarios.",
-      "research_log": "research-data/ai-economic-transparency/openai-research-log.2026-09-03.json"
+      "next": "Do not repeat consumer-surface capture. Continue only distinct API/enterprise/documentation analysis or react to a materially changed provider surface.",
+      "research_log": "research-data/ai-economic-transparency/openai-research-log.2026-09-03.json",
+      "consumer_surface_state": "HISTORICALLY_EXHAUSTED_NO_REQUEST_ATTRIBUTABLE_COST_OR_EXACT_USAGE_OBSERVED",
+      "consumer_surface_prior_authority": "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence-request.json",
+      "consumer_surface_repeat_required": false
     },
     {
       "provider": "anthropic",
       "model_seed": "claude-opus-5",
-      "state": "PUBLIC_DOCS_ACQUIRED_PROTOCOL_IN_PROGRESS",
+      "state": "CONSUMER_SURFACE_EXHAUSTED_API_DOCS_AVAILABLE_REQUEST_RECEIPT_UNOBSERVED",
       "upstream_evidence": "GCAT-BCAT-Engine/workflows:anthropic-ui-candidate-observation-2026-09-03.json",
-      "next": "Obtain authentic request-level usage/cost evidence or exhaust accessible account/billing surfaces; then complete rating and scale scenarios.",
-      "research_log": "research-data/ai-economic-transparency/anthropic-research-log.2026-09-03.json"
+      "next": "Do not repeat consumer-surface capture. Continue only distinct API/enterprise/documentation analysis or react to a materially changed provider surface.",
+      "research_log": "research-data/ai-economic-transparency/anthropic-research-log.2026-09-03.json",
+      "consumer_surface_state": "HISTORICALLY_EXHAUSTED_NO_REQUEST_ATTRIBUTABLE_COST_OR_EXACT_USAGE_OBSERVED",
+      "consumer_surface_prior_authority": "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence-request.json",
+      "consumer_surface_repeat_required": false
     },
     {
       "provider": "deepseek",
       "model_seed": null,
-      "state": "PUBLIC_DOCS_ACQUIRED_MODEL_AND_EXECUTION_EVIDENCE_PENDING",
+      "state": "CONSUMER_SURFACE_EXHAUSTED_MODEL_IDENTITY_UNRESOLVED_API_DOCS_AVAILABLE",
       "upstream_evidence": "GCAT-BCAT-Engine/workflows:deepseek-ui-candidate-observation-2026-09-03.json",
-      "next": "Resolve exact consumer model identity and obtain authentic request-level usage/cost evidence before final scoring.",
-      "research_log": "research-data/ai-economic-transparency/deepseek-research-log.2026-09-03.json"
+      "next": "Do not repeat consumer-surface capture. Continue only distinct API/enterprise/documentation analysis or react to a materially changed provider surface.",
+      "research_log": "research-data/ai-economic-transparency/deepseek-research-log.2026-09-03.json",
+      "consumer_surface_state": "HISTORICALLY_EXHAUSTED_NO_REQUEST_ATTRIBUTABLE_COST_OR_EXACT_USAGE_OBSERVED",
+      "consumer_surface_prior_authority": "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence-request.json",
+      "consumer_surface_repeat_required": false
     },
     {
       "provider": "zai",
       "model_seed": "GLM-5.3-Flash",
-      "state": "PUBLIC_PLATFORM_LOCATED_RATE_AND_USAGE_RECONSTRUCTION_INCOMPLETE",
+      "state": "CONSUMER_SURFACE_CURRENTLY_OPAQUE_PUBLIC_PLATFORM_COST_RECONSTRUCTION_INCOMPLETE",
       "upstream_evidence": "GCAT-BCAT-Engine/workflows:glm-hosted-ui-candidate-observation-2026-09-03.json",
-      "next": "Continue official billing/transparency discovery or exhaust accessible surfaces; do not infer a GLM request rate from usage-bundle marketing.",
-      "research_log": "research-data/ai-economic-transparency/zai-research-log.2026-09-03.json"
+      "next": "Do not repeat consumer-surface capture. Continue only distinct official API/billing/documentation analysis or react to a materially changed provider surface.",
+      "research_log": "research-data/ai-economic-transparency/zai-research-log.2026-09-03.json",
+      "consumer_surface_state": "CURRENT_2026_09_03_OBSERVATION_NO_REQUEST_ATTRIBUTABLE_COST_OR_USAGE_EXPOSED",
+      "consumer_surface_repeat_required": false
     },
     {
       "provider": "perplexity",
       "model_seed": null,
-      "state": "PUBLIC_DOCS_DIRECT_COST_FIELD_DOCUMENTED_EXECUTION_UNOBSERVED",
+      "state": "CONSUMER_SURFACE_CURRENTLY_OPAQUE_AGENT_API_DIRECT_COST_FIELD_DOCUMENTED",
       "upstream_evidence": "GCAT-BCAT-Engine/workflows:perplexity-ui-candidate-observation-2026-09-03.json",
-      "next": "Obtain an authentic Agent API request receipt or exhaust accessible execution evidence before assigning a final DIRECT rating.",
-      "research_log": "research-data/ai-economic-transparency/perplexity-research-log.2026-09-03.json"
+      "next": "Do not repeat consumer-surface capture. Treat Agent API as a separate surface and preserve its direct-cost-field documentation independently.",
+      "research_log": "research-data/ai-economic-transparency/perplexity-research-log.2026-09-03.json",
+      "consumer_surface_state": "CURRENT_SUPPLEMENTAL_RESULT_NO_MODEL_VERSION_OR_REQUEST_ATTRIBUTABLE_COST_USAGE_EXPOSED",
+      "consumer_surface_repeat_required": false
     }
   ]
 }

--- a/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
+++ b/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
@@ -302,3 +302,42 @@ Review/paper branch head `aabd1899d6521dc8c0d63ba0408b3378fea0d644`:
 - Validate Ledger Schemas: run `33766432976` — observed IN_PROGRESS at receipt capture; no success claim is made from that run.
 
 These hosted validations prove the checked source/validation surfaces only. They do not satisfy provider empirical protocols, contradiction review, independent review, activation, or publication.
+
+
+## 2026-09-03 prior-process reconciliation — exhausted consumer surfaces
+
+Issue: #100
+
+The earlier canonical SV-COST cost-evidence process was re-read before continuing this lane.
+
+Prior authority:
+`GCAT-BCAT-Engine/workflows/experiments/sv-cost-program/nine-lane-results/cost-evidence-request.json`
+
+That record already established:
+- OpenAI consumer/plan and aggregate-usage searches did not expose request-attributable SV-RECON-001 cost or exact request usage;
+- Anthropic consumer plan/session/credit observations did not provide a request-attributable delta;
+- DeepSeek remained blocked on admissible request-bound cost evidence;
+- the explicit next-action rule was: **do not repeat already-exhausted plan/aggregate searches unless the UI gains request-level identity, per-message cost, exact tokens, or before/after usage deltas.**
+
+The user has confirmed the same provider surfaces have not materially changed. ERL therefore treats the consumer/non-account-attributed discovery phase as historical completed evidence for OpenAI, Anthropic, and DeepSeek rather than pending user work.
+
+The 2026-09-03 Z.ai/GLM observation likewise exposes no numeric request-attributable usage or cost on the observed hosted consumer surface. The supplemental Perplexity consumer result likewise exposes neither model/version identity nor request-attributable cost/usage. These current observations do not justify repeat consumer capture absent a material surface change.
+
+### Surface-separation rule
+
+Consumer/non-account-attributed product surfaces and API/enterprise billing surfaces are separate research objects.
+
+An API that exposes exact usage or direct cost does **not** erase an opaque consumer surface. Conversely, consumer-surface opacity does not prove the API surface is opaque.
+
+Final reporting must therefore preserve surface-specific findings rather than collapse them into one provider-wide transparency score.
+
+### User-action rule
+
+No repeat provider UI capture is required from the user for the already-exhausted surfaces. Re-opening capture is authorized only when:
+- a provider visibly changes the relevant UI;
+- a new request-attributable cost/usage field appears;
+- exact per-message tokens become exposed;
+- a before/after usage delta becomes attributable to one request; or
+- a materially different provider surface is intentionally added to the study.
+
+This supersedes any current task wording that implied the user should repeat the same consumer-surface process.

--- a/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
+++ b/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
@@ -18,14 +18,14 @@
   },
   "activation_authorized": false,
   "publication_authorized": false,
-  "next_executable_task": "Complete provider disclosure protocols from authentic request-level evidence or governed exhausted-surface determinations; then run scale calculations, contradiction review, independent review, and only then consider activation.",
+  "next_executable_task": "Do not repeat consumer-surface capture. Continue ERL only on distinct API/enterprise/documentation surfaces, scale analysis from admissible evidence, and review execution; reopen consumer capture only on a material provider-surface change.",
   "implementation_completion_percent": 60,
   "validator_state": "INSTALLED",
   "fixture_state": "INSTALLED",
   "activation_registry_group": "ERL-RC-AI-ECON-TRANSPARENCY-2026",
   "scale_sensitivity_engine": "scripts/calculate_ai_cost_scale_sensitivity.py",
   "scale_sensitivity_engine_state": "INSTALLED_HOSTED_VALIDATED",
-  "provider_research_log_state": "5_OF_5_INITIAL_PUBLIC_SOURCE_LOGS_INSTALLED_PROTOCOLS_INCOMPLETE",
+  "provider_research_log_state": "5_OF_5_INITIAL_LOGS_INSTALLED_CONSUMER_SURFACE_REPEATS_CLOSED",
   "review_execution_surfaces_state": "INSTALLED_PENDING_EMPIRICAL_EXECUTION",
   "paper_manuscript": "papers/ai-economic-transparency-elevated-usage.md",
   "paper_state": "METHODS_COMPLETE_RESULTS_PENDING",
@@ -56,5 +56,15 @@
       "id": 33766432976,
       "conclusion": "in_progress_at_observation"
     }
+  },
+  "prior_consumer_surface_reconciliation": {
+    "authority": "GCAT-BCAT-Engine/workflows/experiments/sv-cost-program/nine-lane-results/cost-evidence-request.json",
+    "openai": "HISTORICALLY_EXHAUSTED_NO_REQUEST_ATTRIBUTABLE_COST_OR_EXACT_USAGE",
+    "anthropic": "HISTORICALLY_EXHAUSTED_NO_REQUEST_ATTRIBUTABLE_COST_OR_EXACT_USAGE",
+    "deepseek": "HISTORICALLY_EXHAUSTED_NO_ADMISSIBLE_REQUEST_BOUND_COST",
+    "zai": "CURRENT_OBSERVED_CONSUMER_SURFACE_NO_NUMERIC_REQUEST_COST_OR_USAGE",
+    "perplexity": "CURRENT_SUPPLEMENTAL_CONSUMER_RESULT_NO_REQUEST_COST_USAGE_OR_VERSION",
+    "repeat_user_capture_required": false,
+    "reopen_condition": "MATERIAL_PROVIDER_SURFACE_CHANGE_ONLY"
   }
 }


### PR DESCRIPTION
Closes #100.

Reconciles the prior canonical SV-COST cost-evidence process into ERL-AI-ECON-TRANSPARENCY-001 so already-exhausted consumer/non-account-attributed provider searches are not repeated. Separates consumer and API/enterprise transparency surfaces and closes repeat user capture unless a material provider surface change is observed.