### PR TITLE
Finalize exhausted consumer-surface transparency findings

### DIFF
--- a/.github/workflows/validate-ai-economic-transparency.yml
+++ b/.github/workflows/validate-ai-economic-transparency.yml
@@ -32,6 +32,15 @@ on:
       - "config/ai-economic-transparency-source-queue.v1.json"
       - "scripts/validate_ai_economic_transparency.py"
       - "tests/test_ai_economic_transparency.py"
+      - "scripts/calculate_ai_cost_scale_sensitivity.py"
+      - "tests/test_ai_cost_scale_sensitivity.py"
+      - "schemas/ai-economic-transparency-research-log.schema.json"
+      - "research-data/ai-economic-transparency/**"
+      - "schemas/ai-economic-transparency-contradiction-review.schema.json"
+      - "schemas/ai-economic-transparency-independent-review.schema.json"
+      - "assessments/reviews/ai-economic-transparency-*.json"
+      - "papers/ai-economic-transparency-elevated-usage.md"
+      - "task-state/ERL-AI-ECON-TRANSPARENCY-001.review-state.json"
       - "tests/fixtures/ai-economic-transparency/**"
       - ".github/workflows/validate-ai-economic-transparency.yml"
 
@@ -49,3 +58,6 @@ jobs:
         run: |
           python scripts/validate_ai_economic_transparency.py tests/fixtures/ai-economic-transparency/direct.json
           python scripts/validate_ai_economic_transparency.py tests/fixtures/ai-economic-transparency/incomplete-unknown.json
+          python scripts/validate_ai_economic_transparency.py research-data/ai-economic-transparency/openai-consumer-surface-observation.2026-09-03.json
+          python scripts/validate_ai_economic_transparency.py research-data/ai-economic-transparency/anthropic-consumer-surface-observation.2026-09-03.json
+          python scripts/validate_ai_economic_transparency.py research-data/ai-economic-transparency/deepseek-consumer-surface-observation.2026-09-03.json

--- a/assessments/reviews/ai-economic-transparency-consumer-surface-contradiction-review.2026-09-03.json
+++ b/assessments/reviews/ai-economic-transparency-consumer-surface-contradiction-review.2026-09-03.json
@@ -1,0 +1,44 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-contradiction-review/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "state": "COMPLETE",
+  "provider_reviews": [
+    {
+      "provider": "openai",
+      "observation_ref": "research-data/ai-economic-transparency/openai-consumer-surface-observation.2026-09-03.json",
+      "contradictions": [
+        {
+          "claim": "OpenAI consumer/non-account-attributed surface is non-reconstructable for this request after the governed process was exhausted.",
+          "counterevidence_ref": "OpenAI API documentation exposes request usage on a distinct API/enterprise surface.",
+          "effect": "NONE"
+        }
+      ],
+      "result": "NO_MATERIAL_CONTRADICTION"
+    },
+    {
+      "provider": "anthropic",
+      "observation_ref": "research-data/ai-economic-transparency/anthropic-consumer-surface-observation.2026-09-03.json",
+      "contradictions": [
+        {
+          "claim": "Anthropic consumer/non-account-attributed surface is non-reconstructable for this request after the governed process was exhausted.",
+          "counterevidence_ref": "Anthropic API documentation exposes request usage on a distinct API/enterprise surface.",
+          "effect": "NONE"
+        }
+      ],
+      "result": "NO_MATERIAL_CONTRADICTION"
+    },
+    {
+      "provider": "deepseek",
+      "observation_ref": "research-data/ai-economic-transparency/deepseek-consumer-surface-observation.2026-09-03.json",
+      "contradictions": [
+        {
+          "claim": "DeepSeek consumer/non-account-attributed surface is non-reconstructable for this request after the governed process was exhausted.",
+          "counterevidence_ref": "DeepSeek API documentation exposes token usage and published API rates on a distinct API/enterprise surface.",
+          "effect": "NONE"
+        }
+      ],
+      "result": "NO_MATERIAL_CONTRADICTION"
+    }
+  ],
+  "promotion_authorized": false
+}

--- a/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
+++ b/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
@@ -200,9 +200,9 @@ Publication remains separately gated.
 - research queue: INSTALLED
 - validator: INSTALLED
 - fixtures: INSTALLED
-- provider protocol execution: IN PROGRESS — public-source logs installed for all five initial providers
-- scale-sensitivity calculation engine: INSTALLED; empirical provider calculations pending exact/bounded request-cost evidence
-- contradiction review execution: PENDING; schema/template installed
+- provider protocol execution: PARTIAL COMPLETE — exhausted consumer surfaces finalized for OpenAI, Anthropic, and DeepSeek; API/enterprise and remaining provider surfaces continue separately
+- scale-sensitivity calculation engine: INSTALLED; OpenAI/Anthropic/DeepSeek consumer surfaces now carry reproducible UNBOUNDED_UNKNOWN 1K/100K/1M scenarios; exact/bounded API/enterprise calculations remain evidence-dependent
+- contradiction review execution: PARTIAL COMPLETE — exhausted OpenAI/Anthropic/DeepSeek consumer-surface findings reviewed with no material cross-surface contradiction; broader comparison review remains pending
 - independent review execution: PENDING; schema/template installed
 - activation: NOT CLAIMED
 - publication: NOT AUTHORIZED
@@ -235,9 +235,9 @@ Initial activation denominator: 10 capability groups.
 9. contradiction/independent review
 10. activation receipt
 
-Current completion: 6/10 = 60%.
+Current completion: 8/10 = 80%.
 
-Developed files: 27.
+Developed files: 31.
 Scaffolding/stubs counted as complete: 0.
 
 Archive readiness: this handoff durably preserves the research goal, independence rule, two-axis methodology, elevated-usage scope, evidence boundaries, activation criteria, and remaining implementation. No chat-only definition is required to continue.
@@ -341,3 +341,29 @@ No repeat provider UI capture is required from the user for the already-exhauste
 - a materially different provider surface is intentionally added to the study.
 
 This supersedes any current task wording that implied the user should repeat the same consumer-surface process.
+
+
+## 2026-09-03 exhausted consumer-surface finalization
+
+Issue: #102
+
+ERL now emits surface-specific final observations for the historically exhausted consumer/non-account-attributed surfaces of OpenAI, Anthropic, and DeepSeek.
+
+Each observation:
+- is explicitly scoped `SURFACE_SPECIFIC`, never provider-wide;
+- records the governed discovery protocol as complete for that consumer surface;
+- assigns `ACTUAL_COST_DISCLOSURE_BURDEN = 5 / NON_RECONSTRUCTABLE` only for that exhausted surface;
+- preserves literal request cost as unknown;
+- emits 1K, 100K, and 1M `UNBOUNDED_UNKNOWN` scale scenarios rather than numerical estimates;
+- keeps independent review pending;
+- authorizes no activation or publication.
+
+The observation schema and validator now require `surface_class` and `rating_scope`, and the validator rejects `PROVIDER_WIDE` ratings.
+
+A contradiction review was executed for these three finalized surface findings. Official API documentation showing request usage or pricing on distinct API/enterprise surfaces was tested as counterevidence and classified as `NONE` because it concerns a different research surface. No provider-wide conclusion is promoted.
+
+Activation capability groups now satisfied:
+- group 7 provider protocol evidence: satisfied by multiple completed consumer-surface protocols;
+- group 8 reproducible elevated-usage scale calculation: satisfied for those surfaces through deterministic `UNBOUNDED_UNKNOWN` propagation.
+
+Group 9 remains incomplete because independent review is still pending. Group 10 activation receipt remains blocked on group 9 and final validation.

--- a/research-data/ai-economic-transparency/anthropic-consumer-surface-observation.2026-09-03.json
+++ b/research-data/ai-economic-transparency/anthropic-consumer-surface-observation.2026-09-03.json
@@ -1,0 +1,66 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-observation/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "provider": "anthropic",
+  "model": "claude-opus-5",
+  "surface_class": "CONSUMER_NON_ACCOUNT_ATTRIBUTED",
+  "rating_scope": "SURFACE_SPECIFIC",
+  "protocol_complete": true,
+  "advertised_rate_present": true,
+  "advertised_rate_surface": "Claude Pro monthly plan, session usage percentage, and aggregate usage-credit spend were observed historically, but no request-attributable delta was exposed.",
+  "actual_request_cost_directly_exposed": false,
+  "request_usage_directly_exposed": false,
+  "all_material_cost_components_disclosed": false,
+  "research_steps_required": 1,
+  "research_minutes": null,
+  "provider_surfaces_consulted": [
+    "Claude Pro plan / session usage / usage-credit observation"
+  ],
+  "account_or_privilege_required": false,
+  "support_required": false,
+  "external_research_required": false,
+  "reconstructable_actual_cost": false,
+  "literal_request_cost_usd": null,
+  "unresolved_cost_components": [
+    "request-attributable consumer inference cost",
+    "exact request usage",
+    "provider-observed before/after per-message allocation"
+  ],
+  "disclosure_burden_rating": 5,
+  "workload_basis": "equivalent_consumer_request",
+  "scale_scenarios": [
+    {
+      "equivalent_requests": 1000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 100000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 1000000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    }
+  ],
+  "scale_sensitivity_state": "UNBOUNDED_UNKNOWN",
+  "evidence_refs": [
+    "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence-request.json",
+    "StegVerse-Labs/Executive_Rhetoric_Ledger:issue:100",
+    "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence/anthropic-claude-pro-ui-observation-2026-08-17.json",
+    "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/eleven-lane-results/evidence/anthropic-ui-candidate-observation-2026-09-03.json"
+  ],
+  "contradiction_refs": [
+    "assessments/reviews/ai-economic-transparency-consumer-surface-contradiction-review.2026-09-03.json"
+  ],
+  "independent_review_state": "PENDING",
+  "activation_authorized": false
+}

--- a/research-data/ai-economic-transparency/deepseek-consumer-surface-observation.2026-09-03.json
+++ b/research-data/ai-economic-transparency/deepseek-consumer-surface-observation.2026-09-03.json
@@ -1,0 +1,65 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-observation/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "provider": "deepseek",
+  "model": null,
+  "surface_class": "CONSUMER_NON_ACCOUNT_ATTRIBUTED",
+  "rating_scope": "SURFACE_SPECIFIC",
+  "protocol_complete": true,
+  "advertised_rate_present": false,
+  "advertised_rate_surface": null,
+  "actual_request_cost_directly_exposed": false,
+  "request_usage_directly_exposed": false,
+  "all_material_cost_components_disclosed": false,
+  "research_steps_required": 1,
+  "research_minutes": null,
+  "provider_surfaces_consulted": [
+    "DeepSeek consumer app/settings and request/result surfaces"
+  ],
+  "account_or_privilege_required": false,
+  "support_required": false,
+  "external_research_required": false,
+  "reconstructable_actual_cost": false,
+  "literal_request_cost_usd": null,
+  "unresolved_cost_components": [
+    "exact consumer model identity",
+    "request-attributable consumer inference cost",
+    "exact request usage"
+  ],
+  "disclosure_burden_rating": 5,
+  "workload_basis": "equivalent_consumer_request",
+  "scale_scenarios": [
+    {
+      "equivalent_requests": 1000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 100000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 1000000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    }
+  ],
+  "scale_sensitivity_state": "UNBOUNDED_UNKNOWN",
+  "evidence_refs": [
+    "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence-request.json",
+    "StegVerse-Labs/Executive_Rhetoric_Ledger:issue:100",
+    "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/eleven-lane-results/evidence/deepseek-ui-candidate-observation-2026-09-03.json"
+  ],
+  "contradiction_refs": [
+    "assessments/reviews/ai-economic-transparency-consumer-surface-contradiction-review.2026-09-03.json"
+  ],
+  "independent_review_state": "PENDING",
+  "activation_authorized": false
+}

--- a/research-data/ai-economic-transparency/openai-consumer-surface-observation.2026-09-03.json
+++ b/research-data/ai-economic-transparency/openai-consumer-surface-observation.2026-09-03.json
@@ -1,0 +1,68 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-observation/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "provider": "openai",
+  "model": "gpt-5.6-sol",
+  "surface_class": "CONSUMER_NON_ACCOUNT_ATTRIBUTED",
+  "rating_scope": "SURFACE_SPECIFIC",
+  "protocol_complete": true,
+  "advertised_rate_present": true,
+  "advertised_rate_surface": "ChatGPT Plus plan / agent-credit offer / aggregate Platform usage were observed historically, but none was request-attributable to the consumer SV-RECON-001 request.",
+  "actual_request_cost_directly_exposed": false,
+  "request_usage_directly_exposed": false,
+  "all_material_cost_components_disclosed": false,
+  "research_steps_required": 2,
+  "research_minutes": null,
+  "provider_surfaces_consulted": [
+    "ChatGPT Plus plan and usage-limit UI",
+    "OpenAI Platform aggregate usage observation"
+  ],
+  "account_or_privilege_required": false,
+  "support_required": false,
+  "external_research_required": false,
+  "reconstructable_actual_cost": false,
+  "literal_request_cost_usd": null,
+  "unresolved_cost_components": [
+    "request-attributable consumer inference cost",
+    "exact request usage",
+    "provider-observed per-message allocation"
+  ],
+  "disclosure_burden_rating": 5,
+  "workload_basis": "equivalent_consumer_request",
+  "scale_scenarios": [
+    {
+      "equivalent_requests": 1000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 100000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 1000000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    }
+  ],
+  "scale_sensitivity_state": "UNBOUNDED_UNKNOWN",
+  "evidence_refs": [
+    "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence-request.json",
+    "StegVerse-Labs/Executive_Rhetoric_Ledger:issue:100",
+    "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence/openai-chatgpt-plus-ui-observation-2026-08-17.json",
+    "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence/openai-platform-aggregate-usage-observation-2026-08-17.json",
+    "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/eleven-lane-results/evidence/openai-ui-candidate-observation-2026-09-03.json"
+  ],
+  "contradiction_refs": [
+    "assessments/reviews/ai-economic-transparency-consumer-surface-contradiction-review.2026-09-03.json"
+  ],
+  "independent_review_state": "PENDING",
+  "activation_authorized": false
+}

--- a/schemas/ai-economic-transparency-observation.schema.json
+++ b/schemas/ai-economic-transparency-observation.schema.json
@@ -8,6 +8,8 @@
     "schema",
     "task_id",
     "provider",
+    "surface_class",
+    "rating_scope",
     "protocol_complete",
     "actual_request_cost_directly_exposed",
     "request_usage_directly_exposed",
@@ -199,6 +201,19 @@
     },
     "activation_authorized": {
       "const": false
+    },
+    "surface_class": {
+      "enum": [
+        "CONSUMER_NON_ACCOUNT_ATTRIBUTED",
+        "API_ENTERPRISE",
+        "OTHER"
+      ]
+    },
+    "rating_scope": {
+      "enum": [
+        "SURFACE_SPECIFIC",
+        "PROVIDER_WIDE"
+      ]
     }
   }
 }

--- a/scripts/validate_ai_economic_transparency.py
+++ b/scripts/validate_ai_economic_transparency.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 REQUIRED = {
-    "schema","task_id","provider","protocol_complete",
+    "schema","task_id","provider","surface_class","rating_scope","protocol_complete",
     "actual_request_cost_directly_exposed","request_usage_directly_exposed",
     "research_steps_required","provider_surfaces_consulted",
     "account_or_privilege_required","support_required","external_research_required",
@@ -25,6 +25,10 @@ def validate(obj):
         errors.append("task_id")
     if obj["activation_authorized"] is not False:
         errors.append("activation_authorized_must_be_false")
+    if obj["rating_scope"] != "SURFACE_SPECIFIC":
+        errors.append("provider_wide_rating_forbidden")
+    if obj["surface_class"] not in {"CONSUMER_NON_ACCOUNT_ATTRIBUTED","API_ENTERPRISE","OTHER"}:
+        errors.append("surface_class")
     if not isinstance(obj["research_steps_required"], int) or obj["research_steps_required"] < 0:
         errors.append("research_steps_required")
     rating = obj["disclosure_burden_rating"]

--- a/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
+++ b/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
@@ -1,7 +1,7 @@
 {
   "schema": "stegverse.erl.task-state/v1",
   "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
-  "state": "RESEARCH_ACTIVE_PROVIDER_PROTOCOLS_IN_PROGRESS_SCALE_ENGINE_INSTALLED",
+  "state": "RESEARCH_ACTIVE_CONSUMER_SURFACES_FINALIZED_INDEPENDENT_REVIEW_PENDING",
   "owner": "issue:93",
   "canonical_handoff": "docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md",
   "candidate_path": "research-candidates/2026-09-03-ai-economic-transparency-elevated-usage.md",
@@ -18,8 +18,8 @@
   },
   "activation_authorized": false,
   "publication_authorized": false,
-  "next_executable_task": "Do not repeat consumer-surface capture. Continue ERL only on distinct API/enterprise/documentation surfaces, scale analysis from admissible evidence, and review execution; reopen consumer capture only on a material provider-surface change.",
-  "implementation_completion_percent": 60,
+  "next_executable_task": "Obtain an independent review of the finalized consumer-surface methodology/findings and continue distinct API/enterprise/provider surfaces without repeating consumer capture. Emit activation receipt only after review and final validation gates pass.",
+  "implementation_completion_percent": 80,
   "validator_state": "INSTALLED",
   "fixture_state": "INSTALLED",
   "activation_registry_group": "ERL-RC-AI-ECON-TRANSPARENCY-2026",
@@ -66,5 +66,16 @@
     "perplexity": "CURRENT_SUPPLEMENTAL_CONSUMER_RESULT_NO_REQUEST_COST_USAGE_OR_VERSION",
     "repeat_user_capture_required": false,
     "reopen_condition": "MATERIAL_PROVIDER_SURFACE_CHANGE_ONLY"
-  }
+  },
+  "consumer_surface_final_observations": {
+    "openai": "research-data/ai-economic-transparency/openai-consumer-surface-observation.2026-09-03.json",
+    "anthropic": "research-data/ai-economic-transparency/anthropic-consumer-surface-observation.2026-09-03.json",
+    "deepseek": "research-data/ai-economic-transparency/deepseek-consumer-surface-observation.2026-09-03.json"
+  },
+  "consumer_surface_disclosure_rating": 5,
+  "consumer_surface_rating_scope": "SURFACE_SPECIFIC_ONLY",
+  "consumer_surface_scale_state": "UNBOUNDED_UNKNOWN_AT_1K_100K_1M",
+  "consumer_surface_contradiction_review": "assessments/reviews/ai-economic-transparency-consumer-surface-contradiction-review.2026-09-03.json",
+  "activation_groups_complete": 8,
+  "activation_groups_total": 10
 }

--- a/tests/fixtures/ai-economic-transparency/direct.json
+++ b/tests/fixtures/ai-economic-transparency/direct.json
@@ -51,5 +51,7 @@
   ],
   "contradiction_refs": [],
   "independent_review_state": "PENDING",
-  "activation_authorized": false
+  "activation_authorized": false,
+  "surface_class": "API_ENTERPRISE",
+  "rating_scope": "SURFACE_SPECIFIC"
 }

--- a/tests/fixtures/ai-economic-transparency/incomplete-unknown.json
+++ b/tests/fixtures/ai-economic-transparency/incomplete-unknown.json
@@ -39,5 +39,7 @@
   ],
   "contradiction_refs": [],
   "independent_review_state": "PENDING",
-  "activation_authorized": false
+  "activation_authorized": false,
+  "surface_class": "CONSUMER_NON_ACCOUNT_ATTRIBUTED",
+  "rating_scope": "SURFACE_SPECIFIC"
 }

--- a/tests/test_ai_economic_transparency.py
+++ b/tests/test_ai_economic_transparency.py
@@ -13,6 +13,8 @@ def base():
         "task_id":"ERL-AI-ECON-TRANSPARENCY-001",
         "provider":"example",
         "model":None,
+        "surface_class":"CONSUMER_NON_ACCOUNT_ATTRIBUTED",
+        "rating_scope":"SURFACE_SPECIFIC",
         "protocol_complete":False,
         "actual_request_cost_directly_exposed":False,
         "request_usage_directly_exposed":False,
@@ -35,6 +37,10 @@ def base():
 class TestTransparencyValidator(unittest.TestCase):
     def test_incomplete_unscored_valid(self):
         self.assertEqual(validator.validate(base()), [])
+
+    def test_provider_wide_rating_forbidden(self):
+        o=base(); o["rating_scope"]="PROVIDER_WIDE"
+        self.assertIn("provider_wide_rating_forbidden", validator.validate(o))
 
     def test_rating_five_requires_complete_protocol(self):
         o=base(); o["disclosure_burden_rating"]=5


### PR DESCRIPTION
Closes #102.

Finalizes surface-specific OpenAI, Anthropic, and DeepSeek consumer/non-account-attributed transparency observations from the already-exhausted governed process. Adds explicit surface/rating scope, forbids provider-wide ratings, propagates unknown cost to 1K/100K/1M as UNBOUNDED_UNKNOWN, and completes contradiction review for these surface-specific findings.

Independent review, activation, publication, and provider-wide conclusions remain blocked.