### PR TITLE
Package AI economic transparency findings for independent review

### DIFF
--- a/assessments/reviews/ai-economic-transparency-consumer-surface-independent-review-package.2026-09-03.json
+++ b/assessments/reviews/ai-economic-transparency-consumer-surface-independent-review-package.2026-09-03.json
@@ -1,0 +1,48 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-independent-review-package/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "review_issue": 104,
+  "review_scope": "FINALIZED_CONSUMER_NON_ACCOUNT_ATTRIBUTED_SURFACES_ONLY",
+  "providers": [
+    "openai",
+    "anthropic",
+    "deepseek"
+  ],
+  "required_inputs": [
+    "docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md",
+    "standards/ai-economic-transparency.v1.md",
+    "schemas/ai-economic-transparency-observation.schema.json",
+    "scripts/validate_ai_economic_transparency.py",
+    "research-data/ai-economic-transparency/openai-consumer-surface-observation.2026-09-03.json",
+    "research-data/ai-economic-transparency/anthropic-consumer-surface-observation.2026-09-03.json",
+    "research-data/ai-economic-transparency/deepseek-consumer-surface-observation.2026-09-03.json",
+    "assessments/reviews/ai-economic-transparency-consumer-surface-contradiction-review.2026-09-03.json",
+    "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence-request.json"
+  ],
+  "review_questions": [
+    "Is each finding strictly surface-specific rather than provider-wide?",
+    "Does the prior governed evidence support treating each consumer surface as exhausted absent material UI change?",
+    "Is NON_RECONSTRUCTABLE / rating 5 warranted for the exhausted consumer surface under the current standard?",
+    "Does UNBOUNDED_UNKNOWN correctly preserve elevated-usage uncertainty without inventing a numeric cost?",
+    "Does distinct API/enterprise transparency leave the consumer-surface finding intact rather than contradict it?",
+    "Are any claims broader than the preserved evidence supports?"
+  ],
+  "forbidden_promotions": [
+    "provider-wide transparency ranking",
+    "provider intent finding",
+    "deceptive-pricing intent finding",
+    "Z.ai or Perplexity final rating",
+    "activation",
+    "publication"
+  ],
+  "required_output": {
+    "schema": "stegverse.erl.ai-economic-transparency-independent-review/v1",
+    "path": "assessments/reviews/ai-economic-transparency-consumer-surface-independent-review.2026-09-03.json",
+    "terminal_recommendation": [
+      "APPROVE",
+      "REVISE",
+      "REJECT"
+    ]
+  },
+  "state": "READY_FOR_INDEPENDENT_REVIEW"
+}

--- a/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
+++ b/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
@@ -367,3 +367,16 @@ Activation capability groups now satisfied:
 - group 8 reproducible elevated-usage scale calculation: satisfied for those surfaces through deterministic `UNBOUNDED_UNKNOWN` propagation.
 
 Group 9 remains incomplete because independent review is still pending. Group 10 activation receipt remains blocked on group 9 and final validation.
+
+
+## 2026-09-03 independent-review package
+
+Issue: #104
+
+A bounded independent-review package is now installed for the finalized OpenAI, Anthropic, and DeepSeek consumer/non-account-attributed findings:
+
+`assessments/reviews/ai-economic-transparency-consumer-surface-independent-review-package.2026-09-03.json`
+
+The package fixes the review scope, required inputs, review questions, forbidden promotions, and required terminal output schema/path. It prevents the independent-review step from expanding into provider-wide ranking, intent claims, Z.ai/Perplexity findings, activation, or publication.
+
+This package makes the remaining review gate machine-addressable, but it is not itself an independent review and does not satisfy capability group 9.

--- a/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
+++ b/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
@@ -18,7 +18,7 @@
   },
   "activation_authorized": false,
   "publication_authorized": false,
-  "next_executable_task": "Obtain an independent review of the finalized consumer-surface methodology/findings and continue distinct API/enterprise/provider surfaces without repeating consumer capture. Emit activation receipt only after review and final validation gates pass.",
+  "next_executable_task": "Independent reviewer executes Issue #104 against the fixed review package and emits the required review record. No consumer recapture is required. Activation remains blocked until that review and final validation pass.",
   "implementation_completion_percent": 80,
   "validator_state": "INSTALLED",
   "fixture_state": "INSTALLED",
@@ -77,5 +77,8 @@
   "consumer_surface_scale_state": "UNBOUNDED_UNKNOWN_AT_1K_100K_1M",
   "consumer_surface_contradiction_review": "assessments/reviews/ai-economic-transparency-consumer-surface-contradiction-review.2026-09-03.json",
   "activation_groups_complete": 8,
-  "activation_groups_total": 10
+  "activation_groups_total": 10,
+  "independent_review_issue": 104,
+  "independent_review_package": "assessments/reviews/ai-economic-transparency-consumer-surface-independent-review-package.2026-09-03.json",
+  "independent_review_state": "READY_FOR_INDEPENDENT_REVIEW"
 }


### PR DESCRIPTION
Creates the fixed independent-review package for the finalized OpenAI, Anthropic, and DeepSeek consumer-surface findings under Issue #104. The package fixes scope, inputs, questions, forbidden promotions, and required output. It does not perform or claim independent review, activation, publication, or provider-wide ranking.