### PR TITLE
Materialize API-enterprise cost transparency observations

### DIFF
--- a/.github/workflows/validate-ai-economic-transparency.yml
+++ b/.github/workflows/validate-ai-economic-transparency.yml
@@ -61,3 +61,8 @@ jobs:
           python scripts/validate_ai_economic_transparency.py research-data/ai-economic-transparency/openai-consumer-surface-observation.2026-09-03.json
           python scripts/validate_ai_economic_transparency.py research-data/ai-economic-transparency/anthropic-consumer-surface-observation.2026-09-03.json
           python scripts/validate_ai_economic_transparency.py research-data/ai-economic-transparency/deepseek-consumer-surface-observation.2026-09-03.json
+          python scripts/validate_ai_economic_transparency.py research-data/ai-economic-transparency/openai-api-enterprise-observation.2026-09-03.json
+          python scripts/validate_ai_economic_transparency.py research-data/ai-economic-transparency/anthropic-api-enterprise-observation.2026-09-03.json
+          python scripts/validate_ai_economic_transparency.py research-data/ai-economic-transparency/deepseek-api-enterprise-observation.2026-09-03.json
+          python scripts/validate_ai_economic_transparency.py research-data/ai-economic-transparency/zai-api-enterprise-observation.2026-09-03.json
+          python scripts/validate_ai_economic_transparency.py research-data/ai-economic-transparency/perplexity-api-enterprise-observation.2026-09-03.json

--- a/config/ai-economic-transparency-source-queue.v1.json
+++ b/config/ai-economic-transparency-source-queue.v1.json
@@ -19,7 +19,10 @@
       "research_log": "research-data/ai-economic-transparency/openai-research-log.2026-09-03.json",
       "consumer_surface_state": "HISTORICALLY_EXHAUSTED_NO_REQUEST_ATTRIBUTABLE_COST_OR_EXACT_USAGE_OBSERVED",
       "consumer_surface_prior_authority": "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence-request.json",
-      "consumer_surface_repeat_required": false
+      "consumer_surface_repeat_required": false,
+      "api_enterprise_observation": "research-data/ai-economic-transparency/openai-api-enterprise-observation.2026-09-03.json",
+      "api_enterprise_protocol_complete": false,
+      "api_enterprise_state": "DOCUMENTED_USAGE_AND_PRICING_REQUEST_RECEIPT_UNOBSERVED"
     },
     {
       "provider": "anthropic",
@@ -30,7 +33,10 @@
       "research_log": "research-data/ai-economic-transparency/anthropic-research-log.2026-09-03.json",
       "consumer_surface_state": "HISTORICALLY_EXHAUSTED_NO_REQUEST_ATTRIBUTABLE_COST_OR_EXACT_USAGE_OBSERVED",
       "consumer_surface_prior_authority": "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence-request.json",
-      "consumer_surface_repeat_required": false
+      "consumer_surface_repeat_required": false,
+      "api_enterprise_observation": "research-data/ai-economic-transparency/anthropic-api-enterprise-observation.2026-09-03.json",
+      "api_enterprise_protocol_complete": false,
+      "api_enterprise_state": "DOCUMENTED_USAGE_AND_PRICING_REQUEST_RECEIPT_UNOBSERVED"
     },
     {
       "provider": "deepseek",
@@ -41,7 +47,10 @@
       "research_log": "research-data/ai-economic-transparency/deepseek-research-log.2026-09-03.json",
       "consumer_surface_state": "HISTORICALLY_EXHAUSTED_NO_REQUEST_ATTRIBUTABLE_COST_OR_EXACT_USAGE_OBSERVED",
       "consumer_surface_prior_authority": "GCAT-BCAT-Engine/workflows:experiments/sv-cost-program/nine-lane-results/cost-evidence-request.json",
-      "consumer_surface_repeat_required": false
+      "consumer_surface_repeat_required": false,
+      "api_enterprise_observation": "research-data/ai-economic-transparency/deepseek-api-enterprise-observation.2026-09-03.json",
+      "api_enterprise_protocol_complete": false,
+      "api_enterprise_state": "DOCUMENTED_USAGE_AND_PRICING_MODEL_BINDING_AND_REQUEST_RECEIPT_UNOBSERVED"
     },
     {
       "provider": "zai",
@@ -51,7 +60,10 @@
       "next": "Do not repeat consumer-surface capture. Continue only distinct official API/billing/documentation analysis or react to a materially changed provider surface.",
       "research_log": "research-data/ai-economic-transparency/zai-research-log.2026-09-03.json",
       "consumer_surface_state": "CURRENT_2026_09_03_OBSERVATION_NO_REQUEST_ATTRIBUTABLE_COST_OR_USAGE_EXPOSED",
-      "consumer_surface_repeat_required": false
+      "consumer_surface_repeat_required": false,
+      "api_enterprise_observation": "research-data/ai-economic-transparency/zai-api-enterprise-observation.2026-09-03.json",
+      "api_enterprise_protocol_complete": false,
+      "api_enterprise_state": "PUBLIC_PLATFORM_INSUFFICIENT_FOR_REQUEST_COST_RECONSTRUCTION"
     },
     {
       "provider": "perplexity",
@@ -61,7 +73,10 @@
       "next": "Do not repeat consumer-surface capture. Treat Agent API as a separate surface and preserve its direct-cost-field documentation independently.",
       "research_log": "research-data/ai-economic-transparency/perplexity-research-log.2026-09-03.json",
       "consumer_surface_state": "CURRENT_SUPPLEMENTAL_RESULT_NO_MODEL_VERSION_OR_REQUEST_ATTRIBUTABLE_COST_USAGE_EXPOSED",
-      "consumer_surface_repeat_required": false
+      "consumer_surface_repeat_required": false,
+      "api_enterprise_observation": "research-data/ai-economic-transparency/perplexity-api-enterprise-observation.2026-09-03.json",
+      "api_enterprise_protocol_complete": false,
+      "api_enterprise_state": "DOCUMENTED_DIRECT_COST_OBJECT_AUTHENTIC_REQUEST_RECEIPT_UNOBSERVED"
     }
   ]
 }

--- a/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
+++ b/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
@@ -405,3 +405,28 @@ The previously observed PR #105 validation state is now fully resolved:
 - Validate Ledger Schemas run `33772683540` — SUCCESS
 
 These validation receipts prove source/schema/task consistency only. They do not satisfy independent review or activation.
+
+
+## 2026-09-03 API/enterprise surface materialization
+
+Issue: #108
+
+Surface-specific API/enterprise observations are now materialized for all five initial providers:
+- OpenAI
+- Anthropic
+- DeepSeek
+- Z.ai / GLM
+- supplemental Perplexity
+
+These records convert the already-preserved official-document research into machine-readable `API_ENTERPRISE` observations without assigning final scores.
+
+Current boundaries:
+- OpenAI: official API usage and pricing behavior documented; authentic bounded SV-RECON-001 API receipt remains unobserved.
+- Anthropic: official API usage and pricing behavior documented; authentic bounded SV-RECON-001 API receipt remains unobserved.
+- DeepSeek: official API usage and pricing behavior documented; exact comparison-model binding and authentic bounded API receipt remain unobserved.
+- Z.ai: preserved public platform material remains insufficient to reconstruct a request-level GLM-5.3-Flash cost basis.
+- Perplexity: official Agent API documentation specifies a direct per-response cost object, but no authentic bounded SV-RECON-001 Agent API receipt has been observed.
+
+All five API/enterprise protocols therefore remain `protocol_complete=false` with no final disclosure-burden rating. Their scale state remains `UNBOUNDED_UNKNOWN` until authentic exact/bounded request evidence exists.
+
+No consumer recapture was performed or reopened. API/enterprise observations remain separate from finalized consumer-surface findings.

--- a/research-data/ai-economic-transparency/anthropic-api-enterprise-observation.2026-09-03.json
+++ b/research-data/ai-economic-transparency/anthropic-api-enterprise-observation.2026-09-03.json
@@ -1,0 +1,63 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-observation/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "provider": "anthropic",
+  "model": "claude-opus-5",
+  "surface_class": "API_ENTERPRISE",
+  "rating_scope": "SURFACE_SPECIFIC",
+  "protocol_complete": false,
+  "advertised_rate_present": true,
+  "advertised_rate_surface": "Official Claude Platform pricing documentation.",
+  "actual_request_cost_directly_exposed": false,
+  "request_usage_directly_exposed": true,
+  "all_material_cost_components_disclosed": null,
+  "research_steps_required": 2,
+  "research_minutes": null,
+  "provider_surfaces_consulted": [
+    "official Claude Platform pricing documentation",
+    "official Claude API usage example"
+  ],
+  "account_or_privilege_required": false,
+  "support_required": false,
+  "external_research_required": false,
+  "reconstructable_actual_cost": false,
+  "literal_request_cost_usd": null,
+  "unresolved_cost_components": [
+    "authentic SV-RECON-001 API request usage/receipt",
+    "literal request-attributable API cost"
+  ],
+  "disclosure_burden_rating": null,
+  "workload_basis": "equivalent_api_request",
+  "scale_scenarios": [
+    {
+      "equivalent_requests": 1000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 100000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 1000000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    }
+  ],
+  "scale_sensitivity_state": "UNBOUNDED_UNKNOWN",
+  "evidence_refs": [
+    "research-data/ai-economic-transparency/anthropic-research-log.2026-09-03.json",
+    "https://platform.claude.com/docs/en/about-claude/pricing",
+    "https://platform.claude.com/docs/en/claude_api_primer"
+  ],
+  "contradiction_refs": [],
+  "independent_review_state": "PENDING",
+  "activation_authorized": false
+}

--- a/research-data/ai-economic-transparency/deepseek-api-enterprise-observation.2026-09-03.json
+++ b/research-data/ai-economic-transparency/deepseek-api-enterprise-observation.2026-09-03.json
@@ -1,0 +1,64 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-observation/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "provider": "deepseek",
+  "model": null,
+  "surface_class": "API_ENTERPRISE",
+  "rating_scope": "SURFACE_SPECIFIC",
+  "protocol_complete": false,
+  "advertised_rate_present": true,
+  "advertised_rate_surface": "Official DeepSeek API pricing documentation.",
+  "actual_request_cost_directly_exposed": false,
+  "request_usage_directly_exposed": true,
+  "all_material_cost_components_disclosed": null,
+  "research_steps_required": 2,
+  "research_minutes": null,
+  "provider_surfaces_consulted": [
+    "official API pricing documentation",
+    "official API token-usage documentation"
+  ],
+  "account_or_privilege_required": false,
+  "support_required": false,
+  "external_research_required": false,
+  "reconstructable_actual_cost": false,
+  "literal_request_cost_usd": null,
+  "unresolved_cost_components": [
+    "exact API model identity matching the consumer comparison",
+    "authentic SV-RECON-001 API request usage/receipt",
+    "literal request-attributable API cost"
+  ],
+  "disclosure_burden_rating": null,
+  "workload_basis": "equivalent_api_request",
+  "scale_scenarios": [
+    {
+      "equivalent_requests": 1000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 100000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 1000000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    }
+  ],
+  "scale_sensitivity_state": "UNBOUNDED_UNKNOWN",
+  "evidence_refs": [
+    "research-data/ai-economic-transparency/deepseek-research-log.2026-09-03.json",
+    "https://api-docs.deepseek.com/quick_start/pricing/",
+    "https://api-docs.deepseek.com/quick_start/token_usage/"
+  ],
+  "contradiction_refs": [],
+  "independent_review_state": "PENDING",
+  "activation_authorized": false
+}

--- a/research-data/ai-economic-transparency/openai-api-enterprise-observation.2026-09-03.json
+++ b/research-data/ai-economic-transparency/openai-api-enterprise-observation.2026-09-03.json
@@ -1,0 +1,63 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-observation/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "provider": "openai",
+  "model": "gpt-5.6-sol",
+  "surface_class": "API_ENTERPRISE",
+  "rating_scope": "SURFACE_SPECIFIC",
+  "protocol_complete": false,
+  "advertised_rate_present": true,
+  "advertised_rate_surface": "Official GPT-5.6 Sol API model pricing documentation.",
+  "actual_request_cost_directly_exposed": false,
+  "request_usage_directly_exposed": true,
+  "all_material_cost_components_disclosed": null,
+  "research_steps_required": 2,
+  "research_minutes": null,
+  "provider_surfaces_consulted": [
+    "official model pricing documentation",
+    "official API usage/cost documentation"
+  ],
+  "account_or_privilege_required": false,
+  "support_required": false,
+  "external_research_required": false,
+  "reconstructable_actual_cost": false,
+  "literal_request_cost_usd": null,
+  "unresolved_cost_components": [
+    "authentic SV-RECON-001 API request usage/receipt",
+    "literal request-attributable API cost"
+  ],
+  "disclosure_burden_rating": null,
+  "workload_basis": "equivalent_api_request",
+  "scale_scenarios": [
+    {
+      "equivalent_requests": 1000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 100000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 1000000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    }
+  ],
+  "scale_sensitivity_state": "UNBOUNDED_UNKNOWN",
+  "evidence_refs": [
+    "research-data/ai-economic-transparency/openai-research-log.2026-09-03.json",
+    "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+    "https://help.openai.com/en/articles/10478918-reviewing-api-usage-and-costs"
+  ],
+  "contradiction_refs": [],
+  "independent_review_state": "PENDING",
+  "activation_authorized": false
+}

--- a/research-data/ai-economic-transparency/perplexity-api-enterprise-observation.2026-09-03.json
+++ b/research-data/ai-economic-transparency/perplexity-api-enterprise-observation.2026-09-03.json
@@ -1,0 +1,63 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-observation/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "provider": "perplexity",
+  "model": null,
+  "surface_class": "API_ENTERPRISE",
+  "rating_scope": "SURFACE_SPECIFIC",
+  "protocol_complete": false,
+  "advertised_rate_present": true,
+  "advertised_rate_surface": "Official Perplexity Agent API pricing documentation.",
+  "actual_request_cost_directly_exposed": true,
+  "request_usage_directly_exposed": true,
+  "all_material_cost_components_disclosed": null,
+  "research_steps_required": 2,
+  "research_minutes": null,
+  "provider_surfaces_consulted": [
+    "official Agent API pricing documentation",
+    "official Agent API response documentation"
+  ],
+  "account_or_privilege_required": false,
+  "support_required": false,
+  "external_research_required": false,
+  "reconstructable_actual_cost": false,
+  "literal_request_cost_usd": null,
+  "unresolved_cost_components": [
+    "authentic SV-RECON-001 Agent API execution/receipt",
+    "exact model/version bound to the supplemental consumer comparison"
+  ],
+  "disclosure_burden_rating": null,
+  "workload_basis": "equivalent_api_request",
+  "scale_scenarios": [
+    {
+      "equivalent_requests": 1000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 100000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 1000000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    }
+  ],
+  "scale_sensitivity_state": "UNBOUNDED_UNKNOWN",
+  "evidence_refs": [
+    "research-data/ai-economic-transparency/perplexity-research-log.2026-09-03.json",
+    "https://docs.perplexity.ai/docs/getting-started/pricing",
+    "https://docs.perplexity.ai/api-reference/agent-post"
+  ],
+  "contradiction_refs": [],
+  "independent_review_state": "PENDING",
+  "activation_authorized": false
+}

--- a/research-data/ai-economic-transparency/zai-api-enterprise-observation.2026-09-03.json
+++ b/research-data/ai-economic-transparency/zai-api-enterprise-observation.2026-09-03.json
@@ -1,0 +1,62 @@
+{
+  "schema": "stegverse.erl.ai-economic-transparency-observation/v1",
+  "task_id": "ERL-AI-ECON-TRANSPARENCY-001",
+  "provider": "zai",
+  "model": "GLM-5.3-Flash",
+  "surface_class": "API_ENTERPRISE",
+  "rating_scope": "SURFACE_SPECIFIC",
+  "protocol_complete": false,
+  "advertised_rate_present": null,
+  "advertised_rate_surface": "Public Z.ai model/API platform surface exposed usage bundles but no request-level GLM-5.3-Flash rate basis sufficient for reconstruction in the preserved research pass.",
+  "actual_request_cost_directly_exposed": false,
+  "request_usage_directly_exposed": false,
+  "all_material_cost_components_disclosed": false,
+  "research_steps_required": 1,
+  "research_minutes": null,
+  "provider_surfaces_consulted": [
+    "public Z.ai model/API platform surface"
+  ],
+  "account_or_privilege_required": false,
+  "support_required": false,
+  "external_research_required": false,
+  "reconstructable_actual_cost": false,
+  "literal_request_cost_usd": null,
+  "unresolved_cost_components": [
+    "request-level GLM-5.3-Flash pricing basis",
+    "authentic request usage/receipt",
+    "literal request-attributable API cost"
+  ],
+  "disclosure_burden_rating": null,
+  "workload_basis": "equivalent_api_request",
+  "scale_scenarios": [
+    {
+      "equivalent_requests": 1000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 100000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    },
+    {
+      "equivalent_requests": 1000000,
+      "state": "UNBOUNDED_UNKNOWN",
+      "known_total_cost_usd": null,
+      "lower_bound_usd": null,
+      "upper_bound_usd": null
+    }
+  ],
+  "scale_sensitivity_state": "UNBOUNDED_UNKNOWN",
+  "evidence_refs": [
+    "research-data/ai-economic-transparency/zai-research-log.2026-09-03.json",
+    "https://z.ai/model-api"
+  ],
+  "contradiction_refs": [],
+  "independent_review_state": "PENDING",
+  "activation_authorized": false
+}

--- a/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
+++ b/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
@@ -18,7 +18,7 @@
   },
   "activation_authorized": false,
   "publication_authorized": false,
-  "next_executable_task": "Independent reviewer executes Issue #104 against the fixed review package. In parallel, distinct API/enterprise and Z.ai/Perplexity research may continue without repeating exhausted consumer capture. Activation remains blocked until independent review and final validation pass.",
+  "next_executable_task": "Independent reviewer executes Issue #104. Distinct API/enterprise protocols remain evidence-dependent on authentic request receipts or governed exhausted-surface determinations; no consumer recapture is required.",
   "implementation_completion_percent": 80,
   "validator_state": "INSTALLED",
   "fixture_state": "INSTALLED",
@@ -94,5 +94,13 @@
   "independent_review_issue": 104,
   "independent_review_package": "assessments/reviews/ai-economic-transparency-consumer-surface-independent-review-package.2026-09-03.json",
   "independent_review_state": "READY_FOR_INDEPENDENT_REVIEW",
-  "candidate_results": "research-data/ai-economic-transparency/candidate-results.consumer-surfaces.2026-09-03.json"
+  "candidate_results": "research-data/ai-economic-transparency/candidate-results.consumer-surfaces.2026-09-03.json",
+  "api_enterprise_observations": {
+    "openai": "research-data/ai-economic-transparency/openai-api-enterprise-observation.2026-09-03.json",
+    "anthropic": "research-data/ai-economic-transparency/anthropic-api-enterprise-observation.2026-09-03.json",
+    "deepseek": "research-data/ai-economic-transparency/deepseek-api-enterprise-observation.2026-09-03.json",
+    "zai": "research-data/ai-economic-transparency/zai-api-enterprise-observation.2026-09-03.json",
+    "perplexity": "research-data/ai-economic-transparency/perplexity-api-enterprise-observation.2026-09-03.json"
+  },
+  "api_enterprise_observation_state": "5_OF_5_MATERIALIZED_PROTOCOLS_INCOMPLETE_NO_FINAL_RATINGS"
 }


### PR DESCRIPTION
Closes #108.

Materializes surface-specific API/enterprise observations for OpenAI, Anthropic, DeepSeek, Z.ai, and supplemental Perplexity from already-preserved official documentation. All remain protocol-incomplete and unscored absent authentic request-bound execution/receipts or governed exhausted-surface determinations.

No consumer recapture, provider-wide rating, activation, publication, or intent claim is introduced.