### PR TITLE
Bind resident-review dispatch validation receipts

### DIFF
--- a/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
+++ b/docs/AI_ECONOMIC_TRANSPARENCY_MIRROR_HANDOFF.md
@@ -551,3 +551,21 @@ The authentic review receipt remains unobserved:
 `receipts/erl-ai-economic-transparency-review/SHWP-ERL-AI-ECON-TRANSPARENCY-REVIEW-001.json`
 
 Therefore independent review, activation, and publication remain unclaimed.
+
+
+## 2026-09-03 final resident-dispatch validation receipts
+
+Issue: #118
+
+PR #117 / head `39a74b7227ca8d9478324d85b3989a3cfe0d73c2` completed all observed ERL validation surfaces successfully:
+
+- Validate AI economic transparency: run `33784383315` — SUCCESS
+- Validate durable task state: run `33784383397` — SUCCESS
+- Validate Ledger Schemas: run `33784383350` — SUCCESS
+
+These receipts establish source/schema/task-state consistency for the resident-review dispatch integration only. They do not establish that the resident reviewer executed.
+
+The authentic runtime receipt remains absent:
+`receipts/erl-ai-economic-transparency-review/SHWP-ERL-AI-ECON-TRANSPARENCY-REVIEW-001.json`
+
+No independent-review completion, activation, or publication is inferred.

--- a/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
+++ b/task-state/ERL-AI-ECON-TRANSPARENCY-001.json
@@ -68,6 +68,19 @@
     "independent_review_package_ledger_schemas_run": {
       "id": 33772683540,
       "conclusion": "success"
+    },
+    "resident_review_dispatch_head": "39a74b7227ca8d9478324d85b3989a3cfe0d73c2",
+    "resident_review_dispatch_ai_transparency_run": {
+      "id": 33784383315,
+      "conclusion": "success"
+    },
+    "resident_review_dispatch_task_state_run": {
+      "id": 33784383397,
+      "conclusion": "success"
+    },
+    "resident_review_dispatch_ledger_schemas_run": {
+      "id": 33784383350,
+      "conclusion": "success"
     }
   },
   "prior_consumer_surface_reconciliation": {
@@ -172,7 +185,8 @@
           "id": 33784113903,
           "conclusion": "success"
         }
-      }
+      },
+      "source_control_validation_complete": true
     }
   }
 }


### PR DESCRIPTION
Closes #118.

Records the three successful PR #117 validation receipts in the canonical ERL transparency handoff/task state. These establish source/schema/task consistency only; the authentic fenced resident independent-review receipt remains unobserved and no review completion, activation, or publication is inferred.