### PR TITLE
Bind ERL producer records to canonical provenance references

### DIFF
--- a/docs/CANONICAL_OBJECT_PROVENANCE_REFERENCE_MIRROR_HANDOFF.md
+++ b/docs/CANONICAL_OBJECT_PROVENANCE_REFERENCE_MIRROR_HANDOFF.md
@@ -1,0 +1,87 @@
+# ERL Canonical Object Provenance Reference MIRROR_HANDOFF
+
+Updated: 2026-09-05
+Repository: `StegVerse-Labs/Executive_Rhetoric_Ledger`
+Parent candidate owner: issue #63
+Upstream canonical provenance owner: `StegVerse-Labs/StegOS#190`
+Canonical lineage schema: `stegos.object_provenance_lineage.v1`
+Authority effect: `NONE`
+
+## Machine preflight
+
+Resolved before functional mutation:
+
+- repository continuity authority: `ERL_MIRROR_HANDOFF.md`;
+- bounded Orli candidate authority: `docs/ORLI_SHULL_AI_GOVERNANCE_COLLAPSE_MIRROR_HANDOFF.md` / issue #63;
+- research-candidate activation authority: `docs/RESEARCH_CANDIDATE_ACTIVATION_MIRROR_HANDOFF.md` and `coordination/research-candidate-activation-registry.v1.json`;
+- canonical source-object provenance authority: `StegVerse-Labs/StegOS#190` / `stegos.object_provenance_lineage.v1`;
+- Master Records: custody/reconstruction only;
+- ERL: downstream research-candidate/assessment producer only;
+- Workspace/Site/task registries: downstream references/projections only;
+- TV/TVC credential authority remains unchanged.
+
+Open-PR collision review found no active ERL PR claiming `schemas/canonical-provenance-reference.schema.json`, `scripts/validate_canonical_provenance_reference.py`, `tests/test_canonical_provenance_reference.py`, or this handoff. Existing open ERL research and automation PRs retain their own bounded surfaces.
+
+## Purpose
+
+Issue #190 requires downstream ERL/task/artifact producers to reference canonical receipt-bound provenance rather than prose-only source posture. ERL must not recreate the canonical provenance graph or mint competing object, edge, lineage, transition-receipt, or custody identities.
+
+This change therefore adds a reference-only ERL boundary:
+
+```text
+canonical StegOS lineage
+  -> ERL reference record
+  -> research candidate / assessment producer
+```
+
+The ERL record may carry only canonical IDs and receipt references already produced by the authority-owned lineage path. It cannot contain or manufacture canonical `objects`, `edges`, `root_object_ids`, Workspace projection state, Master Records projection state, provider object identity, or content hashes.
+
+## Implemented source surfaces
+
+- `schemas/canonical-provenance-reference.schema.json`
+- `scripts/validate_canonical_provenance_reference.py`
+- `tests/test_canonical_provenance_reference.py`
+
+The validator requires:
+
+- schema `stegverse.erl.canonical-provenance-reference.v1`;
+- canonical lineage schema exactly `stegos.object_provenance_lineage.v1`;
+- canonical `svlineage:sha256:*`, `svobj:sha256:*`, and `svedge:sha256:*` identifiers;
+- at least one canonical source-root object;
+- at least one canonical derivation edge;
+- at least one transition receipt reference;
+- `authority_effect: NONE`;
+- optional Master Records custody receipt reference only after such a receipt actually exists.
+
+It fails closed on local/noncanonical IDs, missing roots or edges, duplicate receipt references, authority expansion, and attempts to reproduce canonical graph fields inside ERL.
+
+## Historical Orli boundary
+
+No reference record is created for `ERL-2026-09-03-ORLI-SHULL-AI-GOVERNANCE-COLLAPSE-001` yet because authentic canonical lineage for the original source screenshot/conversation event has not been observed. Creating placeholder canonical IDs would fabricate provenance.
+
+Once authentic canonical ingress exists, ERL may persist a reference record bound to the real lineage/candidate object/roots/edges/transition receipts. If only historical source bytes are recovered without the original transition receipt, the record must preserve the bounded historical-recovery posture rather than claim original runtime provenance.
+
+## README completeness predicate
+
+README impact was evaluated before mutation.
+
+**Determination: no README change is required for this change set.** The repository README already defines ERL as a lineage/evidence layer, states that repository origin is provenance rather than proof, and preserves reviewed evidence posture and uncertainty. This change does not alter existing record interpretation, publication rules, authority boundaries, runtime behavior, credential paths, or source-admissibility semantics. It adds a fail-closed internal validator for an optional future reference object and explicitly prevents ERL from becoming provenance authority.
+
+If ERL later requires canonical provenance references for existing record admission, changes public producer interfaces, changes evidence admissibility, or begins consuming/runtime-writing lineage automatically, README must be updated in that same future change set.
+
+## Evidence boundary
+
+Source/schema/test success proves only that ERL can reject malformed or authority-expanding canonical-reference projections. It does not prove:
+
+- authentic source ingress;
+- authentic conversation-event identity;
+- an authentic transition receipt;
+- a canonical ERL candidate object;
+- Master Records custody;
+- reverse reconstruction from a real ERL artifact;
+- Workspace projection;
+- publication or finding authority.
+
+## Next lawful transition
+
+After merge, the next provenance transition remains external to this source adapter: obtain one authentic `stegos.object_provenance_lineage.v1` chain containing an ERL research-candidate derivation, then persist and validate only its canonical references here. The historical Orli candidate must remain unbound until exact source/runtime provenance is truthfully available.

--- a/schemas/canonical-provenance-reference.schema.json
+++ b/schemas/canonical-provenance-reference.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "stegverse.erl.canonical-provenance-reference.v1",
+  "title": "ERL Canonical Provenance Reference",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "candidate_id",
+    "canonical_lineage_schema",
+    "canonical_lineage_id",
+    "candidate_object_id",
+    "source_root_object_ids",
+    "derivation_edge_ids",
+    "transition_receipt_refs",
+    "authority_effect"
+  ],
+  "properties": {
+    "schema": {"const": "stegverse.erl.canonical-provenance-reference.v1"},
+    "candidate_id": {"type": "string", "minLength": 1},
+    "canonical_lineage_schema": {"const": "stegos.object_provenance_lineage.v1"},
+    "canonical_lineage_id": {"type": "string", "pattern": "^svlineage:sha256:[0-9a-f]{64}$"},
+    "candidate_object_id": {"type": "string", "pattern": "^svobj:sha256:[0-9a-f]{64}$"},
+    "source_root_object_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^svobj:sha256:[0-9a-f]{64}$"}
+    },
+    "derivation_edge_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^svedge:sha256:[0-9a-f]{64}$"}
+    },
+    "transition_receipt_refs": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "master_records_custody_receipt_ref": {"type": ["string", "null"], "minLength": 1},
+    "authority_effect": {"const": "NONE"}
+  }
+}

--- a/scripts/validate_canonical_provenance_reference.py
+++ b/scripts/validate_canonical_provenance_reference.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Validate ERL references to canonical StegOS object-provenance lineage.
+
+This validator is projection-only. It never mints provenance objects, edges,
+lineage IDs, transition receipts, or Master Records custody receipts.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA = "stegverse.erl.canonical-provenance-reference.v1"
+CANONICAL_LINEAGE_SCHEMA = "stegos.object_provenance_lineage.v1"
+OBJ = re.compile(r"^svobj:sha256:[0-9a-f]{64}$")
+EDGE = re.compile(r"^svedge:sha256:[0-9a-f]{64}$")
+LINEAGE = re.compile(r"^svlineage:sha256:[0-9a-f]{64}$")
+
+
+class ProvenanceReferenceError(ValueError):
+    pass
+
+
+def _nonempty_unique_strings(value: Any, field: str) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise ProvenanceReferenceError(f"{field} must be a non-empty array")
+    if any(not isinstance(item, str) or not item for item in value):
+        raise ProvenanceReferenceError(f"{field} must contain non-empty strings")
+    if len(value) != len(set(value)):
+        raise ProvenanceReferenceError(f"{field} must be unique")
+    return value
+
+
+def validate_reference(record: Mapping[str, Any]) -> None:
+    if record.get("schema") != SCHEMA:
+        raise ProvenanceReferenceError("unsupported ERL provenance reference schema")
+    if record.get("canonical_lineage_schema") != CANONICAL_LINEAGE_SCHEMA:
+        raise ProvenanceReferenceError("canonical lineage schema mismatch")
+    if record.get("authority_effect") != "NONE":
+        raise ProvenanceReferenceError("provenance references cannot grant authority")
+    candidate_id = record.get("candidate_id")
+    if not isinstance(candidate_id, str) or not candidate_id:
+        raise ProvenanceReferenceError("candidate_id is required")
+    if not isinstance(record.get("canonical_lineage_id"), str) or not LINEAGE.fullmatch(record["canonical_lineage_id"]):
+        raise ProvenanceReferenceError("canonical_lineage_id must be a canonical lineage id")
+    if not isinstance(record.get("candidate_object_id"), str) or not OBJ.fullmatch(record["candidate_object_id"]):
+        raise ProvenanceReferenceError("candidate_object_id must be a canonical object id")
+
+    roots = _nonempty_unique_strings(record.get("source_root_object_ids"), "source_root_object_ids")
+    if any(not OBJ.fullmatch(item) for item in roots):
+        raise ProvenanceReferenceError("source_root_object_ids must contain canonical object ids")
+    edges = _nonempty_unique_strings(record.get("derivation_edge_ids"), "derivation_edge_ids")
+    if any(not EDGE.fullmatch(item) for item in edges):
+        raise ProvenanceReferenceError("derivation_edge_ids must contain canonical edge ids")
+    _nonempty_unique_strings(record.get("transition_receipt_refs"), "transition_receipt_refs")
+
+    custody = record.get("master_records_custody_receipt_ref")
+    if custody is not None and (not isinstance(custody, str) or not custody):
+        raise ProvenanceReferenceError("master_records_custody_receipt_ref must be null or non-empty")
+
+    forbidden = {
+        "objects",
+        "edges",
+        "root_object_ids",
+        "workspace_projection",
+        "master_records_projection",
+        "provider_object_id",
+        "content_sha256",
+    }
+    overlap = sorted(forbidden.intersection(record))
+    if overlap:
+        raise ProvenanceReferenceError(
+            "ERL reference must not reproduce or manufacture canonical provenance fields: " + ", ".join(overlap)
+        )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: validate_canonical_provenance_reference.py FILE [FILE ...]", file=sys.stderr)
+        return 2
+    for raw_path in argv[1:]:
+        path = Path(raw_path)
+        record = json.loads(path.read_text(encoding="utf-8"))
+        validate_reference(record)
+        print(f"PASS {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_canonical_provenance_reference.py
+++ b/tests/test_canonical_provenance_reference.py
@@ -1,0 +1,62 @@
+import copy
+
+import pytest
+
+from scripts.validate_canonical_provenance_reference import (
+    ProvenanceReferenceError,
+    validate_reference,
+)
+
+
+def record():
+    return {
+        "schema": "stegverse.erl.canonical-provenance-reference.v1",
+        "candidate_id": "ERL-2026-09-03-ORLI-SHULL-AI-GOVERNANCE-COLLAPSE-001",
+        "canonical_lineage_schema": "stegos.object_provenance_lineage.v1",
+        "canonical_lineage_id": "svlineage:sha256:" + "a" * 64,
+        "candidate_object_id": "svobj:sha256:" + "b" * 64,
+        "source_root_object_ids": ["svobj:sha256:" + "c" * 64],
+        "derivation_edge_ids": ["svedge:sha256:" + "d" * 64],
+        "transition_receipt_refs": ["intr-receipt:erl-candidate-001"],
+        "master_records_custody_receipt_ref": None,
+        "authority_effect": "NONE",
+    }
+
+
+def test_accepts_reference_only_record():
+    validate_reference(record())
+
+
+def test_rejects_missing_source_root():
+    value = record()
+    value["source_root_object_ids"] = []
+    with pytest.raises(ProvenanceReferenceError, match="source_root_object_ids"):
+        validate_reference(value)
+
+
+def test_rejects_noncanonical_object_identity():
+    value = record()
+    value["candidate_object_id"] = "candidate-local-id"
+    with pytest.raises(ProvenanceReferenceError, match="canonical object id"):
+        validate_reference(value)
+
+
+def test_rejects_authority_expansion():
+    value = record()
+    value["authority_effect"] = "PUBLICATION"
+    with pytest.raises(ProvenanceReferenceError, match="cannot grant authority"):
+        validate_reference(value)
+
+
+def test_rejects_manufactured_canonical_graph_fields():
+    value = copy.deepcopy(record())
+    value["objects"] = []
+    with pytest.raises(ProvenanceReferenceError, match="must not reproduce or manufacture"):
+        validate_reference(value)
+
+
+def test_rejects_duplicate_receipt_refs():
+    value = record()
+    value["transition_receipt_refs"] = ["receipt:1", "receipt:1"]
+    with pytest.raises(ProvenanceReferenceError, match="must be unique"):
+        validate_reference(value)


### PR DESCRIPTION
Continues StegOS canonical provenance issue #190 from the ERL producer side without creating another provenance authority.

Machine preflight resolved before mutation:
- repository continuity: `ERL_MIRROR_HANDOFF.md`;
- bounded Orli owner: issue #63 / `docs/ORLI_SHULL_AI_GOVERNANCE_COLLAPSE_MIRROR_HANDOFF.md`;
- candidate activation registry remains authoritative for candidate lifecycle;
- canonical source-object provenance remains `StegVerse-Labs/StegOS#190` / `stegos.object_provenance_lineage.v1`;
- Master Records remains custody/reconstruction only;
- ERL remains a downstream research-candidate/assessment producer;
- no competing claim was found on the new schema/validator/test/handoff surfaces.

Adds a reference-only ERL contract and validator requiring canonical lineage/object/edge IDs and transition-receipt references while explicitly rejecting attempts to reproduce or manufacture canonical graph fields locally. No historical Orli provenance record is fabricated because authentic canonical source/conversation lineage has not yet been observed.

README completeness predicate: NO CHANGE REQUIRED, with evidence-supported rationale recorded in `docs/CANONICAL_OBJECT_PROVENANCE_REFERENCE_MIRROR_HANDOFF.md`. This adds an optional fail-closed internal projection validator; it does not alter existing record admission, publication, evidence interpretation, runtime behavior, credential paths, or authority semantics. A future change making canonical provenance mandatory for existing ERL admission or changing public producer interfaces must update README in that same change set.

No runtime provenance, source custody, Master Records custody, finding, publication, or authority is claimed by this source change.