### PR TITLE
Make KnowledgeVault the ERL artifact storage medium

### DIFF
--- a/.github/workflows/validate-ledger-schemas.yml
+++ b/.github/workflows/validate-ledger-schemas.yml
@@ -197,5 +197,7 @@ jobs:
           if generated != expected:
               raise SystemExit("Generated discovery-cycle content does not match fixture")
           PY
+      - name: Validate ERL KnowledgeVault storage contract
+        run: python scripts/validate_erl_kv_storage.py
       - name: Run combined activation validation
         run: python scripts/run_activation_validation.py

--- a/ERL_MIRROR_HANDOFF.md
+++ b/ERL_MIRROR_HANDOFF.md
@@ -689,3 +689,22 @@ No Site, Publisher, admissibility-wiki, stegguardian-wiki, tag, release, or publ
 - next executable task: create a primary-source acquisition packet for the 2025-2026 cycle and reconstruct cash-on-hand, receipts, transfers, independent expenditures, vendor payments, debts, refunds, and amendments before assessing misuse
 
 This adjacent candidate does not alter the Fauci/HSGAC active-goal denominator and authorizes no Site, Publisher, admissibility-wiki, stegguardian-wiki, or master-records propagation.
+
+## Adjacent integration lane - KnowledgeVault-backed ERL storage - ACTIVE
+
+Goal ID: `SS-EVIDENCE-COMPARISON-001`
+
+Scoped handoff:
+`docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md`
+
+Canonical KV lane:
+`02_Research/ERL`
+
+Current state:
+- artifact schema: installed on integration branch;
+- mounted-KV writer: installed on integration branch;
+- deterministic idempotency, conflict, hash, traversal, and credential-material tests: installed;
+- hosted validation: pending branch workflow;
+- authentic ERL-to-KV write receipt: pending;
+- release/publication propagation: not yet ready.
+

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ These repositories may contribute candidates, evidence pointers, context, contro
 
 Ledger outputs are normalized datasets, comparisons, evidence receipts, historical timelines, and governed assessments.
 
+## KnowledgeVault-backed ERL storage
+
+ERL uses KnowledgeVault as the durable storage medium for growing research and evidence artifacts. The canonical mounted-KV lane is `02_Research/ERL`. ERL retains its research, evidence, review, and assessment semantics while KV supplies user-custodied persistence and continuity.
+
+The native writer at `adapters/kv/erl_kv_writer.py` validates artifact manifests, object sizes, and SHA-256 values; refuses path traversal, credential material, and conflicting overwrite; permits identical idempotent re-entry; writes the canonical manifest last; and performs byte-for-byte readback. It operates only on an explicitly supplied mounted KV root and does not authenticate to a storage provider.
+
+See [ERL KnowledgeVault Storage Mirror Handoff](docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md).
+
 ## Status
 
 ```yaml

--- a/adapters/kv/erl_kv_writer.py
+++ b/adapters/kv/erl_kv_writer.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Persist validated ERL artifact bundles into an already-mounted KnowledgeVault."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+
+SCHEMA = "stegverse.erl.kv-artifact/v1"
+RECEIPT_SCHEMA = "stegverse.erl.kv-write-receipt/v1"
+KV_LANE = Path("02_Research") / "ERL"
+SAFE_COMPONENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+ARTIFACT_CLASSES = {
+    "SOURCE_CAPTURE",
+    "ERL_RESEARCH_ARTIFACT",
+    "ASSESSMENT",
+    "EVIDENCE_RECEIPT",
+    "REVIEW_RECORD",
+}
+
+
+class ERLKVWriteError(ValueError):
+    """Raised when an ERL bundle cannot be safely persisted."""
+
+
+def _canonical_json(document: Mapping[str, Any]) -> bytes:
+    return (
+        json.dumps(document, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    ).encode("utf-8")
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _require_safe_component(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not SAFE_COMPONENT.fullmatch(value):
+        raise ERLKVWriteError(f"{field} must be a safe path component")
+    return value
+
+
+def _require_rfc3339(value: Any, field: str) -> None:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise ERLKVWriteError(f"{field} must be an RFC3339 UTC timestamp")
+    try:
+        datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as exc:
+        raise ERLKVWriteError(f"{field} must be an RFC3339 UTC timestamp") from exc
+
+
+def validate_manifest(manifest: Mapping[str, Any]) -> None:
+    if manifest.get("schema") != SCHEMA:
+        raise ERLKVWriteError(f"schema must equal {SCHEMA}")
+
+    _require_safe_component(manifest.get("artifact_id"), "artifact_id")
+    if manifest.get("artifact_class") not in ARTIFACT_CLASSES:
+        raise ERLKVWriteError("artifact_class is unsupported")
+    _require_rfc3339(manifest.get("captured_at"), "captured_at")
+
+    source = manifest.get("source")
+    if not isinstance(source, dict):
+        raise ERLKVWriteError("source must be an object")
+    for field in ("title", "publisher", "primary_url"):
+        if not isinstance(source.get(field), str) or not source[field].strip():
+            raise ERLKVWriteError(f"source.{field} is required")
+    if not source["primary_url"].startswith(("https://", "http://")):
+        raise ERLKVWriteError("source.primary_url must be HTTP(S)")
+
+    storage = manifest.get("storage")
+    if not isinstance(storage, dict):
+        raise ERLKVWriteError("storage must be an object")
+    if storage.get("lane") != KV_LANE.as_posix():
+        raise ERLKVWriteError(f"storage.lane must equal {KV_LANE.as_posix()}")
+    _require_safe_component(storage.get("kv_instance_id"), "storage.kv_instance_id")
+    if storage.get("credential_material_present") is not False:
+        raise ERLKVWriteError("credential material must not be stored in ERL KV artifacts")
+
+    objects = manifest.get("objects")
+    if not isinstance(objects, list) or not objects:
+        raise ERLKVWriteError("objects must be a non-empty array")
+    names: set[str] = set()
+    for index, item in enumerate(objects):
+        if not isinstance(item, dict):
+            raise ERLKVWriteError(f"objects[{index}] must be an object")
+        filename = _require_safe_component(item.get("filename"), f"objects[{index}].filename")
+        if filename == "manifest.json" or filename in names:
+            raise ERLKVWriteError("object filenames must be unique and exclude manifest.json")
+        names.add(filename)
+        if not re.fullmatch(r"[0-9a-f]{64}", str(item.get("sha256", ""))):
+            raise ERLKVWriteError(f"objects[{index}].sha256 must be lowercase SHA-256")
+        if not isinstance(item.get("size_bytes"), int) or item["size_bytes"] < 0:
+            raise ERLKVWriteError(f"objects[{index}].size_bytes must be non-negative")
+        if not isinstance(item.get("media_type"), str) or not item["media_type"]:
+            raise ERLKVWriteError(f"objects[{index}].media_type is required")
+        if not isinstance(item.get("role"), str) or not item["role"]:
+            raise ERLKVWriteError(f"objects[{index}].role is required")
+
+
+def _preflight(destination: Path, data: bytes) -> str:
+    if not destination.exists():
+        return "WRITE"
+    if destination.is_symlink() or not destination.is_file():
+        raise ERLKVWriteError(f"destination is not a regular file: {destination}")
+    if destination.read_bytes() != data:
+        raise ERLKVWriteError(f"conflicting artifact already exists: {destination.name}")
+    return "NOOP"
+
+
+def _exclusive_write(destination: Path, data: bytes) -> None:
+    try:
+        descriptor = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        if destination.read_bytes() != data:
+            raise ERLKVWriteError(f"concurrent conflicting write: {destination.name}")
+        return
+    with os.fdopen(descriptor, "wb") as stream:
+        stream.write(data)
+        stream.flush()
+        os.fsync(stream.fileno())
+    if destination.read_bytes() != data:
+        raise ERLKVWriteError(f"readback mismatch: {destination.name}")
+
+
+def write_bundle(
+    *,
+    kv_root: Path,
+    manifest: Mapping[str, Any],
+    payloads: Mapping[str, Path],
+) -> dict[str, Any]:
+    """Write one create-only, idempotent ERL artifact bundle into KV."""
+
+    validate_manifest(manifest)
+    root = kv_root.expanduser().resolve()
+    if not root.is_dir():
+        raise ERLKVWriteError("kv_root must be an existing mounted directory")
+
+    artifact_id = str(manifest["artifact_id"])
+    destination = (root / KV_LANE / artifact_id).resolve()
+    try:
+        destination.relative_to(root)
+    except ValueError as exc:
+        raise ERLKVWriteError("resolved artifact destination escaped kv_root") from exc
+
+    expected = {str(item["filename"]): item for item in manifest["objects"]}
+    if set(payloads) != set(expected):
+        raise ERLKVWriteError("payload filenames must exactly match manifest objects")
+
+    payload_bytes: dict[str, bytes] = {}
+    for filename, item in expected.items():
+        source_path = Path(payloads[filename])
+        if source_path.is_symlink() or not source_path.is_file():
+            raise ERLKVWriteError(f"payload is not a regular file: {filename}")
+        data = source_path.read_bytes()
+        if len(data) != item["size_bytes"]:
+            raise ERLKVWriteError(f"payload size mismatch: {filename}")
+        if _sha256(data) != item["sha256"]:
+            raise ERLKVWriteError(f"payload hash mismatch: {filename}")
+        payload_bytes[filename] = data
+
+    manifest_bytes = _canonical_json(manifest)
+    if destination.exists():
+        planned = {
+            filename: _preflight(destination / filename, data)
+            for filename, data in payload_bytes.items()
+        }
+        planned["manifest.json"] = _preflight(destination / "manifest.json", manifest_bytes)
+    else:
+        planned = {filename: "WRITE" for filename in payload_bytes}
+        planned["manifest.json"] = "WRITE"
+
+    destination.mkdir(parents=True, exist_ok=True)
+    for filename, data in payload_bytes.items():
+        if planned[filename] == "WRITE":
+            _exclusive_write(destination / filename, data)
+    if planned["manifest.json"] == "WRITE":
+        _exclusive_write(destination / "manifest.json", manifest_bytes)
+
+    result = "WRITTEN" if "WRITE" in planned.values() else "NOOP"
+    return {
+        "schema": RECEIPT_SCHEMA,
+        "artifact_id": artifact_id,
+        "result": result,
+        "kv_instance_id": manifest["storage"]["kv_instance_id"],
+        "lane": KV_LANE.as_posix(),
+        "relative_artifact_path": (KV_LANE / artifact_id).as_posix(),
+        "manifest_sha256": _sha256(manifest_bytes),
+        "objects": [
+            {
+                "filename": filename,
+                "sha256": expected[filename]["sha256"],
+                "size_bytes": expected[filename]["size_bytes"],
+                "write_result": planned[filename],
+            }
+            for filename in sorted(expected)
+        ],
+        "credential_material_present": False,
+        "readback_verified": True,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kv-root", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--payload-dir", type=Path, required=True)
+    parser.add_argument("--receipt", type=Path)
+    args = parser.parse_args()
+
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    payloads = {
+        str(item["filename"]): args.payload_dir / str(item["filename"])
+        for item in manifest.get("objects", [])
+    }
+    receipt = write_bundle(kv_root=args.kv_root, manifest=manifest, payloads=payloads)
+    rendered = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    if args.receipt:
+        args.receipt.parent.mkdir(parents=True, exist_ok=True)
+        args.receipt.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md
+++ b/docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md
@@ -1,0 +1,71 @@
+# ERL KnowledgeVault Storage Mirror Handoff
+
+Updated: 2026-09-09
+
+## Goal Task ID
+
+SS-EVIDENCE-COMPARISON-001
+
+Canonical task record:
+StegVerse-Labs/.github/data/canonical-task-records/SS-EVIDENCE-COMPARISON-001.json
+
+COSV: 40000100100000
+
+## Purpose
+
+Make KnowledgeVault the durable storage medium for ERL research and evidence artifacts as the ledger grows. ERL continues to define research, evidence, review, and assessment semantics; KV persists the resulting artifacts under the canonical 02_Research/ERL lane.
+
+## Storage contract
+
+    ERL acquisition or analysis
+    -> ERL artifact manifest
+    -> object hash and size verification
+    -> mounted KV root
+    -> 02_Research/ERL/<artifact_id>/
+    -> create-only object writes
+    -> canonical manifest written last
+    -> byte-for-byte readback
+    -> idempotent write receipt
+
+KV is storage, continuity, and user-custodied persistence. It does not replace ERL classification, comparison, review, or assessment semantics. Provider credentials and reusable secrets are not ERL artifacts and must not be written into the KV research lane.
+
+## Installed repository surfaces
+
+- schemas/erl-kv-artifact.schema.json
+- adapters/kv/erl_kv_writer.py
+- scripts/validate_erl_kv_storage.py
+- scripts/test_erl_kv_writer.py
+- fixtures/erl-kv/sample-manifest.json
+- fixtures/erl-kv/source.txt
+- docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md
+- .github/workflows/validate-ledger-schemas.yml
+- README.md
+
+## Implemented behavior
+
+- requires explicit existing mounted KV root;
+- fixes the ERL destination to 02_Research/ERL;
+- verifies artifact ID, object filenames, media metadata, byte size, and SHA-256;
+- rejects traversal, symlink payloads, missing objects, extra objects, hash mismatch, credential material, and conflicting overwrite;
+- allows identical idempotent re-entry as NOOP;
+- writes a canonical manifest.json after payloads;
+- performs byte-for-byte readback;
+- returns an ERL KV write receipt without opening a provider session.
+
+## Current proof boundary
+
+Deterministic local and hosted tests prove the schema and mounted-filesystem writer behavior. Authentic activation additionally requires running the writer against the user's mounted KV root and preserving the returned receipt for a real ERL intake.
+
+The OpenAI An Alien Mind artifact currently present in MyKV demonstrates the intended storage layout, but its manual placement is not retroactively claimed as execution by this adapter.
+
+## Remaining work
+
+1. Run one real ERL source intake through adapters/kv/erl_kv_writer.py against an authorized mounted KnowledgeVault root.
+2. Preserve the authentic write receipt and bind it to the source acquisition record.
+3. Add Master Records custody/reconstruction for the authentic ERL KV receipt if the shared custody schema does not already accept it.
+4. Update StegVerse-Labs/StegSocials to reference the stable ERL artifact ID and KV receipt where an ERL-backed publication is created.
+5. Verify any pertinent public/index propagation in StegVerse-Labs/Site, GCAT-BCAT-Engine/Publisher, admissibility-wiki, and stegguardian-wiki only when this lane reaches release readiness.
+
+## Current state
+
+SOURCE_IMPLEMENTED_PENDING_AUTHENTIC_KV_WRITE_PROOF

--- a/fixtures/erl-kv/sample-manifest.json
+++ b/fixtures/erl-kv/sample-manifest.json
@@ -1,0 +1,28 @@
+{
+  "schema": "stegverse.erl.kv-artifact/v1",
+  "artifact_id": "ERL-2026-09-09-FIXTURE-001",
+  "artifact_class": "SOURCE_CAPTURE",
+  "captured_at": "2026-09-09T03:30:00Z",
+  "source": {
+    "title": "ERL source fixture",
+    "publisher": "StegVerse",
+    "primary_url": "https://stegverse.org/",
+    "published_at": null,
+    "author": null
+  },
+  "storage": {
+    "kv_instance_id": "kvi_fixture_001",
+    "lane": "02_Research/ERL",
+    "credential_material_present": false
+  },
+  "objects": [
+    {
+      "filename": "source.txt",
+      "role": "SOURCE_TEXT",
+      "media_type": "text/plain",
+      "size_bytes": 19,
+      "sha256": "7e51dd5135eeda57009b22384f845f20c5fd06cf4ab29d88c562f5952c71e4bf"
+    }
+  ],
+  "relationships": []
+}

--- a/fixtures/erl-kv/source.txt
+++ b/fixtures/erl-kv/source.txt
@@ -1,0 +1,1 @@
+ERL source fixture

--- a/schemas/erl-kv-artifact.schema.json
+++ b/schemas/erl-kv-artifact.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/erl-kv-artifact.schema.json",
+  "title": "ERL KnowledgeVault Artifact",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "artifact_id",
+    "artifact_class",
+    "captured_at",
+    "source",
+    "storage",
+    "objects",
+    "relationships"
+  ],
+  "properties": {
+    "schema": {"const": "stegverse.erl.kv-artifact/v1"},
+    "artifact_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "artifact_class": {
+      "enum": [
+        "SOURCE_CAPTURE",
+        "ERL_RESEARCH_ARTIFACT",
+        "ASSESSMENT",
+        "EVIDENCE_RECEIPT",
+        "REVIEW_RECORD"
+      ]
+    },
+    "captured_at": {"type": "string", "format": "date-time"},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "publisher", "primary_url"],
+      "properties": {
+        "title": {"type": "string", "minLength": 1},
+        "publisher": {"type": "string", "minLength": 1},
+        "primary_url": {"type": "string", "format": "uri"},
+        "published_at": {"type": ["string", "null"], "format": "date-time"},
+        "author": {"type": ["string", "null"]}
+      }
+    },
+    "storage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kv_instance_id", "lane", "credential_material_present"],
+      "properties": {
+        "kv_instance_id": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+        },
+        "lane": {"const": "02_Research/ERL"},
+        "credential_material_present": {"const": false}
+      }
+    },
+    "objects": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["filename", "role", "media_type", "size_bytes", "sha256"],
+        "properties": {
+          "filename": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          },
+          "role": {"type": "string", "minLength": 1},
+          "media_type": {"type": "string", "minLength": 1},
+          "size_bytes": {"type": "integer", "minimum": 0},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        }
+      }
+    },
+    "relationships": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["relationship", "target_ref"],
+        "properties": {
+          "relationship": {"type": "string", "minLength": 1},
+          "target_ref": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  }
+}

--- a/scripts/test_erl_kv_writer.py
+++ b/scripts/test_erl_kv_writer.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from adapters.kv.erl_kv_writer import ERLKVWriteError, validate_manifest, write_bundle
+
+
+class ERLKVWriterTests(unittest.TestCase):
+    def build(self, directory: Path) -> tuple[dict, dict[str, Path]]:
+        payload = directory / "source.txt"
+        payload.write_text("ERL source fixture\n", encoding="utf-8")
+        data = payload.read_bytes()
+        manifest = {
+            "schema": "stegverse.erl.kv-artifact/v1",
+            "artifact_id": "ERL-2026-09-09-FIXTURE-001",
+            "artifact_class": "SOURCE_CAPTURE",
+            "captured_at": "2026-09-09T03:30:00Z",
+            "source": {
+                "title": "Fixture",
+                "publisher": "Fixture Publisher",
+                "primary_url": "https://example.test/source",
+            },
+            "storage": {
+                "kv_instance_id": "kvi_fixture_001",
+                "lane": "02_Research/ERL",
+                "credential_material_present": False,
+            },
+            "objects": [{
+                "filename": "source.txt",
+                "role": "SOURCE_TEXT",
+                "media_type": "text/plain",
+                "size_bytes": len(data),
+                "sha256": hashlib.sha256(data).hexdigest(),
+            }],
+            "relationships": [],
+        }
+        return manifest, {"source.txt": payload}
+
+    def test_schema_and_idempotent_write(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            manifest, payloads = self.build(base)
+            kv_root = base / "kv"
+            kv_root.mkdir()
+            first = write_bundle(kv_root=kv_root, manifest=manifest, payloads=payloads)
+            second = write_bundle(kv_root=kv_root, manifest=manifest, payloads=payloads)
+            self.assertEqual("WRITTEN", first["result"])
+            self.assertEqual("NOOP", second["result"])
+            self.assertTrue(first["readback_verified"])
+            self.assertFalse(first["credential_material_present"])
+
+    def test_hash_mismatch_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            manifest, payloads = self.build(base)
+            manifest["objects"][0]["sha256"] = "0" * 64
+            kv_root = base / "kv"
+            kv_root.mkdir()
+            with self.assertRaisesRegex(ERLKVWriteError, "hash mismatch"):
+                write_bundle(kv_root=kv_root, manifest=manifest, payloads=payloads)
+
+    def test_conflicting_rewrite_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            manifest, payloads = self.build(base)
+            kv_root = base / "kv"
+            kv_root.mkdir()
+            write_bundle(kv_root=kv_root, manifest=manifest, payloads=payloads)
+            destination = kv_root / "02_Research/ERL/ERL-2026-09-09-FIXTURE-001/source.txt"
+            destination.write_text("different\n", encoding="utf-8")
+            with self.assertRaisesRegex(ERLKVWriteError, "conflicting artifact"):
+                write_bundle(kv_root=kv_root, manifest=manifest, payloads=payloads)
+
+    def test_path_and_credential_fields_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            manifest, _ = self.build(base)
+            manifest["objects"][0]["filename"] = "../escape.txt"
+            with self.assertRaisesRegex(ERLKVWriteError, "safe path component"):
+                validate_manifest(manifest)
+            manifest, _ = self.build(base)
+            manifest["storage"]["credential_material_present"] = True
+            with self.assertRaisesRegex(ERLKVWriteError, "credential material"):
+                validate_manifest(manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_erl_kv_storage.py
+++ b/scripts/validate_erl_kv_storage.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas/erl-kv-artifact.schema.json"
+FIXTURE = ROOT / "fixtures/erl-kv/sample-manifest.json"
+
+
+def main() -> None:
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    errors = sorted(
+        Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(fixture),
+        key=lambda error: list(error.path),
+    )
+    if errors:
+        raise SystemExit("\n".join(error.message for error in errors))
+    subprocess.run(
+        [sys.executable, str(ROOT / "scripts/test_erl_kv_writer.py")],
+        cwd=ROOT,
+        check=True,
+    )
+    print("ERL KnowledgeVault storage contract validation passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements the active SS-EVIDENCE-COMPARISON-001 storage contract inside ERL.

- adds an ERL KV artifact schema
- adds a create-only, idempotent mounted-KV writer with hash/size/readback validation
- refuses traversal, symlink payloads, credential material, and conflicting overwrite
- adds fixtures, deterministic tests, and hosted CI coverage
- adds a scoped mirror handoff and links it from the repository handoff
- updates README.md with the canonical 02_Research/ERL storage model

Local validation: 4 unit tests PASS; CLI write returns WRITTEN, repeat returns NOOP with byte readback verified.

Authentic activation remains pending one real ERL intake through the writer against a mounted KnowledgeVault root.