### PR TITLE
Separate ERL KV receipts from provider observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ ERL uses KnowledgeVault as the durable storage medium for growing research and e
 
 The native writer at `adapters/kv/erl_kv_writer.py` validates artifact manifests, object sizes, and SHA-256 values; refuses path traversal, credential material, and conflicting overwrite; permits identical idempotent re-entry; writes the canonical manifest last; and performs byte-for-byte readback. It operates only on an explicitly supplied mounted KV root and does not authenticate to a storage provider.
 
+Separate schemas distinguish a canonical `stegverse.erl.kv-write-receipt/v1` from a provisional `stegverse.erl.kv-provider-write-observation/v1`. Metadata-only provider observations are structurally prohibited from claiming byte-for-byte readback or native-adapter execution.
+
 The first live structured artifact is `ERL-2026-09-06-OPENAI-AN-ALIEN-MIND` in MyKV. Its child folder preserves the source PDF, plain-text capture, ERL research record, canonical manifest, and a provider-write observation. Google Drive metadata readback is complete; execution of the native mounted-KV writer and its byte-for-byte receipt remain the next proof boundary.
 
 See [ERL KnowledgeVault Storage Mirror Handoff](docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md).

--- a/docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md
+++ b/docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md
@@ -32,10 +32,15 @@ KV is storage, continuity, and user-custodied persistence. It does not replace E
 ## Installed repository surfaces
 
 - schemas/erl-kv-artifact.schema.json
+- schemas/erl-kv-write-receipt.schema.json
+- schemas/erl-kv-provider-write-observation.schema.json
 - adapters/kv/erl_kv_writer.py
 - scripts/validate_erl_kv_storage.py
 - scripts/test_erl_kv_writer.py
 - fixtures/erl-kv/sample-manifest.json
+- fixtures/erl-kv/sample-write-receipt.json
+- fixtures/erl-kv/sample-provider-write-observation.json
+- fixtures/erl-kv/invalid-provider-observation-overclaims.json
 - fixtures/erl-kv/source.txt
 - docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md
 - .github/workflows/validate-ledger-schemas.yml
@@ -59,6 +64,8 @@ Deterministic local and hosted tests prove the schema and mounted-filesystem wri
 On 2026-09-09, the OpenAI "An Alien Mind" intake was organized in the live MyKV lane at `02_Research/ERL/ERL-2026-09-06-OPENAI-AN-ALIEN-MIND`. The folder contains the preserved PDF, plain-text capture, ERL research record, canonical `manifest.json`, and `provider-write-observation.json`.
 
 Google Drive metadata readback verified the destination folder, stable file IDs, filenames, media types, and byte sizes. The observation explicitly records `byte_for_byte_provider_readback_verified=false` and `adapter_execution_proven=false`; therefore it proves live provider storage and metadata readback without overstating execution of the mounted-filesystem adapter or completion of the canonical receipt proof.
+
+The canonical writer receipt and provisional provider observation now have separate JSON Schemas. The provider-observation schema requires both byte-for-byte verification and adapter execution to remain false, preventing metadata-only evidence from being promoted into a canonical writer receipt.
 
 ## Remaining work
 

--- a/fixtures/erl-kv/invalid-provider-observation-overclaims.json
+++ b/fixtures/erl-kv/invalid-provider-observation-overclaims.json
@@ -1,0 +1,19 @@
+{
+  "schema": "stegverse.erl.kv-provider-write-observation/v1",
+  "artifact_id": "ERL-2026-09-06-OPENAI-AN-ALIEN-MIND",
+  "observed_at": "2026-09-09T04:24:09Z",
+  "result": "PROVIDER_WRITE_OBSERVED",
+  "kv_instance_id": "mykv-01-google-drive",
+  "provider": "google-drive",
+  "lane": "02_Research/ERL",
+  "relative_artifact_path": "02_Research/ERL/ERL-2026-09-06-OPENAI-AN-ALIEN-MIND",
+  "folder_id": "fixture-folder",
+  "folder_url": "https://drive.google.com/drive/folders/fixture-folder",
+  "manifest": {"file_id": "fixture-manifest", "filename": "manifest.json", "size_bytes": 1, "sha256_at_upload": "0000000000000000000000000000000000000000000000000000000000000000"},
+  "objects": [{"file_id": "fixture-object", "filename": "source.txt", "size_bytes": 1, "sha256_at_upload": "0000000000000000000000000000000000000000000000000000000000000000", "parent_verified": true, "size_readback_verified": true}],
+  "credential_material_present": false,
+  "provider_metadata_readback_verified": true,
+  "byte_for_byte_provider_readback_verified": true,
+  "adapter_execution_proven": true,
+  "remaining_proof": "This invalid fixture improperly claims completed proof."
+}

--- a/fixtures/erl-kv/sample-provider-write-observation.json
+++ b/fixtures/erl-kv/sample-provider-write-observation.json
@@ -1,0 +1,19 @@
+{
+  "schema": "stegverse.erl.kv-provider-write-observation/v1",
+  "artifact_id": "ERL-2026-09-06-OPENAI-AN-ALIEN-MIND",
+  "observed_at": "2026-09-09T04:24:09Z",
+  "result": "PROVIDER_WRITE_OBSERVED",
+  "kv_instance_id": "mykv-01-google-drive",
+  "provider": "google-drive",
+  "lane": "02_Research/ERL",
+  "relative_artifact_path": "02_Research/ERL/ERL-2026-09-06-OPENAI-AN-ALIEN-MIND",
+  "folder_id": "1E8vElivCJhsPM7AyWriMQ-WsPK6lQO9R",
+  "folder_url": "https://drive.google.com/drive/folders/1E8vElivCJhsPM7AyWriMQ-WsPK6lQO9R",
+  "manifest": {"file_id": "11E6Gpx0GtIbR37XHFDEVMa79jNl38x5H", "filename": "manifest.json", "size_bytes": 1382, "sha256_at_upload": "8cb3a11ff90e9ba2e40a916c8fcb1046da7db3881c93be0af9e3dd9287486ec0"},
+  "objects": [{"file_id": "1XRB1b9bGqPp4JG_U86kY_T-kXbqZnqUP", "filename": "2026-09-06_OpenAI_An-Alien-Mind.pdf", "size_bytes": 91264, "sha256_at_upload": "15911a771a0573a71354e2bd6efb033d6e9e3af67a41ea9b079c1c810ae872c2", "parent_verified": true, "size_readback_verified": true}],
+  "credential_material_present": false,
+  "provider_metadata_readback_verified": true,
+  "byte_for_byte_provider_readback_verified": false,
+  "adapter_execution_proven": false,
+  "remaining_proof": "Execute the native mounted-KV writer and preserve its canonical receipt."
+}

--- a/fixtures/erl-kv/sample-write-receipt.json
+++ b/fixtures/erl-kv/sample-write-receipt.json
@@ -1,0 +1,12 @@
+{
+  "schema": "stegverse.erl.kv-write-receipt/v1",
+  "artifact_id": "ERL-2026-09-09-FIXTURE-001",
+  "result": "WRITTEN",
+  "kv_instance_id": "kvi_fixture_001",
+  "lane": "02_Research/ERL",
+  "relative_artifact_path": "02_Research/ERL/ERL-2026-09-09-FIXTURE-001",
+  "manifest_sha256": "4d08c16d870f03553ca13e5bcab1af10c56990f5aa561af17cd2abec6960522b",
+  "objects": [{"filename": "source.txt", "sha256": "7e51dd5135eeda57009b22384f845f20c5fd06cf4ab29d88c562f5952c71e4bf", "size_bytes": 19, "write_result": "WRITE"}],
+  "credential_material_present": false,
+  "readback_verified": true
+}

--- a/schemas/erl-kv-provider-write-observation.schema.json
+++ b/schemas/erl-kv-provider-write-observation.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/erl-kv-provider-write-observation.schema.json",
+  "title": "ERL KnowledgeVault Provider Write Observation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "artifact_id", "observed_at", "result", "kv_instance_id", "provider", "lane", "relative_artifact_path", "folder_id", "folder_url", "manifest", "objects", "credential_material_present", "provider_metadata_readback_verified", "byte_for_byte_provider_readback_verified", "adapter_execution_proven", "remaining_proof"],
+  "properties": {
+    "schema": {"const": "stegverse.erl.kv-provider-write-observation/v1"},
+    "artifact_id": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"},
+    "observed_at": {"type": "string", "format": "date-time"},
+    "result": {"const": "PROVIDER_WRITE_OBSERVED"},
+    "kv_instance_id": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"},
+    "provider": {"type": "string", "minLength": 1},
+    "lane": {"const": "02_Research/ERL"},
+    "relative_artifact_path": {"type": "string", "pattern": "^02_Research/ERL/[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"},
+    "folder_id": {"type": "string", "minLength": 1},
+    "folder_url": {"type": "string", "format": "uri"},
+    "manifest": {"$ref": "#/$defs/providerObject"},
+    "objects": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "allOf": [
+          {"$ref": "#/$defs/providerObject"},
+          {"required": ["parent_verified", "size_readback_verified"]}
+        ]
+      }
+    },
+    "credential_material_present": {"const": false},
+    "provider_metadata_readback_verified": {"const": true},
+    "byte_for_byte_provider_readback_verified": {"const": false},
+    "adapter_execution_proven": {"const": false},
+    "remaining_proof": {"type": "string", "minLength": 1}
+  },
+  "$defs": {
+    "providerObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["file_id", "filename", "size_bytes", "sha256_at_upload"],
+      "properties": {
+        "file_id": {"type": "string", "minLength": 1},
+        "filename": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"},
+        "size_bytes": {"type": "integer", "minimum": 0},
+        "sha256_at_upload": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "parent_verified": {"const": true},
+        "size_readback_verified": {"const": true}
+      }
+    }
+  }
+}

--- a/schemas/erl-kv-write-receipt.schema.json
+++ b/schemas/erl-kv-write-receipt.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/erl-kv-write-receipt.schema.json",
+  "title": "ERL KnowledgeVault Write Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "artifact_id", "result", "kv_instance_id", "lane", "relative_artifact_path", "manifest_sha256", "objects", "credential_material_present", "readback_verified"],
+  "properties": {
+    "schema": {"const": "stegverse.erl.kv-write-receipt/v1"},
+    "artifact_id": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"},
+    "result": {"enum": ["WRITTEN", "NOOP"]},
+    "kv_instance_id": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"},
+    "lane": {"const": "02_Research/ERL"},
+    "relative_artifact_path": {"type": "string", "pattern": "^02_Research/ERL/[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"},
+    "manifest_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "objects": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["filename", "sha256", "size_bytes", "write_result"],
+        "properties": {
+          "filename": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+          "size_bytes": {"type": "integer", "minimum": 0},
+          "write_result": {"enum": ["WRITE", "NOOP"]}
+        }
+      }
+    },
+    "credential_material_present": {"const": false},
+    "readback_verified": {"const": true}
+  }
+}

--- a/scripts/validate_erl_kv_storage.py
+++ b/scripts/validate_erl_kv_storage.py
@@ -9,19 +9,33 @@ from pathlib import Path
 from jsonschema import Draft202012Validator, FormatChecker
 
 ROOT = Path(__file__).resolve().parents[1]
-SCHEMA = ROOT / "schemas/erl-kv-artifact.schema.json"
-FIXTURE = ROOT / "fixtures/erl-kv/sample-manifest.json"
+VALID_FIXTURES = [
+    (ROOT / "schemas/erl-kv-artifact.schema.json", ROOT / "fixtures/erl-kv/sample-manifest.json"),
+    (ROOT / "schemas/erl-kv-write-receipt.schema.json", ROOT / "fixtures/erl-kv/sample-write-receipt.json"),
+    (ROOT / "schemas/erl-kv-provider-write-observation.schema.json", ROOT / "fixtures/erl-kv/sample-provider-write-observation.json"),
+]
+INVALID_FIXTURES = [
+    (ROOT / "schemas/erl-kv-provider-write-observation.schema.json", ROOT / "fixtures/erl-kv/invalid-provider-observation-overclaims.json"),
+]
 
 
 def main() -> None:
-    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
-    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
-    errors = sorted(
-        Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(fixture),
-        key=lambda error: list(error.path),
-    )
-    if errors:
-        raise SystemExit("\n".join(error.message for error in errors))
+    for schema_path, fixture_path in VALID_FIXTURES:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+        errors = sorted(
+            Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(fixture),
+            key=lambda error: list(error.path),
+        )
+        if errors:
+            raise SystemExit(f"{fixture_path.name}: " + "\n".join(error.message for error in errors))
+
+    for schema_path, fixture_path in INVALID_FIXTURES:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+        errors = list(Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(fixture))
+        if not errors:
+            raise SystemExit(f"{fixture_path.name}: invalid fixture unexpectedly passed")
     subprocess.run(
         [sys.executable, str(ROOT / "scripts/test_erl_kv_writer.py")],
         cwd=ROOT,


### PR DESCRIPTION
## Summary
- add a strict schema for canonical mounted-KV writer receipts
- add a separate fail-closed schema for provider metadata observations
- reject observations that claim byte-for-byte readback or native-adapter execution
- add valid and invalid fixtures to hosted validation
- update the ERL KV handoff and repository README

## Why
The first live MyKV artifact has verified provider placement and size metadata, but the current connector cannot expose downloaded bytes to the local verifier without an inline-binary fallback. These schemas prevent that partial evidence from being mistaken for the native writer's canonical receipt.