### PR TITLE
Reconcile completed ERL KV propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The first live structured artifact is `ERL-2026-09-06-OPENAI-AN-ALIEN-MIND` in M
 
 The second live artifact, `ERL-2026-09-08-NSA-AI-DISTILLATION`, completed the full write path. The native ERL writer validated and materialized the source and structured record; Google Drive accepted both payloads, then the canonical manifest last, followed by the native receipt and retained provider-operation receipt. Independent downloads reproduced every payload, manifest, native receipt, and provider receipt byte-for-byte. The provider operation evidence is retained under `evidence/kv-provider-operations/` and validated fail-closed in hosted CI. Master Records pins the exact ERL schemas, custodies both authentic receipts, deterministically reproduces their import, and reconstructs them alongside the original metadata-only observation; all nine workflows passed before PR #89 merged at `1c565c160d1a25b408e130402b5da52e855a8169`.
 
+The bounded propagation verification is also complete. Site and Publisher now carry validated upstream-proof projections; Admissibility Wiki and the intentionally `StegVerse-002`-hosted Guardian wiki were inspected and recorded as not applicable because neither contains an ERL/KV consumer path. Canonical closure is retained under `SS-ERL-KV-PROPAGATION-VERIFICATION-001` at `StegVerse-Labs/.github@2d6e477c6ebed075c1610a979ace28e53560f284`.
+
 See [ERL KnowledgeVault Storage Mirror Handoff](docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md).
 
 ## Status

--- a/docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md
+++ b/docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md
@@ -85,10 +85,18 @@ On 2026-09-09, `ERL-2026-09-08-NSA-AI-DISTILLATION` completed the native-materia
 
 Master Records pinned the three ERL KV schemas at exact source commit/blob coordinates, custodied the native writer and provider-operation receipts, reproduced all three live imports, and reconstructed the combined chain. All nine workflows passed; PR #89 merged at `1c565c160d1a25b408e130402b5da52e855a8169`.
 
+## Propagation completion
+
+The separate task `SS-ERL-KV-PROPAGATION-VERIFICATION-001` completed and was canonically retired by `StegVerse-Labs/.github@2d6e477c6ebed075c1610a979ace28e53560f284`.
+
+- Site consumed the proof through `ca106480cd78a35fffa107e73a678219ca918bb1` and finalized its handoff at `3ac0a20ddf9895e724984e9b24dfa174537cc796`.
+- Publisher consumed the proof through `93a4743ceb5974689c1872c0e88dbb86de980f7e` and finalized its handoff at `0debdb0cf0e06f672a515e8b7fbf6d642521588e`.
+- Admissibility Wiki and the correctly located `StegVerse-002/stegguardian-wiki` were inspected and received evidence-backed `NOT_APPLICABLE` dispositions because neither has an ERL/KV consumer path.
+
 ## Remaining work
 
-1. Execute the separate propagation-verification task for applicable Site, Publisher, admissibility-wiki, and stegguardian-wiki surfaces.
+None for the ERL-to-MyKV storage integration or its bounded propagation verification. Authentic current-iPhone StegSocials standard-flow evidence remains under the parent task and is not part of this storage integration.
 
 ## Current state
 
-ERL_KV_INTEGRATION_COMPLETE_PROPAGATION_SEPARATE
+ERL_KV_INTEGRATION_AND_PROPAGATION_COMPLETE


### PR DESCRIPTION
Update the ERL KV README and canonical storage handoff with the retired propagation task, merged Site and Publisher projections, corrected Guardian repository location, and evidence-backed wiki dispositions.