### PR TITLE
Document digital data reclamation and sovereignty

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ The bounded propagation verification is also complete. Site and Publisher now ca
 
 See [ERL KnowledgeVault Storage Mirror Handoff](docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md).
 
+## Digital data reclamation and sovereignty
+
+The Meta AI child-data assembly privacy intake exposed a broader StegVerse architecture requirement: digital ownership must govern more than storage and deletion of source objects. Custody, access, correlation, derivation, and propagation are treated as separable rights, and technical readability does not automatically confer authority to combine data into new sensitive inferences.
+
+The documented StegVerse direction is a governed reclamation lifecycle: discover external personal data, classify it, establish authority, request or execute deletion/restriction, propagate revocation where possible, independently verify resulting state, retain receipts, and monitor recurrence. The architecture explicitly rejects claims of universal Internet erasure and requires source-specific proof classes instead.
+
+KnowledgeVault is the intended authoritative private inventory and continuity surface for known source objects, external appearances, legal/contractual authority, correlation and derivation permissions, deletion/restriction requests, verification evidence, receipts, and recurrence state. KnowledgeVault custody itself is not blanket authority for AI correlation across everything stored in the vault.
+
+See [Digital Data Reclamation and Sovereignty](docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY.md) and its [scoped mirror handoff](docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md).
+
 ## Status
 
 ```yaml
@@ -135,7 +145,7 @@ The Automated Political Reality Compendium Standard defines recurring search, ad
 ## Machine-readable schemas
 
 - [Political Influence Tree JSON Schema](schemas/political-influence-tree.schema.json)
-- [Source Posture JSON Schema](schemas/source-posture.schema.json)
+- [Source Posture JSON Schema](standards/source-posture-schema.md)
 - [Producer Export JSON Schema](schemas/producer-export.schema.json)
 - [Validation Result JSON Schema](schemas/validation-result.schema.json)
 - [Primary Record Intake JSON Schema](schemas/primary-record-intake.schema.json)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The Automated Political Reality Compendium Standard defines recurring search, ad
 ## Machine-readable schemas
 
 - [Political Influence Tree JSON Schema](schemas/political-influence-tree.schema.json)
-- [Source Posture JSON Schema](standards/source-posture-schema.md)
+- [Source Posture JSON Schema](schemas/source-posture.schema.json)
 - [Producer Export JSON Schema](schemas/producer-export.schema.json)
 - [Validation Result JSON Schema](schemas/validation-result.schema.json)
 - [Primary Record Intake JSON Schema](schemas/primary-record-intake.schema.json)

--- a/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY.md
+++ b/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY.md
@@ -1,0 +1,158 @@
+# StegVerse Digital Data Reclamation and Sovereignty
+
+Status: architecture/design record
+Updated: 2026-09-09
+Parent Goal Task ID: `SS-EVIDENCE-COMPARISON-001`
+Related ERL candidate: `ERL-2026-09-09-META-AI-CHILD-DATA-ASSEMBLY-001`
+
+## Purpose
+
+Define a StegVerse capability for reclaiming practical control over a person's digital footprint while preserving a strict distinction between verifiable deletion/revocation evidence and claims of universal erasure.
+
+The service objective is not to promise that information can be made to disappear from every system. The objective is to discover where personal data exists, establish authority to act, request or execute deletion/revocation where lawful and technically possible, verify resulting state, retain receipts, and repeatedly detect recurrence or reappearance.
+
+## Core principle
+
+Ownership of digital data is broader than possession of a source object.
+
+StegVerse models at least five separable rights:
+
+1. `custody` — who physically or logically holds a source object;
+2. `access` — who may read the source object;
+3. `correlation` — who may join it with other objects or identities;
+4. `derivation` — who may create inferred attributes, relationship graphs, scores, or classifications from it;
+5. `propagation` — who may publish, replicate, sell, train on, disclose, or otherwise distribute source or derived material.
+
+Possession or technical readability does not itself grant correlation, derivation, or propagation authority.
+
+## Derived Data Authority
+
+A governed system should be able to answer:
+
+`May actor/system A combine objects X + Y + Z to derive inference Q, for purpose P, for requester R, at time T?`
+
+This authorization is separate from access to X, Y, or Z individually.
+
+Sensitive derivations such as identity resolution, minor status, family relationships, location, health, financial state, social graphs, behavioral predictions, and similar inferences may therefore require separate governed authority even when the underlying source objects are individually readable.
+
+## KnowledgeVault role
+
+KnowledgeVault should act as the user's authoritative private inventory and continuity layer for digital-data ownership and reclamation state.
+
+A future Personal Data Inventory should be able to retain:
+
+- canonical identities and aliases controlled by the user;
+- known source objects and hashes where available;
+- observed external locations where personal information appears;
+- account/platform/broker/source identity;
+- legal or contractual authority to request deletion or restriction;
+- correlation and derivation permissions;
+- propagation history where known;
+- deletion, correction, restriction, objection, and revocation requests;
+- response state and deadlines;
+- independent verification observations;
+- receipts, hashes, and provider references;
+- recurrence/reappearance observations;
+- unresolved or unverifiable external copies.
+
+KnowledgeVault custody must not be interpreted as permission for StegVerse or another AI to freely correlate everything inside the vault. Governed traversal remains a separate authority question.
+
+## Data Propagation Graph
+
+StegVerse should be able to represent the observable path of a person's information as a graph:
+
+`source object -> platform/account -> copy/repost -> index/cache -> data broker -> derived attribute -> downstream recipient -> model/retrieval surface`
+
+Each edge should carry, where available:
+
+- provenance;
+- observed timestamp;
+- authority/consent basis;
+- permitted purpose;
+- expiration or revocation state;
+- evidence class;
+- removal/restriction capability;
+- current verification state.
+
+The graph must distinguish direct copies from derived representations. Deletion of a source object must never be treated as proof that embeddings, indexes, caches, independently sourced copies, relationship edges, model-derived attributes, or downstream replicas were also deleted.
+
+## Reclamation workflow
+
+The canonical conceptual flow is:
+
+`discover -> classify -> establish authority -> request/execute deletion or restriction -> propagate revocation -> verify -> receipt -> monitor recurrence`
+
+The system should preserve fail-closed proof classes such as:
+
+- `DISCOVERED_ONLY`
+- `REQUEST_SUBMITTED`
+- `PROVIDER_ACKNOWLEDGED`
+- `SOURCE_NOT_FOUND_ON_RECHECK`
+- `DEINDEXED_VERIFIED`
+- `DELETED_PROVIDER_ASSERTED`
+- `DELETED_INDEPENDENTLY_VERIFIED`
+- `RESTRICTION_VERIFIED`
+- `DERIVED_DATA_REVOCATION_REQUESTED`
+- `DERIVED_DATA_REVOCATION_VERIFIED`
+- `REAPPEARED`
+- `UNVERIFIABLE`
+- `NOT_REMOVABLE_LEGAL_RECORD`
+
+No class may imply universal Internet erasure.
+
+## Expected effectiveness by source class
+
+The system should express effectiveness as evidence-backed source-specific posture rather than a single removal percentage.
+
+- user-controlled accounts: potentially very high when platform controls permit deletion and verification;
+- data brokers and people-search services: potentially high where opt-out or deletion mechanisms exist, but recurrence monitoring is required;
+- search engines: often high for qualifying de-indexing, while the originating material may remain online;
+- cooperative third-party sites: moderate to high depending on policy, jurisdiction, and operator response;
+- reposts, caches, mirrors, archives, and peer copies: variable and often materially harder;
+- public/government records: frequently restricted or non-removable depending on law;
+- derived profiles and inferred attributes: harder because the internal representation may not be externally observable;
+- trained AI models: direct parameter-level erasure may not be independently provable; practical controls can include source removal, retrieval suppression, future-use restriction, model-output restrictions, and provider attestation without claiming parameter deletion.
+
+## Receipts and evidence boundaries
+
+A StegVerse reclamation system should never equate a submitted request with successful removal.
+
+Every important transition should produce or reference evidence adequate to prove only that transition. Examples:
+
+- request receipt proves submission;
+- provider acknowledgement proves acknowledgement;
+- independent fetch/search proves current external observability state;
+- hash/reference comparison proves an observed object identity;
+- provider assertion may prove only what the provider states unless independently verified;
+- recurrence detection proves the data is observable again, not necessarily that the provider violated a prior obligation.
+
+## Prospective sovereignty
+
+Historical cleanup is intrinsically incomplete because copies and inferences may already exist outside the user's control.
+
+The stronger long-term StegVerse model is prospective: new disclosures originating from KnowledgeVault can carry governed purpose, recipient, duration, redistribution, correlation, and derivation authority. Where counterpart systems can consume these controls, authorization can travel with the data instead of being reduced to an opaque one-time consent event.
+
+## Children and dependent identities
+
+Data involving minors requires additional restrictions because the subject may not have meaningful capacity to consent to long-term profiling, correlation, or future uses created by adults or third parties.
+
+A parent or guardian authorizing one disclosure should not automatically authorize perpetual identity resolution, family-graph construction, location inference, commercialization, training use, or unrelated downstream processing.
+
+## Non-goals
+
+This capability must not claim:
+
+- universal Internet erasure;
+- deletion from systems that cannot be observed or lawfully reached;
+- parameter-level machine-learning deletion without evidence;
+- ownership of facts that are independently and lawfully held by others merely because they concern the user;
+- legal authority where no such authority exists;
+- successful deletion from a provider solely because a request was submitted.
+
+## Product direction
+
+Working capability name: `Digital Data Reclamation and Sovereignty`.
+
+This can become a StegVerse service combining KnowledgeVault, governed execution, provider adapters, legal-rights routing, recurrence monitoring, provenance, and verifiable receipts.
+
+The differentiator is not merely automation of opt-out forms. It is a governed, reconstructable lifecycle for source data, derived data, revocation, propagation, verification, and recurrence.

--- a/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
+++ b/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
@@ -1,0 +1,69 @@
+# Digital Data Reclamation and Sovereignty Mirror Handoff
+
+Updated: 2026-09-09
+
+## Goal Task ID
+
+`SS-EVIDENCE-COMPARISON-001`
+
+Canonical task record: `StegVerse-Labs/.github/data/canonical-task-records/SS-EVIDENCE-COMPARISON-001.json`
+COSV: `40000100100000`
+
+## Scope
+
+This scoped handoff governs the documentation and architecture projection created from the ERL privacy/derived-data intake. It does not replace `docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md` for ERL-to-KnowledgeVault storage proof.
+
+## Installed architecture
+
+- `docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY.md`
+- `research-candidates/2026-09-09-meta-ai-child-data-assembly-privacy.md`
+- `research-candidates/README.md`
+
+## Canonical concepts
+
+The installed design separates five digital-data rights: custody, access, correlation, derivation, and propagation.
+
+`Derived Data Authority` is a separate governed question from source-object access. Technical readability of several objects does not automatically authorize joining them into a sensitive inference.
+
+The proposed reclamation lifecycle is:
+
+`discover -> classify -> establish authority -> request/execute deletion or restriction -> propagate revocation -> verify -> receipt -> monitor recurrence`
+
+KnowledgeVault is the intended authoritative private inventory/continuity surface for known personal-data objects, external appearances, requests, responses, evidence, revocation state, and recurrence observations. KnowledgeVault custody itself must not be interpreted as blanket authority for AI correlation across all stored objects.
+
+## Evidence boundary
+
+The architecture explicitly refuses a universal Internet-erasure claim. Removal success must be expressed by source-specific evidence posture. A request receipt proves submission, not deletion. Provider acknowledgement proves acknowledgement, not independent erasure. Current external non-observability proves only the checked surface at the checked time.
+
+The model also distinguishes direct copies from indexes, caches, embeddings, independently sourced copies, relationship edges, derived attributes, retrieval surfaces, and trained-model behavior. Source deletion is not proof that those downstream representations were removed.
+
+## Product direction
+
+Working capability name: `Digital Data Reclamation and Sovereignty`.
+
+The intended StegVerse service combines KnowledgeVault, governed execution, provider adapters, legal-rights routing, Data Propagation Graphs, recurrence monitoring, provenance, and verifiable receipts.
+
+The long-term differentiator is prospective sovereignty: new disclosures can carry explicit purpose, recipient, duration, redistribution, correlation, and derivation authority rather than reducing consent to a one-time opaque permission.
+
+## Current state
+
+`DOCUMENTED / ERL-BOUND / KNOWLEDGEVAULT-ROLE-DEFINED / IMPLEMENTATION-NOT-YET-CLAIMED`
+
+No runtime deletion/reclamation service, provider adapter set, legal-rights router, propagation graph engine, recurrence monitor, or cross-provider verification runtime is claimed by this documentation change.
+
+## Next implementation decomposition
+
+When implementation begins, create dedicated canonical tasks for separable execution lanes rather than overloading this research/evidence parent:
+
+1. Personal Data Inventory schema and KnowledgeVault storage contract.
+2. Data Propagation Graph schema and provenance model.
+3. Derived Data Authority policy/receipt schema.
+4. Provider discovery/removal/restriction adapter framework.
+5. Verification and proof-class engine.
+6. Recurrence/reappearance monitor.
+7. Legal-rights/jurisdiction routing with explicit non-legal-advice boundaries.
+8. Prospective disclosure authority envelope for new StegVerse-originated data.
+
+## Manual work
+
+None for the documentation projection.


### PR DESCRIPTION
Documents the StegVerse Digital Data Reclamation and Sovereignty architecture derived from the ERL Meta AI child-data assembly privacy intake. Adds a scoped mirror handoff, root README integration, five separable digital-data rights, Derived Data Authority, Personal Data Inventory and Data Propagation Graph concepts, fail-closed reclamation proof classes, recurrence monitoring, and explicit refusal of universal Internet-erasure claims. This is an architecture/documentation change only; no runtime reclamation service is claimed.