### PR TITLE
Record Google Results about you as reclamation baseline

### DIFF
--- a/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY.md
+++ b/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY.md
@@ -100,6 +100,24 @@ The system should preserve fail-closed proof classes such as:
 
 No class may imply universal Internet erasure.
 
+## Observed industry baseline — Google Results about you
+
+A user-supplied current-iPhone capture of Google's `Results about you` surface on 2026-09-09 provides a useful bounded comparison point.
+
+The visible interface shows Google checking for search results associated with the user and maintaining a removal-request history with states such as `In progress` and `Approved`. Visible targets in the supplied capture include Whitepages, Anywho, USPhonebook, SearchPeopleFREE, and True People Search.
+
+This is useful capability, but the observed surface is materially narrower than the StegVerse reclamation model. It appears centered on Google Search discovery and removal-request handling for qualifying results. The screenshots do not establish that Google deletes the originating records from the named third-party services, reconstructs downstream propagation, revokes derived attributes, verifies model-training deletion, governs future correlation, or provides user-owned cross-provider custody of the full reclamation history.
+
+The StegVerse design therefore treats a search-engine removal workflow as one adapter class inside a broader reclamation system rather than as the whole system:
+
+`search-result discovery -> deindex/removal request -> search-surface verification`
+
+is only one branch of:
+
+`personal-data inventory -> source discovery -> source-specific action -> downstream propagation analysis -> derived-data authority/revocation -> independent verification -> receipt custody -> recurrence monitoring`
+
+This comparison must remain evidence-bounded. The supplied screenshots prove only what is visible in that interface at that moment; they do not prove Google's complete internal capabilities or product limits.
+
 ## Expected effectiveness by source class
 
 The system should express effectiveness as evidence-backed source-specific posture rather than a single removal percentage.

--- a/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
+++ b/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
@@ -37,6 +37,14 @@ The architecture explicitly refuses a universal Internet-erasure claim. Removal 
 
 The model also distinguishes direct copies from indexes, caches, embeddings, independently sourced copies, relationship edges, derived attributes, retrieval surfaces, and trained-model behavior. Source deletion is not proof that those downstream representations were removed.
 
+## Observed Google baseline — 2026-09-09
+
+The user supplied two current-iPhone screenshots of Google's `Results about you` surface. The visible interface shows Google checking for results about the user and displaying removal-request state such as `In progress` and `Approved`. Visible result targets include Whitepages, Anywho, USPhonebook, SearchPeopleFREE, and True People Search.
+
+This is recorded as a bounded industry-comparison observation, not a claim about Google's complete internal feature set. The screenshots show a useful search-result discovery/removal workflow, but do not establish source-site deletion, downstream propagation tracing, derived-data revocation, model-training erasure, prospective correlation authority, or user-owned cross-provider custody.
+
+StegVerse therefore treats search-engine result removal as one provider-adapter lane inside the broader reclamation architecture rather than as the complete reclamation model.
+
 ## Product direction
 
 Working capability name: `Digital Data Reclamation and Sovereignty`.
@@ -47,7 +55,7 @@ The long-term differentiator is prospective sovereignty: new disclosures can car
 
 ## Current state
 
-`DOCUMENTED / ERL-BOUND / KNOWLEDGEVAULT-ROLE-DEFINED / IMPLEMENTATION-NOT-YET-CLAIMED`
+`DOCUMENTED / ERL-BOUND / KNOWLEDGEVAULT-ROLE-DEFINED / GOOGLE-SEARCH-REMOVAL-BASELINE-RECORDED / IMPLEMENTATION-NOT-YET-CLAIMED`
 
 No runtime deletion/reclamation service, provider adapter set, legal-rights router, propagation graph engine, recurrence monitor, or cross-provider verification runtime is claimed by this documentation change.
 


### PR DESCRIPTION
Adds a bounded industry-comparison observation from the user-supplied current-iPhone captures of Google Results about you. Documents the visible search-result discovery/removal workflow and explicitly distinguishes it from StegVerse's broader KnowledgeVault-backed reclamation model: source actions, propagation analysis, derived-data authority/revocation, independent verification, receipt custody, and recurrence monitoring. No claim is made about Google's complete internal capabilities.