### PR TITLE
Add SKAP-seeded customer-data disclosure graph

### DIFF
--- a/.github/workflows/validate-digital-data-reclamation.yml
+++ b/.github/workflows/validate-digital-data-reclamation.yml
@@ -1,0 +1,39 @@
+name: Validate Digital Data Reclamation Foundation
+
+on:
+  pull_request:
+    paths:
+      - 'schemas/personal-data-inventory.schema.json'
+      - 'schemas/data-propagation-graph.schema.json'
+      - 'schemas/derived-data-authority-receipt.schema.json'
+      - 'fixtures/digital-data-reclamation/**'
+      - 'scripts/validate_digital_data_reclamation.py'
+      - 'docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY**'
+      - '.github/workflows/validate-digital-data-reclamation.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'schemas/personal-data-inventory.schema.json'
+      - 'schemas/data-propagation-graph.schema.json'
+      - 'schemas/derived-data-authority-receipt.schema.json'
+      - 'fixtures/digital-data-reclamation/**'
+      - 'scripts/validate_digital_data_reclamation.py'
+      - 'docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY**'
+      - '.github/workflows/validate-digital-data-reclamation.yml'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install validator
+        run: python -m pip install --upgrade jsonschema referencing
+      - name: Validate Digital Data Reclamation foundation
+        run: python scripts/validate_digital_data_reclamation.py

--- a/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
+++ b/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
@@ -13,85 +13,74 @@ COSV: `40000100100000`
 
 This scoped handoff governs the documentation and first implementation foundation created from the ERL privacy/derived-data intake. It does not replace `docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md` for ERL-to-KnowledgeVault storage proof.
 
-The current parent task remains canonical because it is the registered ACTIVE task that established the ERL/KV evidence boundary. This implementation slice is bounded to schemas, deterministic validation, and fail-closed authority semantics; it does not claim a live deletion service.
+The current parent task remains canonical because it is the registered ACTIVE task that established the ERL/KV evidence boundary. This implementation slice is bounded to schemas, deterministic validation, fail-closed authority semantics, and evidence-bounded discovery topology; it does not claim a live deletion service.
 
-## Installed architecture
+## Installed architecture and implementation
 
 - `docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY.md`
-- `research-candidates/2026-09-09-meta-ai-child-data-assembly-privacy.md`
-- `research-candidates/README.md`
-
-## First implementation foundation
-
-Implemented on branch `impl/digital-data-reclamation-foundation-20260909`:
-
+- `docs/SKAP_ACCOUNT_DISCLOSURE_GRAPH.md`
 - `schemas/personal-data-inventory.schema.json`
 - `schemas/data-propagation-graph.schema.json`
 - `schemas/derived-data-authority-receipt.schema.json`
-- `fixtures/digital-data-reclamation/personal-data-inventory.sample.json`
-- `fixtures/digital-data-reclamation/data-propagation-graph.sample.json`
-- `fixtures/digital-data-reclamation/derived-data-authority-receipt.sample.json`
-- `fixtures/digital-data-reclamation/invalid-no-authority-allows-derivation.json`
+- `schemas/skap-account-disclosure-graph.schema.json`
+- `fixtures/digital-data-reclamation/`
 - `scripts/validate_digital_data_reclamation.py`
 - `.github/workflows/validate-digital-data-reclamation.yml`
 
-The Personal Data Inventory provides a machine-readable user-centered inventory for source objects, external appearances, current removal state, and the five separable authority dimensions. The Data Propagation Graph provides explicit source/copy/index/broker/derived/downstream/model nodes and provenance-bearing edges. The Derived Data Authority receipt requires actor, requester, source objects, requested derivation, purpose, authority basis, decision, and downstream-use constraints.
+The Personal Data Inventory models source objects, external appearances, removal state, and five separable authority dimensions. The Data Propagation Graph models source/copy/index/broker/derived/downstream/model nodes. The Derived Data Authority receipt fails closed when no derivation authority exists.
 
-The receipt schema fails closed when `authority_basis=NO_AUTHORITY`: the only valid decision is `DENY`. The deterministic validator also checks inventory object references, graph node/edge referential integrity, duplicate graph identifiers, and a negative fixture proving that `NO_AUTHORITY + ALLOW` is rejected.
+The SKAP Account Disclosure Graph extends discovery upstream from known harvesting sites. Every authorized SKAP account can seed an evidence-bounded account-provider topology:
+
+`SKAP account -> account provider -> declared/observed downstream organization -> additional recipient -> broker/search/public surface`
+
+This graph distinguishes evidence-backed distribution relationships from unverified inference. A provider privacy disclosure, subprocessor list, regulator/court record, user export, or authentic transfer observation may establish a downstream candidate. It does not by itself prove that a particular user's datum traversed that edge.
+
+The deterministic validator enforces SKAP account/provider referential integrity, organization and edge uniqueness, retained evidence references for evidence-backed edges, and a fail-closed rule preventing `INFERRED_UNVERIFIED` or `UNKNOWN` edges from becoming `PRIMARY` reclamation targets.
 
 ## Canonical concepts
 
-The installed design separates five digital-data rights: custody, access, correlation, derivation, and propagation.
-
-`Derived Data Authority` is a separate governed question from source-object access. Technical readability of several objects does not automatically authorize joining them into a sensitive inference.
+Digital ownership separates custody, access, correlation, derivation, and propagation. Technical readability does not automatically confer authority to correlate or derive.
 
 The reclamation lifecycle is:
 
 `discover -> classify -> establish authority -> request/execute deletion or restriction -> propagate revocation -> verify -> receipt -> monitor recurrence`
 
-KnowledgeVault is the intended authoritative private inventory/continuity surface for known personal-data objects, external appearances, requests, responses, evidence, revocation state, and recurrence observations. KnowledgeVault custody itself must not be interpreted as blanket authority for AI correlation across all stored objects.
+Discovery itself now has two complementary origins:
+
+`known external harvesting/removal targets`
+
+plus
+
+`known SKAP accounts -> account providers -> evidence-backed customer-data distribution graph`
+
+KnowledgeVault is the intended authoritative private inventory/continuity surface for account topology, source objects, external appearances, provider-distribution evidence, requests, responses, revocation state, receipts, and recurrence observations. Graph membership is discovery context, not execution authority; Interlock/InTr remains the governed transition authority.
 
 ## Evidence boundary
 
-The architecture explicitly refuses a universal Internet-erasure claim. Removal success must be expressed by source-specific evidence posture. A request receipt proves submission, not deletion. Provider acknowledgement proves acknowledgement, not independent erasure. Current external non-observability proves only the checked surface at the checked time.
-
-The model also distinguishes direct copies from indexes, caches, embeddings, independently sourced copies, relationship edges, derived attributes, retrieval surfaces, and trained-model behavior. Source deletion is not proof that those downstream representations were removed.
+The architecture refuses universal Internet-erasure claims. A submitted request is not proof of deletion. A provider disclosure relationship is not proof that a specific user's data traversed it. An inferred relationship cannot be promoted to a primary reclamation target without stronger evidence.
 
 ## Observed Google baseline — 2026-09-09
 
-The user supplied two current-iPhone screenshots of Google's `Results about you` surface. The visible interface shows Google checking for results about the user and displaying removal-request state such as `In progress` and `Approved`. Visible result targets include Whitepages, Anywho, USPhonebook, SearchPeopleFREE, and True People Search.
-
-This is recorded as a bounded industry-comparison observation, not a claim about Google's complete internal feature set. The screenshots show a useful search-result discovery/removal workflow, but do not establish source-site deletion, downstream propagation tracing, derived-data revocation, model-training erasure, prospective correlation authority, or user-owned cross-provider custody.
-
-StegVerse therefore treats search-engine result removal as one provider-adapter lane inside the broader reclamation architecture rather than as the complete reclamation model.
-
-## Product direction
-
-Working capability name: `Digital Data Reclamation and Sovereignty`.
-
-The intended StegVerse service combines KnowledgeVault, governed execution, provider adapters, legal-rights routing, Data Propagation Graphs, recurrence monitoring, provenance, and verifiable receipts.
-
-The long-term differentiator is prospective sovereignty: new disclosures can carry explicit purpose, recipient, duration, redistribution, correlation, and derivation authority rather than reducing consent to a one-time opaque permission.
+The user supplied current-iPhone screenshots of Google's `Results about you` interface showing result checking and removal-request states such as `In progress` and `Approved`, including visible people-search targets. This is retained only as a bounded comparison point for search-surface removal; it does not establish source-site deletion or full downstream propagation control.
 
 ## Current state
 
-`FOUNDATION_IMPLEMENTED / SCHEMAS_AND_FAIL_CLOSED_VALIDATOR_PRESENT / HOSTED_VALIDATION_PENDING / LIVE_RECLAMATION_RUNTIME_NOT_YET_CLAIMED`
+`FOUNDATION_IMPLEMENTED / HOSTED_VALIDATION_OF_BASE_FOUNDATION_PASSED / SKAP_DISCLOSURE_GRAPH_IMPLEMENTED_PENDING_CURRENT_PR_VALIDATION / LIVE_RECLAMATION_RUNTIME_NOT_YET_CLAIMED`
 
 No live deletion/reclamation service, provider adapter set, legal-rights router, recurrence monitor, or cross-provider verification runtime is claimed yet.
 
 ## Remaining implementation decomposition
 
-1. Bind Personal Data Inventory to a concrete KnowledgeVault storage contract and writer/readback receipt.
-2. Add Data Propagation Graph mutation/reconciliation logic from observed provider/search evidence.
-3. Bind Derived Data Authority receipts to Interlock/InTr governed transition evaluation.
-4. Build provider discovery/removal/restriction adapter framework, beginning with search-result and people-search lanes.
-5. Build verification/proof-class engine that cannot promote request/acknowledgement into deletion.
-6. Build recurrence/reappearance monitor.
-7. Add legal-rights/jurisdiction routing with explicit non-legal-advice boundaries.
-8. Add prospective disclosure authority envelope for new StegVerse-originated data.
+1. Bind Personal Data Inventory and SKAP account topology to concrete KnowledgeVault writer/readback receipts.
+2. Build evidence ingestion that derives disclosure-graph edges from provider policies, subprocessor lists, regulatory records, user exports, and authentic observations.
+3. Reconcile the SKAP Account Disclosure Graph into the Data Propagation Graph without converting candidate relationships into user-specific transfer facts.
+4. Bind Derived Data Authority receipts to Interlock/InTr governed transition evaluation.
+5. Build provider discovery/removal/restriction adapters and verification/proof-class engine.
+6. Build recurrence/reappearance monitoring and legal-rights/jurisdiction routing.
+7. Add prospective disclosure authority envelopes for new StegVerse-originated data.
 
-By Goal Prompt Count 20, any genuinely separable remaining implementation lanes must be transferred into new canonical Goal Task IDs rather than extending this evidence-comparison parent indefinitely.
+By Goal Prompt Count 20, genuinely separable implementation lanes must move into new canonical Goal Task IDs rather than extending this evidence-comparison parent indefinitely.
 
 ## Manual work
 
-None for this implementation foundation.
+None for this implementation slice.

--- a/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
+++ b/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
@@ -11,7 +11,9 @@ COSV: `40000100100000`
 
 ## Scope
 
-This scoped handoff governs the documentation and architecture projection created from the ERL privacy/derived-data intake. It does not replace `docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md` for ERL-to-KnowledgeVault storage proof.
+This scoped handoff governs the documentation and first implementation foundation created from the ERL privacy/derived-data intake. It does not replace `docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md` for ERL-to-KnowledgeVault storage proof.
+
+The current parent task remains canonical because it is the registered ACTIVE task that established the ERL/KV evidence boundary. This implementation slice is bounded to schemas, deterministic validation, and fail-closed authority semantics; it does not claim a live deletion service.
 
 ## Installed architecture
 
@@ -19,13 +21,31 @@ This scoped handoff governs the documentation and architecture projection create
 - `research-candidates/2026-09-09-meta-ai-child-data-assembly-privacy.md`
 - `research-candidates/README.md`
 
+## First implementation foundation
+
+Implemented on branch `impl/digital-data-reclamation-foundation-20260909`:
+
+- `schemas/personal-data-inventory.schema.json`
+- `schemas/data-propagation-graph.schema.json`
+- `schemas/derived-data-authority-receipt.schema.json`
+- `fixtures/digital-data-reclamation/personal-data-inventory.sample.json`
+- `fixtures/digital-data-reclamation/data-propagation-graph.sample.json`
+- `fixtures/digital-data-reclamation/derived-data-authority-receipt.sample.json`
+- `fixtures/digital-data-reclamation/invalid-no-authority-allows-derivation.json`
+- `scripts/validate_digital_data_reclamation.py`
+- `.github/workflows/validate-digital-data-reclamation.yml`
+
+The Personal Data Inventory provides a machine-readable user-centered inventory for source objects, external appearances, current removal state, and the five separable authority dimensions. The Data Propagation Graph provides explicit source/copy/index/broker/derived/downstream/model nodes and provenance-bearing edges. The Derived Data Authority receipt requires actor, requester, source objects, requested derivation, purpose, authority basis, decision, and downstream-use constraints.
+
+The receipt schema fails closed when `authority_basis=NO_AUTHORITY`: the only valid decision is `DENY`. The deterministic validator also checks inventory object references, graph node/edge referential integrity, duplicate graph identifiers, and a negative fixture proving that `NO_AUTHORITY + ALLOW` is rejected.
+
 ## Canonical concepts
 
 The installed design separates five digital-data rights: custody, access, correlation, derivation, and propagation.
 
 `Derived Data Authority` is a separate governed question from source-object access. Technical readability of several objects does not automatically authorize joining them into a sensitive inference.
 
-The proposed reclamation lifecycle is:
+The reclamation lifecycle is:
 
 `discover -> classify -> establish authority -> request/execute deletion or restriction -> propagate revocation -> verify -> receipt -> monitor recurrence`
 
@@ -55,23 +75,23 @@ The long-term differentiator is prospective sovereignty: new disclosures can car
 
 ## Current state
 
-`DOCUMENTED / ERL-BOUND / KNOWLEDGEVAULT-ROLE-DEFINED / GOOGLE-SEARCH-REMOVAL-BASELINE-RECORDED / IMPLEMENTATION-NOT-YET-CLAIMED`
+`FOUNDATION_IMPLEMENTED / SCHEMAS_AND_FAIL_CLOSED_VALIDATOR_PRESENT / HOSTED_VALIDATION_PENDING / LIVE_RECLAMATION_RUNTIME_NOT_YET_CLAIMED`
 
-No runtime deletion/reclamation service, provider adapter set, legal-rights router, propagation graph engine, recurrence monitor, or cross-provider verification runtime is claimed by this documentation change.
+No live deletion/reclamation service, provider adapter set, legal-rights router, recurrence monitor, or cross-provider verification runtime is claimed yet.
 
-## Next implementation decomposition
+## Remaining implementation decomposition
 
-When implementation begins, create dedicated canonical tasks for separable execution lanes rather than overloading this research/evidence parent:
+1. Bind Personal Data Inventory to a concrete KnowledgeVault storage contract and writer/readback receipt.
+2. Add Data Propagation Graph mutation/reconciliation logic from observed provider/search evidence.
+3. Bind Derived Data Authority receipts to Interlock/InTr governed transition evaluation.
+4. Build provider discovery/removal/restriction adapter framework, beginning with search-result and people-search lanes.
+5. Build verification/proof-class engine that cannot promote request/acknowledgement into deletion.
+6. Build recurrence/reappearance monitor.
+7. Add legal-rights/jurisdiction routing with explicit non-legal-advice boundaries.
+8. Add prospective disclosure authority envelope for new StegVerse-originated data.
 
-1. Personal Data Inventory schema and KnowledgeVault storage contract.
-2. Data Propagation Graph schema and provenance model.
-3. Derived Data Authority policy/receipt schema.
-4. Provider discovery/removal/restriction adapter framework.
-5. Verification and proof-class engine.
-6. Recurrence/reappearance monitor.
-7. Legal-rights/jurisdiction routing with explicit non-legal-advice boundaries.
-8. Prospective disclosure authority envelope for new StegVerse-originated data.
+By Goal Prompt Count 20, any genuinely separable remaining implementation lanes must be transferred into new canonical Goal Task IDs rather than extending this evidence-comparison parent indefinitely.
 
 ## Manual work
 
-None for the documentation projection.
+None for this implementation foundation.

--- a/docs/SKAP_ACCOUNT_DISCLOSURE_GRAPH.md
+++ b/docs/SKAP_ACCOUNT_DISCLOSURE_GRAPH.md
@@ -1,0 +1,17 @@
+# SKAP-Seeded Account Disclosure Graph
+
+StegVerse Digital Data Reclamation must not discover personal exposure only by checking known data-harvesting sites. It must also begin from the user's own known account topology.
+
+For every authorized SKAP account, the reclamation system should identify the account provider and maintain an evidence-bounded graph of organizations to which that provider is known, reported, observed, or suspected to disclose, sell, share, process, subprocess, affiliate, index, or otherwise expose customer data.
+
+The discovery expansion becomes:
+
+`SKAP account -> account provider -> declared/observed downstream organizations -> additional downstream recipients -> public/search/broker surfaces`
+
+This graph is a discovery-priority graph, not proof that a particular user's records were transferred on every edge. Edge evidence state is therefore mandatory. `DECLARED_BY_PROVIDER`, `OBSERVED_TRANSFER`, and `REGULATORY_OR_COURT_RECORD` can support stronger follow-up than `INFERRED_UNVERIFIED` or `UNKNOWN`.
+
+A provider privacy policy, subprocessor list, sale/share disclosure, regulator record, court record, user export, or authentic network/provider receipt can establish a candidate downstream relationship. It cannot by itself prove that a specific datum for a specific user traversed that edge unless evidence supports that narrower claim.
+
+This prevents two opposite failures: missing likely downstream copies because StegVerse only searches known brokers, and overclaiming that every listed provider relationship contains the user's data.
+
+KnowledgeVault should retain the subject's SKAP-linked account inventory, the disclosure graph, evidence references, verification timestamps, and reclamation state. Interlock/InTr remains the transition authority for governed execution; graph membership is discovery context, not permission to act.

--- a/fixtures/digital-data-reclamation/data-propagation-graph.sample.json
+++ b/fixtures/digital-data-reclamation/data-propagation-graph.sample.json
@@ -1,0 +1,37 @@
+{
+  "schema": "stegverse.data-propagation-graph/v1",
+  "graph_id": "DPG-SAMPLE-001",
+  "subject_ref": "subject:sample",
+  "generated_at": "2026-09-09T21:30:00Z",
+  "nodes": [
+    {"node_id": "n1", "node_type": "source_object", "identity": "obj:email:1", "current_state": "OBSERVED"},
+    {"node_id": "n2", "node_type": "data_broker", "identity": "people-search-service", "current_state": "REMOVAL_REQUESTED"},
+    {"node_id": "n3", "node_type": "index_or_cache", "identity": "search-result-surface", "current_state": "OBSERVED"}
+  ],
+  "edges": [
+    {
+      "edge_id": "e1",
+      "from": "n1",
+      "to": "n2",
+      "relationship": "aggregated_by",
+      "observed_at": "2026-09-09T21:30:00Z",
+      "authority_basis": null,
+      "permitted_purpose": null,
+      "revocation_state": "REQUESTED",
+      "evidence_class": "DIRECT_OBSERVATION",
+      "verification_state": "VERIFIED"
+    },
+    {
+      "edge_id": "e2",
+      "from": "n2",
+      "to": "n3",
+      "relationship": "indexed_by",
+      "observed_at": "2026-09-09T21:30:00Z",
+      "authority_basis": null,
+      "permitted_purpose": null,
+      "revocation_state": "REQUESTED",
+      "evidence_class": "DIRECT_OBSERVATION",
+      "verification_state": "VERIFIED"
+    }
+  ]
+}

--- a/fixtures/digital-data-reclamation/derived-data-authority-receipt.sample.json
+++ b/fixtures/digital-data-reclamation/derived-data-authority-receipt.sample.json
@@ -1,0 +1,21 @@
+{
+  "schema": "stegverse.derived-data-authority-receipt/v1",
+  "receipt_id": "DDA-SAMPLE-001",
+  "issued_at": "2026-09-09T21:30:00Z",
+  "subject_ref": "subject:sample",
+  "actor": "stegverse-governed-ai",
+  "requester": "subject:sample",
+  "source_object_refs": ["obj:email:1"],
+  "requested_derivation": "correlate public appearances to discover removal targets",
+  "purpose": "personal-data-reclamation",
+  "decision": "CONDITIONAL",
+  "authority_basis": "SUBJECT_CONSENT",
+  "constraints": {
+    "expires_at": "2026-09-10T21:30:00Z",
+    "redistribution_allowed": false,
+    "training_use_allowed": false,
+    "further_derivation_allowed": false
+  },
+  "governance_artifact_ref": "governance:sample:1",
+  "revocation_ref": null
+}

--- a/fixtures/digital-data-reclamation/invalid-no-authority-allows-derivation.json
+++ b/fixtures/digital-data-reclamation/invalid-no-authority-allows-derivation.json
@@ -1,0 +1,21 @@
+{
+  "schema": "stegverse.derived-data-authority-receipt/v1",
+  "receipt_id": "DDA-INVALID-001",
+  "issued_at": "2026-09-09T21:30:00Z",
+  "subject_ref": "subject:sample",
+  "actor": "external-ai",
+  "requester": "external-requester",
+  "source_object_refs": ["obj:email:1"],
+  "requested_derivation": "derive home location",
+  "purpose": "unspecified",
+  "decision": "ALLOW",
+  "authority_basis": "NO_AUTHORITY",
+  "constraints": {
+    "expires_at": null,
+    "redistribution_allowed": true,
+    "training_use_allowed": true,
+    "further_derivation_allowed": true
+  },
+  "governance_artifact_ref": null,
+  "revocation_ref": null
+}

--- a/fixtures/digital-data-reclamation/invalid-unverified-primary-disclosure-edge.json
+++ b/fixtures/digital-data-reclamation/invalid-unverified-primary-disclosure-edge.json
@@ -1,0 +1,28 @@
+{
+  "schema": "stegverse.skap-account-disclosure-graph/v1",
+  "graph_id": "DDR-SKAP-GRAPH-INVALID-001",
+  "subject_ref": "subject:example-user",
+  "updated_at": "2026-09-10T03:28:00Z",
+  "accounts": [
+    {"skap_account_ref": "skap:account:example-social", "provider_org_ref": "org:example-social", "account_class": "social", "status": "ACTIVE"}
+  ],
+  "organizations": [
+    {"org_ref": "org:example-social", "name": "Example Social Provider", "role": "ACCOUNT_PROVIDER"},
+    {"org_ref": "org:unknown-recipient", "name": "Unknown Recipient", "role": "OTHER"}
+  ],
+  "disclosure_edges": [
+    {
+      "edge_id": "edge:unverified-primary",
+      "from_org_ref": "org:example-social",
+      "to_org_ref": "org:unknown-recipient",
+      "skap_account_refs": ["skap:account:example-social"],
+      "data_classes": ["identity"],
+      "relationship": "UNKNOWN_TRANSFER",
+      "purpose": null,
+      "evidence_state": "INFERRED_UNVERIFIED",
+      "evidence_refs": [],
+      "last_verified_at": "2026-09-10T03:28:00Z",
+      "reclamation_priority": "PRIMARY"
+    }
+  ]
+}

--- a/fixtures/digital-data-reclamation/personal-data-inventory.sample.json
+++ b/fixtures/digital-data-reclamation/personal-data-inventory.sample.json
@@ -1,0 +1,33 @@
+{
+  "schema": "stegverse.personal-data-inventory/v1",
+  "inventory_id": "PDI-SAMPLE-001",
+  "subject_ref": "subject:sample",
+  "updated_at": "2026-09-09T21:30:00Z",
+  "objects": [
+    {
+      "object_id": "obj:email:1",
+      "classification": "contact",
+      "custody_state": "BOTH",
+      "source_identity": "user-owned-email-address",
+      "sha256": null,
+      "sensitivity": "sensitive"
+    }
+  ],
+  "external_appearances": [
+    {
+      "appearance_id": "appearance:whitepages:1",
+      "object_ref": "obj:email:1",
+      "surface": "people-search-service",
+      "url": "https://example.invalid/person/1",
+      "observed_at": "2026-09-09T21:30:00Z",
+      "state": "REMOVAL_REQUESTED"
+    }
+  ],
+  "authority": {
+    "custody": "ALLOW",
+    "access": "CONDITIONAL",
+    "correlation": "DENY",
+    "derivation": "DENY",
+    "propagation": "DENY"
+  }
+}

--- a/fixtures/digital-data-reclamation/skap-account-disclosure-graph.sample.json
+++ b/fixtures/digital-data-reclamation/skap-account-disclosure-graph.sample.json
@@ -1,0 +1,42 @@
+{
+  "schema": "stegverse.skap-account-disclosure-graph/v1",
+  "graph_id": "DDR-SKAP-GRAPH-001",
+  "subject_ref": "subject:example-user",
+  "updated_at": "2026-09-10T03:28:00Z",
+  "accounts": [
+    {"skap_account_ref": "skap:account:example-social", "provider_org_ref": "org:example-social", "account_class": "social", "status": "ACTIVE"}
+  ],
+  "organizations": [
+    {"org_ref": "org:example-social", "name": "Example Social Provider", "role": "ACCOUNT_PROVIDER"},
+    {"org_ref": "org:example-analytics", "name": "Example Analytics Partner", "role": "ANALYTICS_PARTNER"},
+    {"org_ref": "org:example-broker", "name": "Example Data Broker", "role": "DATA_BROKER"}
+  ],
+  "disclosure_edges": [
+    {
+      "edge_id": "edge:provider-to-analytics",
+      "from_org_ref": "org:example-social",
+      "to_org_ref": "org:example-analytics",
+      "skap_account_refs": ["skap:account:example-social"],
+      "data_classes": ["identity", "device", "behavioral"],
+      "relationship": "SHARED_WITH",
+      "purpose": "analytics",
+      "evidence_state": "DECLARED_BY_PROVIDER",
+      "evidence_refs": ["evidence:provider-privacy-disclosure:example"],
+      "last_verified_at": "2026-09-10T03:28:00Z",
+      "reclamation_priority": "DOWNSTREAM"
+    },
+    {
+      "edge_id": "edge:analytics-to-broker",
+      "from_org_ref": "org:example-analytics",
+      "to_org_ref": "org:example-broker",
+      "skap_account_refs": ["skap:account:example-social"],
+      "data_classes": ["derived", "advertising"],
+      "relationship": "UNKNOWN_TRANSFER",
+      "purpose": null,
+      "evidence_state": "INFERRED_UNVERIFIED",
+      "evidence_refs": [],
+      "last_verified_at": "2026-09-10T03:28:00Z",
+      "reclamation_priority": "WATCH"
+    }
+  ]
+}

--- a/schemas/data-propagation-graph.schema.json
+++ b/schemas/data-propagation-graph.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/data-propagation-graph.schema.json",
+  "title": "StegVerse Data Propagation Graph",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "graph_id", "subject_ref", "generated_at", "nodes", "edges"],
+  "properties": {
+    "schema": {"const": "stegverse.data-propagation-graph/v1"},
+    "graph_id": {"type": "string", "minLength": 3},
+    "subject_ref": {"type": "string", "minLength": 1},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["node_id", "node_type", "identity"],
+        "properties": {
+          "node_id": {"type": "string", "minLength": 1},
+          "node_type": {"type": "string", "enum": ["source_object", "platform_account", "copy_or_repost", "index_or_cache", "data_broker", "derived_attribute", "downstream_recipient", "model_or_retrieval_surface"]},
+          "identity": {"type": "string", "minLength": 1},
+          "current_state": {"type": "string", "enum": ["OBSERVED", "NOT_OBSERVED", "REMOVAL_REQUESTED", "RESTRICTED", "PROVIDER_ASSERTED_DELETED", "INDEPENDENTLY_VERIFIED_DELETED", "REAPPEARED", "UNVERIFIABLE"]}
+        }
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["edge_id", "from", "to", "relationship", "evidence_class", "verification_state"],
+        "properties": {
+          "edge_id": {"type": "string", "minLength": 1},
+          "from": {"type": "string", "minLength": 1},
+          "to": {"type": "string", "minLength": 1},
+          "relationship": {"type": "string", "enum": ["copied_to", "indexed_by", "cached_by", "aggregated_by", "correlated_with", "derived_into", "disclosed_to", "retrievable_through"]},
+          "observed_at": {"type": ["string", "null"], "format": "date-time"},
+          "authority_basis": {"type": ["string", "null"]},
+          "permitted_purpose": {"type": ["string", "null"]},
+          "revocation_state": {"type": "string", "enum": ["NOT_REQUESTED", "REQUESTED", "ACKNOWLEDGED", "VERIFIED", "UNVERIFIABLE", "NOT_APPLICABLE"]},
+          "evidence_class": {"type": "string", "enum": ["DIRECT_OBSERVATION", "PROVIDER_ASSERTION", "INDEPENDENT_RECHECK", "INFERRED_RELATIONSHIP", "USER_ASSERTION", "UNKNOWN"]},
+          "verification_state": {"type": "string", "enum": ["UNVERIFIED", "PARTIALLY_VERIFIED", "VERIFIED", "CONTRADICTED"]}
+        }
+      }
+    }
+  }
+}

--- a/schemas/derived-data-authority-receipt.schema.json
+++ b/schemas/derived-data-authority-receipt.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/derived-data-authority-receipt.schema.json",
+  "title": "StegVerse Derived Data Authority Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "receipt_id", "issued_at", "subject_ref", "actor", "requester", "source_object_refs", "requested_derivation", "purpose", "decision", "authority_basis", "constraints"],
+  "properties": {
+    "schema": {"const": "stegverse.derived-data-authority-receipt/v1"},
+    "receipt_id": {"type": "string", "minLength": 3},
+    "issued_at": {"type": "string", "format": "date-time"},
+    "subject_ref": {"type": "string", "minLength": 1},
+    "actor": {"type": "string", "minLength": 1},
+    "requester": {"type": "string", "minLength": 1},
+    "source_object_refs": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "requested_derivation": {"type": "string", "minLength": 1},
+    "purpose": {"type": "string", "minLength": 1},
+    "decision": {"type": "string", "enum": ["ALLOW", "DENY", "CONDITIONAL"]},
+    "authority_basis": {"type": "string", "enum": ["SUBJECT_CONSENT", "GUARDIAN_AUTHORITY", "CONTRACT", "LEGAL_REQUIREMENT", "GOVERNANCE_POLICY", "NO_AUTHORITY"]},
+    "constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["expires_at", "redistribution_allowed", "training_use_allowed", "further_derivation_allowed"],
+      "properties": {
+        "expires_at": {"type": ["string", "null"], "format": "date-time"},
+        "redistribution_allowed": {"type": "boolean"},
+        "training_use_allowed": {"type": "boolean"},
+        "further_derivation_allowed": {"type": "boolean"}
+      }
+    },
+    "governance_artifact_ref": {"type": ["string", "null"]},
+    "revocation_ref": {"type": ["string", "null"]}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"authority_basis": {"const": "NO_AUTHORITY"}}, "required": ["authority_basis"]},
+      "then": {"properties": {"decision": {"const": "DENY"}}}
+    }
+  ]
+}

--- a/schemas/personal-data-inventory.schema.json
+++ b/schemas/personal-data-inventory.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/personal-data-inventory.schema.json",
+  "title": "StegVerse Personal Data Inventory",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "inventory_id", "subject_ref", "updated_at", "objects", "external_appearances", "authority"],
+  "properties": {
+    "schema": {"const": "stegverse.personal-data-inventory/v1"},
+    "inventory_id": {"type": "string", "pattern": "^[A-Z0-9][A-Z0-9._:-]{2,127}$"},
+    "subject_ref": {"type": "string", "minLength": 1},
+    "updated_at": {"type": "string", "format": "date-time"},
+    "objects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["object_id", "classification", "custody_state", "source_identity"],
+        "properties": {
+          "object_id": {"type": "string", "minLength": 1},
+          "classification": {"type": "string", "enum": ["identity", "contact", "location", "family", "media", "financial", "health", "employment", "account", "legal", "other"]},
+          "custody_state": {"type": "string", "enum": ["USER_CUSTODIED", "EXTERNAL_ONLY", "BOTH", "UNKNOWN"]},
+          "source_identity": {"type": "string", "minLength": 1},
+          "sha256": {"type": ["string", "null"], "pattern": "^[0-9a-f]{64}$"},
+          "sensitivity": {"type": "string", "enum": ["ordinary", "sensitive", "highly_sensitive", "minor_related"]}
+        }
+      }
+    },
+    "external_appearances": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["appearance_id", "object_ref", "surface", "observed_at", "state"],
+        "properties": {
+          "appearance_id": {"type": "string", "minLength": 1},
+          "object_ref": {"type": "string", "minLength": 1},
+          "surface": {"type": "string", "minLength": 1},
+          "url": {"type": ["string", "null"], "format": "uri"},
+          "observed_at": {"type": "string", "format": "date-time"},
+          "state": {"type": "string", "enum": ["DISCOVERED", "REMOVAL_REQUESTED", "PROVIDER_ACKNOWLEDGED", "NOT_FOUND_ON_RECHECK", "DEINDEXED", "DELETED_PROVIDER_ASSERTED", "DELETED_INDEPENDENTLY_VERIFIED", "RESTRICTED", "REAPPEARED", "UNVERIFIABLE", "NOT_REMOVABLE_LEGAL_RECORD"]}
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["custody", "access", "correlation", "derivation", "propagation"],
+      "properties": {
+        "custody": {"type": "string", "enum": ["ALLOW", "DENY", "CONDITIONAL"]},
+        "access": {"type": "string", "enum": ["ALLOW", "DENY", "CONDITIONAL"]},
+        "correlation": {"type": "string", "enum": ["ALLOW", "DENY", "CONDITIONAL"]},
+        "derivation": {"type": "string", "enum": ["ALLOW", "DENY", "CONDITIONAL"]},
+        "propagation": {"type": "string", "enum": ["ALLOW", "DENY", "CONDITIONAL"]}
+      }
+    }
+  }
+}

--- a/schemas/skap-account-disclosure-graph.schema.json
+++ b/schemas/skap-account-disclosure-graph.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/skap-account-disclosure-graph.schema.json",
+  "title": "StegVerse SKAP Account Disclosure Graph",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "graph_id", "subject_ref", "updated_at", "accounts", "organizations", "disclosure_edges"],
+  "properties": {
+    "schema": {"const": "stegverse.skap-account-disclosure-graph/v1"},
+    "graph_id": {"type": "string", "pattern": "^[A-Z0-9][A-Z0-9._:-]{2,127}$"},
+    "subject_ref": {"type": "string", "minLength": 1},
+    "updated_at": {"type": "string", "format": "date-time"},
+    "accounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["skap_account_ref", "provider_org_ref", "account_class", "status"],
+        "properties": {
+          "skap_account_ref": {"type": "string", "minLength": 1},
+          "provider_org_ref": {"type": "string", "minLength": 1},
+          "account_class": {"type": "string", "enum": ["social", "email", "commerce", "financial", "health", "cloud", "identity", "telecom", "government", "other"]},
+          "status": {"type": "string", "enum": ["ACTIVE", "INACTIVE", "CLOSED", "UNKNOWN"]}
+        }
+      }
+    },
+    "organizations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["org_ref", "name", "role"],
+        "properties": {
+          "org_ref": {"type": "string", "minLength": 1},
+          "name": {"type": "string", "minLength": 1},
+          "role": {"type": "string", "enum": ["ACCOUNT_PROVIDER", "PROCESSOR", "SUBPROCESSOR", "DATA_BROKER", "ADVERTISING_PARTNER", "ANALYTICS_PARTNER", "AFFILIATE", "PUBLIC_SOURCE", "SEARCH_ENGINE", "OTHER"]}
+        }
+      }
+    },
+    "disclosure_edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["edge_id", "from_org_ref", "to_org_ref", "data_classes", "relationship", "evidence_state", "evidence_refs", "last_verified_at"],
+        "properties": {
+          "edge_id": {"type": "string", "minLength": 1},
+          "from_org_ref": {"type": "string", "minLength": 1},
+          "to_org_ref": {"type": "string", "minLength": 1},
+          "skap_account_refs": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+          "data_classes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "enum": ["identity", "contact", "location", "family", "media", "financial", "health", "employment", "account", "device", "behavioral", "advertising", "derived", "other"]}},
+          "relationship": {"type": "string", "enum": ["DISCLOSED_TO", "SOLD_TO", "SHARED_WITH", "PROCESSED_BY", "SUBPROCESSED_BY", "AFFILIATED_WITH", "INDEXED_BY", "PUBLICLY_EXPOSED_TO", "UNKNOWN_TRANSFER"]},
+          "purpose": {"type": ["string", "null"]},
+          "evidence_state": {"type": "string", "enum": ["DECLARED_BY_PROVIDER", "OBSERVED_TRANSFER", "REGULATORY_OR_COURT_RECORD", "CREDIBLE_THIRD_PARTY_REPORT", "INFERRED_UNVERIFIED", "UNKNOWN"]},
+          "evidence_refs": {"type": "array", "items": {"type": "string", "minLength": 1}},
+          "last_verified_at": {"type": "string", "format": "date-time"},
+          "reclamation_priority": {"type": "string", "enum": ["PRIMARY", "DOWNSTREAM", "WATCH", "EXCLUDED_LEGAL", "UNKNOWN"]}
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate_digital_data_reclamation.py
+++ b/scripts/validate_digital_data_reclamation.py
@@ -88,6 +88,15 @@ def check_authority_fail_closed():
         raise SystemExit("NO_AUTHORITY + ALLOW was incorrectly accepted")
 
 
+def check_unverified_disclosure_fail_closed():
+    invalid = load(FIX / "invalid-unverified-primary-disclosure-edge.json")
+    try:
+        check_skap_disclosure_refs(invalid)
+    except SystemExit:
+        return
+    raise SystemExit("unverified disclosure edge was incorrectly accepted as PRIMARY")
+
+
 def main():
     inventory = validate("inventory", SAMPLES["inventory"])
     graph = validate("graph", SAMPLES["graph"])
@@ -96,6 +105,7 @@ def main():
     check_cross_refs(inventory, graph)
     check_skap_disclosure_refs(skap_disclosure)
     check_authority_fail_closed()
+    check_unverified_disclosure_fail_closed()
     print("Digital Data Reclamation foundation validation: PASS")
 
 

--- a/scripts/validate_digital_data_reclamation.py
+++ b/scripts/validate_digital_data_reclamation.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).resolve().parents[1]
+FIX = ROOT / "fixtures" / "digital-data-reclamation"
+SCHEMAS = {
+    "inventory": ROOT / "schemas" / "personal-data-inventory.schema.json",
+    "graph": ROOT / "schemas" / "data-propagation-graph.schema.json",
+    "authority": ROOT / "schemas" / "derived-data-authority-receipt.schema.json",
+}
+SAMPLES = {
+    "inventory": FIX / "personal-data-inventory.sample.json",
+    "graph": FIX / "data-propagation-graph.sample.json",
+    "authority": FIX / "derived-data-authority-receipt.sample.json",
+}
+
+
+def load(path):
+    return json.loads(path.read_text())
+
+
+def validate(name, path):
+    schema = load(SCHEMAS[name])
+    doc = load(path)
+    errors = sorted(
+        Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(doc),
+        key=lambda e: list(e.absolute_path),
+    )
+    if errors:
+        raise SystemExit(f"{path}: " + "; ".join(e.message for e in errors))
+    return doc
+
+
+def check_cross_refs(inventory, graph):
+    object_ids = {item["object_id"] for item in inventory["objects"]}
+    for appearance in inventory["external_appearances"]:
+        if appearance["object_ref"] not in object_ids:
+            raise SystemExit("external appearance references unknown inventory object")
+
+    node_ids = {node["node_id"] for node in graph["nodes"]}
+    if len(node_ids) != len(graph["nodes"]):
+        raise SystemExit("graph node_id values must be unique")
+    edge_ids = set()
+    for edge in graph["edges"]:
+        if edge["edge_id"] in edge_ids:
+            raise SystemExit("graph edge_id values must be unique")
+        edge_ids.add(edge["edge_id"])
+        if edge["from"] not in node_ids or edge["to"] not in node_ids:
+            raise SystemExit("graph edge references unknown node")
+
+
+def check_authority_fail_closed():
+    invalid = FIX / "invalid-no-authority-allows-derivation.json"
+    schema = load(SCHEMAS["authority"])
+    errors = list(
+        Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(load(invalid))
+    )
+    if not errors:
+        raise SystemExit("NO_AUTHORITY + ALLOW was incorrectly accepted")
+
+
+def main():
+    inventory = validate("inventory", SAMPLES["inventory"])
+    graph = validate("graph", SAMPLES["graph"])
+    validate("authority", SAMPLES["authority"])
+    check_cross_refs(inventory, graph)
+    check_authority_fail_closed()
+    print("Digital Data Reclamation foundation validation: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_digital_data_reclamation.py
+++ b/scripts/validate_digital_data_reclamation.py
@@ -9,11 +9,13 @@ SCHEMAS = {
     "inventory": ROOT / "schemas" / "personal-data-inventory.schema.json",
     "graph": ROOT / "schemas" / "data-propagation-graph.schema.json",
     "authority": ROOT / "schemas" / "derived-data-authority-receipt.schema.json",
+    "skap_disclosure": ROOT / "schemas" / "skap-account-disclosure-graph.schema.json",
 }
 SAMPLES = {
     "inventory": FIX / "personal-data-inventory.sample.json",
     "graph": FIX / "data-propagation-graph.sample.json",
     "authority": FIX / "derived-data-authority-receipt.sample.json",
+    "skap_disclosure": FIX / "skap-account-disclosure-graph.sample.json",
 }
 
 
@@ -51,6 +53,31 @@ def check_cross_refs(inventory, graph):
             raise SystemExit("graph edge references unknown node")
 
 
+def check_skap_disclosure_refs(doc):
+    account_refs = {item["skap_account_ref"] for item in doc["accounts"]}
+    if len(account_refs) != len(doc["accounts"]):
+        raise SystemExit("SKAP disclosure graph account refs must be unique")
+    org_refs = {item["org_ref"] for item in doc["organizations"]}
+    if len(org_refs) != len(doc["organizations"]):
+        raise SystemExit("SKAP disclosure graph organization refs must be unique")
+    provider_refs = {item["provider_org_ref"] for item in doc["accounts"]}
+    if not provider_refs.issubset(org_refs):
+        raise SystemExit("SKAP account references unknown provider organization")
+    edge_ids = set()
+    for edge in doc["disclosure_edges"]:
+        if edge["edge_id"] in edge_ids:
+            raise SystemExit("SKAP disclosure graph edge ids must be unique")
+        edge_ids.add(edge["edge_id"])
+        if edge["from_org_ref"] not in org_refs or edge["to_org_ref"] not in org_refs:
+            raise SystemExit("SKAP disclosure edge references unknown organization")
+        if not set(edge.get("skap_account_refs", [])).issubset(account_refs):
+            raise SystemExit("SKAP disclosure edge references unknown SKAP account")
+        if edge["evidence_state"] in {"DECLARED_BY_PROVIDER", "OBSERVED_TRANSFER", "REGULATORY_OR_COURT_RECORD", "CREDIBLE_THIRD_PARTY_REPORT"} and not edge["evidence_refs"]:
+            raise SystemExit("evidence-backed SKAP disclosure edge must retain evidence refs")
+        if edge["evidence_state"] in {"INFERRED_UNVERIFIED", "UNKNOWN"} and edge["reclamation_priority"] == "PRIMARY":
+            raise SystemExit("unverified SKAP disclosure edge cannot become PRIMARY reclamation target")
+
+
 def check_authority_fail_closed():
     invalid = FIX / "invalid-no-authority-allows-derivation.json"
     schema = load(SCHEMAS["authority"])
@@ -65,7 +92,9 @@ def main():
     inventory = validate("inventory", SAMPLES["inventory"])
     graph = validate("graph", SAMPLES["graph"])
     validate("authority", SAMPLES["authority"])
+    skap_disclosure = validate("skap_disclosure", SAMPLES["skap_disclosure"])
     check_cross_refs(inventory, graph)
+    check_skap_disclosure_refs(skap_disclosure)
     check_authority_fail_closed()
     print("Digital Data Reclamation foundation validation: PASS")
 


### PR DESCRIPTION
Superseded before merge because the reused branch still carried the pre-squash foundation history and produced a noisy 14-file diff. Rebuilt the SKAP disclosure graph changes on a clean branch from current main to preserve a minimal auditable diff.