### PR TITLE
Add SKAP-seeded customer-data disclosure graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ The documented StegVerse direction is a governed reclamation lifecycle: discover
 
 KnowledgeVault is the intended authoritative private inventory and continuity surface for known source objects, external appearances, legal/contractual authority, correlation and derivation permissions, deletion/restriction requests, verification evidence, receipts, and recurrence state. KnowledgeVault custody itself is not blanket authority for AI correlation across everything stored in the vault.
 
-See [Digital Data Reclamation and Sovereignty](docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY.md) and its [scoped mirror handoff](docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md).
+Discovery is not limited to known data brokers or harvesting sites. Authorized SKAP accounts can seed an evidence-bounded account-provider disclosure graph so StegVerse can expand from a user's known account companies into organizations those companies are documented, observed, reported, or suspected to share customer data with. Evidence state is retained per edge, and an unverified relationship cannot be promoted into a primary reclamation target. Provider relationship evidence identifies where to look next; it does not prove that a specific user's datum traversed that edge.
+
+See [Digital Data Reclamation and Sovereignty](docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY.md), [SKAP-Seeded Account Disclosure Graph](docs/SKAP_ACCOUNT_DISCLOSURE_GRAPH.md), and the [scoped mirror handoff](docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md).
 
 ## Status
 
@@ -145,20 +147,25 @@ The Automated Political Reality Compendium Standard defines recurring search, ad
 ## Machine-readable schemas
 
 - [Political Influence Tree JSON Schema](schemas/political-influence-tree.schema.json)
-- [Source Posture JSON Schema](schemas/source-posture.schema.json)
+- [Source Posture JSON Schema](standards/source-posture-schema.md)
 - [Producer Export JSON Schema](schemas/producer-export.schema.json)
 - [Validation Result JSON Schema](schemas/validation-result.schema.json)
 - [Primary Record Intake JSON Schema](schemas/primary-record-intake.schema.json)
 - [Force Event Packet JSON Schema](schemas/force-event-packet.schema.json)
 - [Discovery Cycle JSON Schema](schemas/discovery-cycle.schema.json)
 - [Related Repository Network JSON Schema](schemas/related-repository-network.schema.json)
+- [Personal Data Inventory JSON Schema](schemas/personal-data-inventory.schema.json)
+- [Data Propagation Graph JSON Schema](schemas/data-propagation-graph.schema.json)
+- [Derived Data Authority Receipt JSON Schema](schemas/derived-data-authority-receipt.schema.json)
+- [SKAP Account Disclosure Graph JSON Schema](schemas/skap-account-disclosure-graph.schema.json)
 
-These schemas provide validation targets for ledger entries, source receipts, upstream exports, validation receipts, evidence-intake queues, individualized events, recurring discovery cycles, and governed repository relationships.
+These schemas provide validation targets for ledger entries, source receipts, upstream exports, validation receipts, evidence-intake queues, individualized events, recurring discovery cycles, governed repository relationships, and the Digital Data Reclamation foundation.
 
 ## Validation
 
 - [Validate Ledger Schemas workflow](.github/workflows/validate-ledger-schemas.yml)
 - [Validate UAP Evidence Classes workflow](.github/workflows/validate-uap-evidence-classes.yml)
+- [Validate Digital Data Reclamation Foundation workflow](.github/workflows/validate-digital-data-reclamation.yml)
 - [Validation Status Note](release/validation-status-note.md)
 - [Final Activation Handoff](release/final-activation-handoff.md)
 - [Passed Activation Validation Receipt](validation_results/workflow-run-29719676248.passed.json)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The Automated Political Reality Compendium Standard defines recurring search, ad
 ## Machine-readable schemas
 
 - [Political Influence Tree JSON Schema](schemas/political-influence-tree.schema.json)
-- [Source Posture JSON Schema](standards/source-posture-schema.md)
+- [Source Posture JSON Schema](schemas/source-posture-schema.json)
 - [Producer Export JSON Schema](schemas/producer-export.schema.json)
 - [Validation Result JSON Schema](schemas/validation-result.schema.json)
 - [Primary Record Intake JSON Schema](schemas/primary-record-intake.schema.json)

--- a/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
+++ b/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
@@ -13,85 +13,74 @@ COSV: `40000100100000`
 
 This scoped handoff governs the documentation and first implementation foundation created from the ERL privacy/derived-data intake. It does not replace `docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md` for ERL-to-KnowledgeVault storage proof.
 
-The current parent task remains canonical because it is the registered ACTIVE task that established the ERL/KV evidence boundary. This implementation slice is bounded to schemas, deterministic validation, and fail-closed authority semantics; it does not claim a live deletion service.
+The current parent task remains canonical because it is the registered ACTIVE task that established the ERL/KV evidence boundary. This implementation slice is bounded to schemas, deterministic validation, fail-closed authority semantics, and evidence-bounded discovery topology; it does not claim a live deletion service.
 
-## Installed architecture
+## Installed architecture and implementation
 
 - `docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY.md`
-- `research-candidates/2026-09-09-meta-ai-child-data-assembly-privacy.md`
-- `research-candidates/README.md`
-
-## First implementation foundation
-
-Implemented on branch `impl/digital-data-reclamation-foundation-20260909`:
-
+- `docs/SKAP_ACCOUNT_DISCLOSURE_GRAPH.md`
 - `schemas/personal-data-inventory.schema.json`
 - `schemas/data-propagation-graph.schema.json`
 - `schemas/derived-data-authority-receipt.schema.json`
-- `fixtures/digital-data-reclamation/personal-data-inventory.sample.json`
-- `fixtures/digital-data-reclamation/data-propagation-graph.sample.json`
-- `fixtures/digital-data-reclamation/derived-data-authority-receipt.sample.json`
-- `fixtures/digital-data-reclamation/invalid-no-authority-allows-derivation.json`
+- `schemas/skap-account-disclosure-graph.schema.json`
+- `fixtures/digital-data-reclamation/`
 - `scripts/validate_digital_data_reclamation.py`
 - `.github/workflows/validate-digital-data-reclamation.yml`
 
-The Personal Data Inventory provides a machine-readable user-centered inventory for source objects, external appearances, current removal state, and the five separable authority dimensions. The Data Propagation Graph provides explicit source/copy/index/broker/derived/downstream/model nodes and provenance-bearing edges. The Derived Data Authority receipt requires actor, requester, source objects, requested derivation, purpose, authority basis, decision, and downstream-use constraints.
+The Personal Data Inventory models source objects, external appearances, removal state, and five separable authority dimensions. The Data Propagation Graph models source/copy/index/broker/derived/downstream/model nodes. The Derived Data Authority receipt fails closed when no derivation authority exists.
 
-The receipt schema fails closed when `authority_basis=NO_AUTHORITY`: the only valid decision is `DENY`. The deterministic validator also checks inventory object references, graph node/edge referential integrity, duplicate graph identifiers, and a negative fixture proving that `NO_AUTHORITY + ALLOW` is rejected.
+The SKAP Account Disclosure Graph extends discovery upstream from known harvesting sites. Every authorized SKAP account can seed an evidence-bounded account-provider topology:
+
+`SKAP account -> account provider -> declared/observed downstream organization -> additional recipient -> broker/search/public surface`
+
+This graph distinguishes evidence-backed distribution relationships from unverified inference. A provider privacy disclosure, subprocessor list, regulator/court record, user export, or authentic transfer observation may establish a downstream candidate. It does not by itself prove that a particular user's datum traversed that edge.
+
+The deterministic validator enforces SKAP account/provider referential integrity, organization and edge uniqueness, retained evidence references for evidence-backed edges, and a fail-closed rule preventing `INFERRED_UNVERIFIED` or `UNKNOWN` edges from becoming `PRIMARY` reclamation targets.
 
 ## Canonical concepts
 
-The installed design separates five digital-data rights: custody, access, correlation, derivation, and propagation.
-
-`Derived Data Authority` is a separate governed question from source-object access. Technical readability of several objects does not automatically authorize joining them into a sensitive inference.
+Digital ownership separates custody, access, correlation, derivation, and propagation. Technical readability does not automatically confer authority to correlate or derive.
 
 The reclamation lifecycle is:
 
 `discover -> classify -> establish authority -> request/execute deletion or restriction -> propagate revocation -> verify -> receipt -> monitor recurrence`
 
-KnowledgeVault is the intended authoritative private inventory/continuity surface for known personal-data objects, external appearances, requests, responses, evidence, revocation state, and recurrence observations. KnowledgeVault custody itself must not be interpreted as blanket authority for AI correlation across all stored objects.
+Discovery itself now has two complementary origins:
+
+`known external harvesting/removal targets`
+
+plus
+
+`known SKAP accounts -> account providers -> evidence-backed customer-data distribution graph`
+
+KnowledgeVault is the intended authoritative private inventory/continuity surface for account topology, source objects, external appearances, provider-distribution evidence, requests, responses, revocation state, receipts, and recurrence observations. Graph membership is discovery context, not execution authority; Interlock/InTr remains the governed transition authority.
 
 ## Evidence boundary
 
-The architecture explicitly refuses a universal Internet-erasure claim. Removal success must be expressed by source-specific evidence posture. A request receipt proves submission, not deletion. Provider acknowledgement proves acknowledgement, not independent erasure. Current external non-observability proves only the checked surface at the checked time.
-
-The model also distinguishes direct copies from indexes, caches, embeddings, independently sourced copies, relationship edges, derived attributes, retrieval surfaces, and trained-model behavior. Source deletion is not proof that those downstream representations were removed.
+The architecture refuses universal Internet-erasure claims. A submitted request is not proof of deletion. A provider disclosure relationship is not proof that a specific user's data traversed it. An inferred relationship cannot be promoted to a primary reclamation target without stronger evidence.
 
 ## Observed Google baseline — 2026-09-09
 
-The user supplied two current-iPhone screenshots of Google's `Results about you` surface. The visible interface shows Google checking for results about the user and displaying removal-request state such as `In progress` and `Approved`. Visible result targets include Whitepages, Anywho, USPhonebook, SearchPeopleFREE, and True People Search.
-
-This is recorded as a bounded industry-comparison observation, not a claim about Google's complete internal feature set. The screenshots show a useful search-result discovery/removal workflow, but do not establish source-site deletion, downstream propagation tracing, derived-data revocation, model-training erasure, prospective correlation authority, or user-owned cross-provider custody.
-
-StegVerse therefore treats search-engine result removal as one provider-adapter lane inside the broader reclamation architecture rather than as the complete reclamation model.
-
-## Product direction
-
-Working capability name: `Digital Data Reclamation and Sovereignty`.
-
-The intended StegVerse service combines KnowledgeVault, governed execution, provider adapters, legal-rights routing, Data Propagation Graphs, recurrence monitoring, provenance, and verifiable receipts.
-
-The long-term differentiator is prospective sovereignty: new disclosures can carry explicit purpose, recipient, duration, redistribution, correlation, and derivation authority rather than reducing consent to a one-time opaque permission.
+The user supplied current-iPhone screenshots of Google's `Results about you` interface showing result checking and removal-request states such as `In progress` and `Approved`, including visible people-search targets. This is retained only as a bounded comparison point for search-surface removal; it does not establish source-site deletion or full downstream propagation control.
 
 ## Current state
 
-`FOUNDATION_IMPLEMENTED / SCHEMAS_AND_FAIL_CLOSED_VALIDATOR_PRESENT / HOSTED_VALIDATION_PENDING / LIVE_RECLAMATION_RUNTIME_NOT_YET_CLAIMED`
+`FOUNDATION_IMPLEMENTED / HOSTED_VALIDATION_OF_BASE_FOUNDATION_PASSED / SKAP_DISCLOSURE_GRAPH_IMPLEMENTED_PENDING_CURRENT_PR_VALIDATION / LIVE_RECLAMATION_RUNTIME_NOT_YET_CLAIMED`
 
 No live deletion/reclamation service, provider adapter set, legal-rights router, recurrence monitor, or cross-provider verification runtime is claimed yet.
 
 ## Remaining implementation decomposition
 
-1. Bind Personal Data Inventory to a concrete KnowledgeVault storage contract and writer/readback receipt.
-2. Add Data Propagation Graph mutation/reconciliation logic from observed provider/search evidence.
-3. Bind Derived Data Authority receipts to Interlock/InTr governed transition evaluation.
-4. Build provider discovery/removal/restriction adapter framework, beginning with search-result and people-search lanes.
-5. Build verification/proof-class engine that cannot promote request/acknowledgement into deletion.
-6. Build recurrence/reappearance monitor.
-7. Add legal-rights/jurisdiction routing with explicit non-legal-advice boundaries.
-8. Add prospective disclosure authority envelope for new StegVerse-originated data.
+1. Bind Personal Data Inventory and SKAP account topology to concrete KnowledgeVault writer/readback receipts.
+2. Build evidence ingestion that derives disclosure-graph edges from provider policies, subprocessor lists, regulatory records, user exports, and authentic observations.
+3. Reconcile the SKAP Account Disclosure Graph into the Data Propagation Graph without converting candidate relationships into user-specific transfer facts.
+4. Bind Derived Data Authority receipts to Interlock/InTr governed transition evaluation.
+5. Build provider discovery/removal/restriction adapters and verification/proof-class engine.
+6. Build recurrence/reappearance monitoring and legal-rights/jurisdiction routing.
+7. Add prospective disclosure authority envelopes for new StegVerse-originated data.
 
-By Goal Prompt Count 20, any genuinely separable remaining implementation lanes must be transferred into new canonical Goal Task IDs rather than extending this evidence-comparison parent indefinitely.
+By Goal Prompt Count 20, genuinely separable implementation lanes must move into new canonical Goal Task IDs rather than extending this evidence-comparison parent indefinitely.
 
 ## Manual work
 
-None for this implementation foundation.
+None for this implementation slice.

--- a/docs/SKAP_ACCOUNT_DISCLOSURE_GRAPH.md
+++ b/docs/SKAP_ACCOUNT_DISCLOSURE_GRAPH.md
@@ -1,0 +1,17 @@
+# SKAP-Seeded Account Disclosure Graph
+
+StegVerse Digital Data Reclamation must not discover personal exposure only by checking known data-harvesting sites. It must also begin from the user's own known account topology.
+
+For every authorized SKAP account, the reclamation system should identify the account provider and maintain an evidence-bounded graph of organizations to which that provider is known, reported, observed, or suspected to disclose, sell, share, process, subprocess, affiliate, index, or otherwise expose customer data.
+
+The discovery expansion becomes:
+
+`SKAP account -> account provider -> declared/observed downstream organizations -> additional downstream recipients -> public/search/broker surfaces`
+
+This graph is a discovery-priority graph, not proof that a particular user's records were transferred on every edge. Edge evidence state is mandatory. `DECLARED_BY_PROVIDER`, `OBSERVED_TRANSFER`, and `REGULATORY_OR_COURT_RECORD` can support stronger follow-up than `INFERRED_UNVERIFIED` or `UNKNOWN`.
+
+A provider privacy policy, subprocessor list, sale/share disclosure, regulator record, court record, user export, or authentic network/provider receipt can establish a candidate downstream relationship. It cannot by itself prove that a specific datum for a specific user traversed that edge unless evidence supports that narrower claim.
+
+This prevents two opposite failures: missing likely downstream copies because StegVerse only searches known brokers, and overclaiming that every listed provider relationship contains the user's data.
+
+KnowledgeVault should retain the subject's SKAP-linked account inventory, the disclosure graph, evidence references, verification timestamps, and reclamation state. Interlock/InTr remains the transition authority for governed execution; graph membership is discovery context, not permission to act.

--- a/fixtures/digital-data-reclamation/invalid-unverified-primary-disclosure-edge.json
+++ b/fixtures/digital-data-reclamation/invalid-unverified-primary-disclosure-edge.json
@@ -1,0 +1,12 @@
+{
+  "schema": "stegverse.skap-account-disclosure-graph/v1",
+  "graph_id": "DDR-SKAP-GRAPH-INVALID-001",
+  "subject_ref": "subject:example-user",
+  "updated_at": "2026-09-10T03:28:00Z",
+  "accounts": [{"skap_account_ref": "skap:account:example-social", "provider_org_ref": "org:example-social", "account_class": "social", "status": "ACTIVE"}],
+  "organizations": [
+    {"org_ref": "org:example-social", "name": "Example Social Provider", "role": "ACCOUNT_PROVIDER"},
+    {"org_ref": "org:unknown-recipient", "name": "Unknown Recipient", "role": "OTHER"}
+  ],
+  "disclosure_edges": [{"edge_id": "edge:unverified-primary", "from_org_ref": "org:example-social", "to_org_ref": "org:unknown-recipient", "skap_account_refs": ["skap:account:example-social"], "data_classes": ["identity"], "relationship": "UNKNOWN_TRANSFER", "purpose": null, "evidence_state": "INFERRED_UNVERIFIED", "evidence_refs": [], "last_verified_at": "2026-09-10T03:28:00Z", "reclamation_priority": "PRIMARY"}]
+}

--- a/fixtures/digital-data-reclamation/skap-account-disclosure-graph.sample.json
+++ b/fixtures/digital-data-reclamation/skap-account-disclosure-graph.sample.json
@@ -1,0 +1,18 @@
+{
+  "schema": "stegverse.skap-account-disclosure-graph/v1",
+  "graph_id": "DDR-SKAP-GRAPH-001",
+  "subject_ref": "subject:example-user",
+  "updated_at": "2026-09-10T03:28:00Z",
+  "accounts": [
+    {"skap_account_ref": "skap:account:example-social", "provider_org_ref": "org:example-social", "account_class": "social", "status": "ACTIVE"}
+  ],
+  "organizations": [
+    {"org_ref": "org:example-social", "name": "Example Social Provider", "role": "ACCOUNT_PROVIDER"},
+    {"org_ref": "org:example-analytics", "name": "Example Analytics Partner", "role": "ANALYTICS_PARTNER"},
+    {"org_ref": "org:example-broker", "name": "Example Data Broker", "role": "DATA_BROKER"}
+  ],
+  "disclosure_edges": [
+    {"edge_id": "edge:provider-to-analytics", "from_org_ref": "org:example-social", "to_org_ref": "org:example-analytics", "skap_account_refs": ["skap:account:example-social"], "data_classes": ["identity", "device", "behavioral"], "relationship": "SHARED_WITH", "purpose": "analytics", "evidence_state": "DECLARED_BY_PROVIDER", "evidence_refs": ["evidence:provider-privacy-disclosure:example"], "last_verified_at": "2026-09-10T03:28:00Z", "reclamation_priority": "DOWNSTREAM"},
+    {"edge_id": "edge:analytics-to-broker", "from_org_ref": "org:example-analytics", "to_org_ref": "org:example-broker", "skap_account_refs": ["skap:account:example-social"], "data_classes": ["derived", "advertising"], "relationship": "UNKNOWN_TRANSFER", "purpose": null, "evidence_state": "INFERRED_UNVERIFIED", "evidence_refs": [], "last_verified_at": "2026-09-10T03:28:00Z", "reclamation_priority": "WATCH"}
+  ]
+}

--- a/schemas/skap-account-disclosure-graph.schema.json
+++ b/schemas/skap-account-disclosure-graph.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/skap-account-disclosure-graph.schema.json",
+  "title": "StegVerse SKAP Account Disclosure Graph",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "graph_id", "subject_ref", "updated_at", "accounts", "organizations", "disclosure_edges"],
+  "properties": {
+    "schema": {"const": "stegverse.skap-account-disclosure-graph/v1"},
+    "graph_id": {"type": "string", "pattern": "^[A-Z0-9][A-Z0-9._:-]{2,127}$"},
+    "subject_ref": {"type": "string", "minLength": 1},
+    "updated_at": {"type": "string", "format": "date-time"},
+    "accounts": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["skap_account_ref", "provider_org_ref", "account_class", "status"], "properties": {"skap_account_ref": {"type": "string", "minLength": 1}, "provider_org_ref": {"type": "string", "minLength": 1}, "account_class": {"type": "string", "enum": ["social", "email", "commerce", "financial", "health", "cloud", "identity", "telecom", "government", "other"]}, "status": {"type": "string", "enum": ["ACTIVE", "INACTIVE", "CLOSED", "UNKNOWN"]}}}},
+    "organizations": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["org_ref", "name", "role"], "properties": {"org_ref": {"type": "string", "minLength": 1}, "name": {"type": "string", "minLength": 1}, "role": {"type": "string", "enum": ["ACCOUNT_PROVIDER", "PROCESSOR", "SUBPROCESSOR", "DATA_BROKER", "ADVERTISING_PARTNER", "ANALYTICS_PARTNER", "AFFILIATE", "PUBLIC_SOURCE", "SEARCH_ENGINE", "OTHER"]}}}},
+    "disclosure_edges": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["edge_id", "from_org_ref", "to_org_ref", "data_classes", "relationship", "evidence_state", "evidence_refs", "last_verified_at", "reclamation_priority"], "properties": {"edge_id": {"type": "string", "minLength": 1}, "from_org_ref": {"type": "string", "minLength": 1}, "to_org_ref": {"type": "string", "minLength": 1}, "skap_account_refs": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true}, "data_classes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "enum": ["identity", "contact", "location", "family", "media", "financial", "health", "employment", "account", "device", "behavioral", "advertising", "derived", "other"]}}, "relationship": {"type": "string", "enum": ["DISCLOSED_TO", "SOLD_TO", "SHARED_WITH", "PROCESSED_BY", "SUBPROCESSED_BY", "AFFILIATED_WITH", "INDEXED_BY", "PUBLICLY_EXPOSED_TO", "UNKNOWN_TRANSFER"]}, "purpose": {"type": ["string", "null"]}, "evidence_state": {"type": "string", "enum": ["DECLARED_BY_PROVIDER", "OBSERVED_TRANSFER", "REGULATORY_OR_COURT_RECORD", "CREDIBLE_THIRD_PARTY_REPORT", "INFERRED_UNVERIFIED", "UNKNOWN"]}, "evidence_refs": {"type": "array", "items": {"type": "string", "minLength": 1}}, "last_verified_at": {"type": "string", "format": "date-time"}, "reclamation_priority": {"type": "string", "enum": ["PRIMARY", "DOWNSTREAM", "WATCH", "EXCLUDED_LEGAL", "UNKNOWN"]}}}}
+  }
+}

--- a/scripts/validate_digital_data_reclamation.py
+++ b/scripts/validate_digital_data_reclamation.py
@@ -9,11 +9,13 @@ SCHEMAS = {
     "inventory": ROOT / "schemas" / "personal-data-inventory.schema.json",
     "graph": ROOT / "schemas" / "data-propagation-graph.schema.json",
     "authority": ROOT / "schemas" / "derived-data-authority-receipt.schema.json",
+    "skap_disclosure": ROOT / "schemas" / "skap-account-disclosure-graph.schema.json",
 }
 SAMPLES = {
     "inventory": FIX / "personal-data-inventory.sample.json",
     "graph": FIX / "data-propagation-graph.sample.json",
     "authority": FIX / "derived-data-authority-receipt.sample.json",
+    "skap_disclosure": FIX / "skap-account-disclosure-graph.sample.json",
 }
 
 
@@ -51,22 +53,56 @@ def check_cross_refs(inventory, graph):
             raise SystemExit("graph edge references unknown node")
 
 
+def check_skap_disclosure_refs(doc):
+    account_refs = {item["skap_account_ref"] for item in doc["accounts"]}
+    if len(account_refs) != len(doc["accounts"]):
+        raise SystemExit("SKAP disclosure graph account refs must be unique")
+    org_refs = {item["org_ref"] for item in doc["organizations"]}
+    if len(org_refs) != len(doc["organizations"]):
+        raise SystemExit("SKAP disclosure graph organization refs must be unique")
+    if not {item["provider_org_ref"] for item in doc["accounts"]}.issubset(org_refs):
+        raise SystemExit("SKAP account references unknown provider organization")
+    edge_ids = set()
+    for edge in doc["disclosure_edges"]:
+        if edge["edge_id"] in edge_ids:
+            raise SystemExit("SKAP disclosure graph edge ids must be unique")
+        edge_ids.add(edge["edge_id"])
+        if edge["from_org_ref"] not in org_refs or edge["to_org_ref"] not in org_refs:
+            raise SystemExit("SKAP disclosure edge references unknown organization")
+        if not set(edge.get("skap_account_refs", [])).issubset(account_refs):
+            raise SystemExit("SKAP disclosure edge references unknown SKAP account")
+        if edge["evidence_state"] in {"DECLARED_BY_PROVIDER", "OBSERVED_TRANSFER", "REGULATORY_OR_COURT_RECORD", "CREDIBLE_THIRD_PARTY_REPORT"} and not edge["evidence_refs"]:
+            raise SystemExit("evidence-backed SKAP disclosure edge must retain evidence refs")
+        if edge["evidence_state"] in {"INFERRED_UNVERIFIED", "UNKNOWN"} and edge["reclamation_priority"] == "PRIMARY":
+            raise SystemExit("unverified SKAP disclosure edge cannot become PRIMARY reclamation target")
+
+
 def check_authority_fail_closed():
     invalid = FIX / "invalid-no-authority-allows-derivation.json"
     schema = load(SCHEMAS["authority"])
-    errors = list(
-        Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(load(invalid))
-    )
+    errors = list(Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(load(invalid)))
     if not errors:
         raise SystemExit("NO_AUTHORITY + ALLOW was incorrectly accepted")
+
+
+def check_unverified_disclosure_fail_closed():
+    invalid = load(FIX / "invalid-unverified-primary-disclosure-edge.json")
+    try:
+        check_skap_disclosure_refs(invalid)
+    except SystemExit:
+        return
+    raise SystemExit("unverified disclosure edge was incorrectly accepted as PRIMARY")
 
 
 def main():
     inventory = validate("inventory", SAMPLES["inventory"])
     graph = validate("graph", SAMPLES["graph"])
     validate("authority", SAMPLES["authority"])
+    skap_disclosure = validate("skap_disclosure", SAMPLES["skap_disclosure"])
     check_cross_refs(inventory, graph)
+    check_skap_disclosure_refs(skap_disclosure)
     check_authority_fail_closed()
+    check_unverified_disclosure_fail_closed()
     print("Digital Data Reclamation foundation validation: PASS")
 
 


### PR DESCRIPTION
Clean implementation built from current main. Extends Digital Data Reclamation discovery from known harvesting/removal targets to authorized SKAP account topology. Adds a machine-readable account-provider disclosure graph, evidence-bounded downstream relationships, fail-closed prevention of unverified edges becoming primary reclamation targets, validator coverage, README documentation, and handoff updates. Provider relationship evidence is discovery context, not proof that a specific user's data traversed an edge. No live deletion runtime is claimed.