### PR TITLE
Add deterministic reclamation target reconciliation

### DIFF
--- a/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
+++ b/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
@@ -11,19 +11,22 @@ COSV: `40000100100000`
 
 ## Scope
 
-This scoped handoff governs the documentation and first implementation foundation created from the ERL privacy/derived-data intake. It does not replace `docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md` for ERL-to-KnowledgeVault storage proof.
+This scoped handoff governs the documentation and implementation foundation created from the ERL privacy/derived-data intake. It does not replace `docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md` for ERL-to-KnowledgeVault storage proof.
 
-The current parent task remains canonical because it is the registered ACTIVE task that established the ERL/KV evidence boundary. This implementation slice is bounded to schemas, deterministic validation, fail-closed authority semantics, and evidence-bounded discovery topology; it does not claim a live deletion service.
+The current parent task remains canonical because it is the registered ACTIVE task that established the ERL/KV evidence boundary. This implementation slice is bounded to schemas, deterministic validation, fail-closed authority semantics, evidence-bounded discovery topology, and deterministic reclamation-target reconciliation; it does not claim a live deletion service.
 
 ## Installed architecture and implementation
 
 - `docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY.md`
 - `docs/SKAP_ACCOUNT_DISCLOSURE_GRAPH.md`
+- `docs/RECLAMATION_TARGET_RECONCILIATION.md`
 - `schemas/personal-data-inventory.schema.json`
 - `schemas/data-propagation-graph.schema.json`
 - `schemas/derived-data-authority-receipt.schema.json`
 - `schemas/skap-account-disclosure-graph.schema.json`
+- `schemas/reclamation-target-set.schema.json`
 - `fixtures/digital-data-reclamation/`
+- `scripts/build_reclamation_target_set.py`
 - `scripts/validate_digital_data_reclamation.py`
 - `.github/workflows/validate-digital-data-reclamation.yml`
 
@@ -37,15 +40,33 @@ This graph distinguishes evidence-backed distribution relationships from unverif
 
 The deterministic validator enforces SKAP account/provider referential integrity, organization and edge uniqueness, retained evidence references for evidence-backed edges, and a fail-closed rule preventing `INFERRED_UNVERIFIED` or `UNKNOWN` edges from becoming `PRIMARY` reclamation targets.
 
+## Reclamation target reconciliation
+
+`build_reclamation_target_set.py` now combines the SKAP disclosure graph with an observed Data Propagation Graph to produce `stegverse.reclamation-target-set/v1`.
+
+Target posture is evidence bounded:
+
+- authorized SKAP account providers -> `PRIMARY / DIRECT / ELIGIBLE`;
+- provider-declared, observed-transfer, and regulator/court downstream edges -> eligible downstream targets unless the source graph deliberately makes them more conservative;
+- credible third-party reports -> watch-only;
+- inferred or unknown downstream edges -> `WATCH / BLOCKED_UNVERIFIED`;
+- currently observed or reappeared propagation nodes -> eligible downstream targets;
+- already requested/restricted/provider-asserted-deleted propagation nodes -> watch posture;
+- independently verified deleted propagation nodes -> complete posture.
+
+The reconciler refuses cross-subject joins and preserves distinct evidence lanes even when multiple lanes identify the same organization. The target set is a governed investigation/action candidate surface, not proof that deletion occurred or that a specific datum traversed any unobserved edge.
+
+The paired reconciliation fixtures and `reclamation-target-set.sample.json` provide deterministic expected output. Repository validation reconstructs and compares that target set, rejects a cross-subject join, and verifies that unverified targets cannot become `ELIGIBLE`.
+
 ## Canonical concepts
 
 Digital ownership separates custody, access, correlation, derivation, and propagation. Technical readability does not automatically confer authority to correlate or derive.
 
 The reclamation lifecycle is:
 
-`discover -> classify -> establish authority -> request/execute deletion or restriction -> propagate revocation -> verify -> receipt -> monitor recurrence`
+`discover -> classify -> establish authority -> reconcile targets -> request/execute deletion or restriction -> propagate revocation -> verify -> receipt -> monitor recurrence`
 
-Discovery itself now has two complementary origins:
+Discovery has two complementary origins:
 
 `known external harvesting/removal targets`
 
@@ -53,11 +74,11 @@ plus
 
 `known SKAP accounts -> account providers -> evidence-backed customer-data distribution graph`
 
-KnowledgeVault is the intended authoritative private inventory/continuity surface for account topology, source objects, external appearances, provider-distribution evidence, requests, responses, revocation state, receipts, and recurrence observations. Graph membership is discovery context, not execution authority; Interlock/InTr remains the governed transition authority.
+KnowledgeVault is the intended authoritative private inventory/continuity surface for account topology, source objects, external appearances, provider-distribution evidence, generated target sets, requests, responses, revocation state, receipts, and recurrence observations. Graph membership is discovery context, not execution authority; Interlock/InTr remains the governed transition authority.
 
 ## Evidence boundary
 
-The architecture refuses universal Internet-erasure claims. A submitted request is not proof of deletion. A provider disclosure relationship is not proof that a specific user's data traversed it. An inferred relationship cannot be promoted to a primary reclamation target without stronger evidence.
+The architecture refuses universal Internet-erasure claims. A submitted request is not proof of deletion. A provider disclosure relationship is not proof that a specific user's data traversed it. An inferred relationship cannot be promoted to an eligible reclamation target without stronger evidence.
 
 ## Observed Google baseline — 2026-09-09
 
@@ -65,19 +86,18 @@ The user supplied current-iPhone screenshots of Google's `Results about you` int
 
 ## Current state
 
-`FOUNDATION_IMPLEMENTED / HOSTED_VALIDATION_OF_BASE_FOUNDATION_PASSED / SKAP_DISCLOSURE_GRAPH_IMPLEMENTED_PENDING_CURRENT_PR_VALIDATION / LIVE_RECLAMATION_RUNTIME_NOT_YET_CLAIMED`
+`FOUNDATION_IMPLEMENTED / BASE_AND_SKAP_GRAPH_HOSTED_VALIDATION_PASSED / DETERMINISTIC_TARGET_RECONCILIATION_IMPLEMENTED_PENDING_CURRENT_PR_VALIDATION / LIVE_RECLAMATION_RUNTIME_NOT_YET_CLAIMED`
 
-No live deletion/reclamation service, provider adapter set, legal-rights router, recurrence monitor, or cross-provider verification runtime is claimed yet.
+No live deletion/reclamation service, provider adapter set, legal-rights router, recurrence monitor, KnowledgeVault target-set writer/readback receipt, or cross-provider verification runtime is claimed yet.
 
 ## Remaining implementation decomposition
 
-1. Bind Personal Data Inventory and SKAP account topology to concrete KnowledgeVault writer/readback receipts.
+1. Bind Personal Data Inventory, SKAP account topology, and generated reclamation target sets to concrete KnowledgeVault writer/readback receipts.
 2. Build evidence ingestion that derives disclosure-graph edges from provider policies, subprocessor lists, regulatory records, user exports, and authentic observations.
-3. Reconcile the SKAP Account Disclosure Graph into the Data Propagation Graph without converting candidate relationships into user-specific transfer facts.
-4. Bind Derived Data Authority receipts to Interlock/InTr governed transition evaluation.
-5. Build provider discovery/removal/restriction adapters and verification/proof-class engine.
-6. Build recurrence/reappearance monitoring and legal-rights/jurisdiction routing.
-7. Add prospective disclosure authority envelopes for new StegVerse-originated data.
+3. Bind Derived Data Authority and target execution to Interlock/InTr governed transition evaluation.
+4. Build provider discovery/removal/restriction adapters and verification/proof-class engine.
+5. Build recurrence/reappearance monitoring and legal-rights/jurisdiction routing.
+6. Add prospective disclosure authority envelopes for new StegVerse-originated data.
 
 By Goal Prompt Count 20, genuinely separable implementation lanes must move into new canonical Goal Task IDs rather than extending this evidence-comparison parent indefinitely.
 

--- a/docs/RECLAMATION_TARGET_RECONCILIATION.md
+++ b/docs/RECLAMATION_TARGET_RECONCILIATION.md
@@ -1,0 +1,32 @@
+# Reclamation Target Reconciliation
+
+## Purpose
+
+The reclamation runtime must not wait for a search engine or data broker to expose a user's information before deciding where to look. It should derive an evidence-bounded target set from two independent discovery surfaces:
+
+1. the user's authorized SKAP account topology and provider-disclosure graph; and
+2. the observed Data Propagation Graph produced by external discovery and prior reclamation activity.
+
+The reconciler at `scripts/build_reclamation_target_set.py` combines those surfaces without collapsing evidence classes.
+
+## Target posture
+
+A SKAP account provider is a `PRIMARY / DIRECT / ELIGIBLE` target because the existence of an authorized account is direct evidence that the provider holds at least account-associated data for that subject.
+
+Downstream disclosure edges are mapped according to evidence posture. Provider declarations, observed transfers, and regulator/court records may produce eligible downstream targets. Credible third-party reporting remains watch-only unless strengthened. `INFERRED_UNVERIFIED` and `UNKNOWN` relationships are blocked from eligible execution and remain watch targets.
+
+Observed propagation nodes such as data brokers, downstream recipients, indexes/caches, and model/retrieval surfaces may become eligible downstream targets when currently observed or reappeared. Prior removal/restriction/deletion states remain watch or complete posture rather than silently returning to active execution.
+
+## Fail-closed boundaries
+
+The reconciler refuses cross-subject joins. A SKAP graph for one subject cannot be reconciled with a propagation graph for another subject.
+
+Distinct evidence lanes remain distinct even when they point at the same organization. A provider disclosure and an independently observed propagation node are not silently collapsed into one proof claim.
+
+No target-set state proves that deletion occurred. It only determines where an authorized reclamation process may next investigate, request, restrict, verify, or watch.
+
+## Deterministic validation
+
+`schemas/reclamation-target-set.schema.json` defines the output contract. `fixtures/digital-data-reclamation/reclamation-target-set.sample.json` is the expected deterministic result for the paired SKAP and propagation reconciliation fixtures.
+
+The repository validator reconstructs the target set, compares it byte-semanticly to the expected fixture, rejects cross-subject reconciliation, and ensures unverified targets cannot become `ELIGIBLE`.

--- a/fixtures/digital-data-reclamation/data-propagation-graph.reconciliation.sample.json
+++ b/fixtures/digital-data-reclamation/data-propagation-graph.reconciliation.sample.json
@@ -1,0 +1,15 @@
+{
+  "schema": "stegverse.data-propagation-graph/v1",
+  "graph_id": "DPG-RECONCILIATION-001",
+  "subject_ref": "subject:example-user",
+  "generated_at": "2026-09-10T03:40:00Z",
+  "nodes": [
+    {"node_id": "n-source", "node_type": "source_object", "identity": "obj:email:example", "current_state": "OBSERVED"},
+    {"node_id": "n-broker", "node_type": "data_broker", "identity": "org:observed-broker", "current_state": "OBSERVED"},
+    {"node_id": "n-search", "node_type": "index_or_cache", "identity": "org:observed-search-surface", "current_state": "REMOVAL_REQUESTED"}
+  ],
+  "edges": [
+    {"edge_id": "edge:source-broker", "from": "n-source", "to": "n-broker", "relationship": "aggregated_by", "observed_at": "2026-09-10T03:40:00Z", "authority_basis": null, "permitted_purpose": null, "revocation_state": "NOT_REQUESTED", "evidence_class": "DIRECT_OBSERVATION", "verification_state": "VERIFIED"},
+    {"edge_id": "edge:broker-search", "from": "n-broker", "to": "n-search", "relationship": "indexed_by", "observed_at": "2026-09-10T03:40:00Z", "authority_basis": null, "permitted_purpose": null, "revocation_state": "REQUESTED", "evidence_class": "DIRECT_OBSERVATION", "verification_state": "VERIFIED"}
+  ]
+}

--- a/fixtures/digital-data-reclamation/reclamation-target-set.sample.json
+++ b/fixtures/digital-data-reclamation/reclamation-target-set.sample.json
@@ -1,0 +1,63 @@
+{
+  "schema": "stegverse.reclamation-target-set/v1",
+  "target_set_id": "DDR-SKAP-GRAPH-001:targets",
+  "subject_ref": "subject:example-user",
+  "generated_at": "2026-09-10T03:45:00Z",
+  "targets": [
+    {
+      "target_id": "target:account-provider:org:example-social",
+      "org_ref": "org:example-social",
+      "source": "SKAP_ACCOUNT_PROVIDER",
+      "priority": "PRIMARY",
+      "evidence_state": "DIRECT",
+      "action_state": "ELIGIBLE",
+      "data_classes": ["account"],
+      "skap_account_refs": ["skap:account:example-social"],
+      "reason_refs": ["skap-account:skap:account:example-social"]
+    },
+    {
+      "target_id": "target:disclosure:edge:provider-to-analytics",
+      "org_ref": "org:example-analytics",
+      "source": "SKAP_DISCLOSURE_EDGE",
+      "priority": "DOWNSTREAM",
+      "evidence_state": "DECLARED",
+      "action_state": "ELIGIBLE",
+      "data_classes": ["behavioral", "device", "identity"],
+      "skap_account_refs": ["skap:account:example-social"],
+      "reason_refs": ["evidence:provider-privacy-disclosure:example"]
+    },
+    {
+      "target_id": "target:propagation:n-broker",
+      "org_ref": "org:observed-broker",
+      "source": "OBSERVED_PROPAGATION_NODE",
+      "priority": "DOWNSTREAM",
+      "evidence_state": "OBSERVED",
+      "action_state": "ELIGIBLE",
+      "data_classes": [],
+      "skap_account_refs": [],
+      "reason_refs": ["propagation-node:n-broker"]
+    },
+    {
+      "target_id": "target:disclosure:edge:analytics-to-broker",
+      "org_ref": "org:example-broker",
+      "source": "SKAP_DISCLOSURE_EDGE",
+      "priority": "WATCH",
+      "evidence_state": "INFERRED_UNVERIFIED",
+      "action_state": "BLOCKED_UNVERIFIED",
+      "data_classes": ["advertising", "derived"],
+      "skap_account_refs": ["skap:account:example-social"],
+      "reason_refs": ["disclosure-edge:edge:analytics-to-broker"]
+    },
+    {
+      "target_id": "target:propagation:n-search",
+      "org_ref": "org:observed-search-surface",
+      "source": "OBSERVED_PROPAGATION_NODE",
+      "priority": "WATCH",
+      "evidence_state": "OBSERVED",
+      "action_state": "WATCH_ONLY",
+      "data_classes": [],
+      "skap_account_refs": [],
+      "reason_refs": ["propagation-node:n-search"]
+    }
+  ]
+}

--- a/schemas/reclamation-target-set.schema.json
+++ b/schemas/reclamation-target-set.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stegverse.org/schemas/reclamation-target-set.schema.json",
+  "title": "StegVerse Reclamation Target Set",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "target_set_id", "subject_ref", "generated_at", "targets"],
+  "properties": {
+    "schema": {"const": "stegverse.reclamation-target-set/v1"},
+    "target_set_id": {"type": "string", "minLength": 3},
+    "subject_ref": {"type": "string", "minLength": 1},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "targets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["target_id", "org_ref", "source", "priority", "evidence_state", "action_state", "reason_refs"],
+        "properties": {
+          "target_id": {"type": "string", "minLength": 1},
+          "org_ref": {"type": "string", "minLength": 1},
+          "source": {"type": "string", "enum": ["SKAP_ACCOUNT_PROVIDER", "SKAP_DISCLOSURE_EDGE", "OBSERVED_PROPAGATION_NODE", "KNOWN_REMOVAL_SURFACE"]},
+          "priority": {"type": "string", "enum": ["PRIMARY", "DOWNSTREAM", "WATCH", "EXCLUDED"]},
+          "evidence_state": {"type": "string", "enum": ["DIRECT", "DECLARED", "REGULATORY", "OBSERVED", "CREDIBLE_REPORT", "INFERRED_UNVERIFIED", "UNKNOWN"]},
+          "action_state": {"type": "string", "enum": ["ELIGIBLE", "WATCH_ONLY", "BLOCKED_UNVERIFIED", "EXCLUDED_LEGAL", "COMPLETE"]},
+          "data_classes": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+          "skap_account_refs": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+          "reason_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}, "uniqueItems": true}
+        }
+      }
+    }
+  }
+}

--- a/scripts/build_reclamation_target_set.py
+++ b/scripts/build_reclamation_target_set.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+EDGE_POSTURE = {
+    "DECLARED_BY_PROVIDER": ("DOWNSTREAM", "DECLARED", "ELIGIBLE"),
+    "OBSERVED_TRANSFER": ("DOWNSTREAM", "OBSERVED", "ELIGIBLE"),
+    "REGULATORY_OR_COURT_RECORD": ("DOWNSTREAM", "REGULATORY", "ELIGIBLE"),
+    "CREDIBLE_THIRD_PARTY_REPORT": ("WATCH", "CREDIBLE_REPORT", "WATCH_ONLY"),
+    "INFERRED_UNVERIFIED": ("WATCH", "INFERRED_UNVERIFIED", "BLOCKED_UNVERIFIED"),
+    "UNKNOWN": ("WATCH", "UNKNOWN", "BLOCKED_UNVERIFIED"),
+}
+
+PROPAGATION_ELIGIBLE_TYPES = {"data_broker", "downstream_recipient", "index_or_cache", "model_or_retrieval_surface"}
+
+
+def load(path):
+    return json.loads(Path(path).read_text())
+
+
+def target_key(target):
+    return (target["org_ref"], target["source"])
+
+
+def build(skap, propagation, generated_at):
+    targets = []
+
+    # A user-authorized SKAP account is direct evidence that the account provider
+    # holds at least account-associated data for the subject. It is therefore a
+    # primary reclamation/access/export candidate without inferring downstream flow.
+    for account in skap["accounts"]:
+        if account["status"] == "CLOSED":
+            action_state = "ELIGIBLE"
+        else:
+            action_state = "ELIGIBLE"
+        targets.append({
+            "target_id": f"target:account-provider:{account['provider_org_ref']}",
+            "org_ref": account["provider_org_ref"],
+            "source": "SKAP_ACCOUNT_PROVIDER",
+            "priority": "PRIMARY",
+            "evidence_state": "DIRECT",
+            "action_state": action_state,
+            "data_classes": ["account"],
+            "skap_account_refs": [account["skap_account_ref"]],
+            "reason_refs": [f"skap-account:{account['skap_account_ref']}"],
+        })
+
+    for edge in skap["disclosure_edges"]:
+        priority, evidence_state, action_state = EDGE_POSTURE[edge["evidence_state"]]
+        # Explicit source graph priority can only make posture more conservative.
+        if edge.get("reclamation_priority") == "WATCH":
+            priority = "WATCH"
+            if action_state == "ELIGIBLE":
+                action_state = "WATCH_ONLY"
+        elif edge.get("reclamation_priority") == "EXCLUDED_LEGAL":
+            priority = "EXCLUDED"
+            action_state = "EXCLUDED_LEGAL"
+        targets.append({
+            "target_id": f"target:disclosure:{edge['edge_id']}",
+            "org_ref": edge["to_org_ref"],
+            "source": "SKAP_DISCLOSURE_EDGE",
+            "priority": priority,
+            "evidence_state": evidence_state,
+            "action_state": action_state,
+            "data_classes": sorted(edge["data_classes"]),
+            "skap_account_refs": sorted(edge.get("skap_account_refs", [])),
+            "reason_refs": sorted(edge.get("evidence_refs", []) or [f"disclosure-edge:{edge['edge_id']}"]),
+        })
+
+    for node in propagation["nodes"]:
+        if node["node_type"] not in PROPAGATION_ELIGIBLE_TYPES:
+            continue
+        state = node.get("current_state", "UNVERIFIABLE")
+        if state in {"OBSERVED", "REAPPEARED"}:
+            action_state = "ELIGIBLE"
+            evidence_state = "OBSERVED"
+            priority = "DOWNSTREAM"
+        elif state in {"REMOVAL_REQUESTED", "RESTRICTED", "PROVIDER_ASSERTED_DELETED", "INDEPENDENTLY_VERIFIED_DELETED"}:
+            action_state = "COMPLETE" if state == "INDEPENDENTLY_VERIFIED_DELETED" else "WATCH_ONLY"
+            evidence_state = "OBSERVED"
+            priority = "WATCH"
+        else:
+            action_state = "WATCH_ONLY"
+            evidence_state = "UNKNOWN"
+            priority = "WATCH"
+        targets.append({
+            "target_id": f"target:propagation:{node['node_id']}",
+            "org_ref": node["identity"],
+            "source": "OBSERVED_PROPAGATION_NODE",
+            "priority": priority,
+            "evidence_state": evidence_state,
+            "action_state": action_state,
+            "data_classes": [],
+            "skap_account_refs": [],
+            "reason_refs": [f"propagation-node:{node['node_id']}"],
+        })
+
+    # Preserve distinct evidence lanes; deduplicate only exact source/org collisions.
+    deduped = {}
+    for target in targets:
+        deduped[target_key(target)] = target
+
+    return {
+        "schema": "stegverse.reclamation-target-set/v1",
+        "target_set_id": f"{skap['graph_id']}:targets",
+        "subject_ref": skap["subject_ref"],
+        "generated_at": generated_at,
+        "targets": sorted(deduped.values(), key=lambda t: (t["priority"], t["org_ref"], t["source"])),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--skap-graph", required=True)
+    parser.add_argument("--propagation-graph", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--generated-at")
+    args = parser.parse_args()
+
+    generated_at = args.generated_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    result = build(load(args.skap_graph), load(args.propagation_graph), generated_at)
+    Path(args.output).write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_reclamation_target_set.py
+++ b/scripts/build_reclamation_target_set.py
@@ -14,6 +14,7 @@ EDGE_POSTURE = {
 }
 
 PROPAGATION_ELIGIBLE_TYPES = {"data_broker", "downstream_recipient", "index_or_cache", "model_or_retrieval_surface"}
+PRIORITY_RANK = {"PRIMARY": 0, "DOWNSTREAM": 1, "WATCH": 2, "EXCLUDED": 3}
 
 
 def load(path):
@@ -25,23 +26,22 @@ def target_key(target):
 
 
 def build(skap, propagation, generated_at):
+    if skap["subject_ref"] != propagation["subject_ref"]:
+        raise ValueError("SKAP and propagation graphs must refer to the same subject")
+
     targets = []
 
     # A user-authorized SKAP account is direct evidence that the account provider
     # holds at least account-associated data for the subject. It is therefore a
     # primary reclamation/access/export candidate without inferring downstream flow.
     for account in skap["accounts"]:
-        if account["status"] == "CLOSED":
-            action_state = "ELIGIBLE"
-        else:
-            action_state = "ELIGIBLE"
         targets.append({
             "target_id": f"target:account-provider:{account['provider_org_ref']}",
             "org_ref": account["provider_org_ref"],
             "source": "SKAP_ACCOUNT_PROVIDER",
             "priority": "PRIMARY",
             "evidence_state": "DIRECT",
-            "action_state": action_state,
+            "action_state": "ELIGIBLE",
             "data_classes": ["account"],
             "skap_account_refs": [account["skap_account_ref"]],
             "reason_refs": [f"skap-account:{account['skap_account_ref']}"],
@@ -107,7 +107,10 @@ def build(skap, propagation, generated_at):
         "target_set_id": f"{skap['graph_id']}:targets",
         "subject_ref": skap["subject_ref"],
         "generated_at": generated_at,
-        "targets": sorted(deduped.values(), key=lambda t: (t["priority"], t["org_ref"], t["source"])),
+        "targets": sorted(
+            deduped.values(),
+            key=lambda t: (PRIORITY_RANK[t["priority"]], t["org_ref"], t["source"]),
+        ),
     }
 
 

--- a/scripts/validate_digital_data_reclamation.py
+++ b/scripts/validate_digital_data_reclamation.py
@@ -2,6 +2,7 @@
 import json
 from pathlib import Path
 from jsonschema import Draft202012Validator, FormatChecker
+from build_reclamation_target_set import build as build_target_set
 
 ROOT = Path(__file__).resolve().parents[1]
 FIX = ROOT / "fixtures" / "digital-data-reclamation"
@@ -10,12 +11,14 @@ SCHEMAS = {
     "graph": ROOT / "schemas" / "data-propagation-graph.schema.json",
     "authority": ROOT / "schemas" / "derived-data-authority-receipt.schema.json",
     "skap_disclosure": ROOT / "schemas" / "skap-account-disclosure-graph.schema.json",
+    "target_set": ROOT / "schemas" / "reclamation-target-set.schema.json",
 }
 SAMPLES = {
     "inventory": FIX / "personal-data-inventory.sample.json",
     "graph": FIX / "data-propagation-graph.sample.json",
     "authority": FIX / "derived-data-authority-receipt.sample.json",
     "skap_disclosure": FIX / "skap-account-disclosure-graph.sample.json",
+    "target_set": FIX / "reclamation-target-set.sample.json",
 }
 
 
@@ -94,6 +97,27 @@ def check_unverified_disclosure_fail_closed():
     raise SystemExit("unverified disclosure edge was incorrectly accepted as PRIMARY")
 
 
+def check_target_reconciliation(skap_disclosure):
+    propagation = validate("graph", FIX / "data-propagation-graph.reconciliation.sample.json")
+    expected = validate("target_set", SAMPLES["target_set"])
+    actual = build_target_set(skap_disclosure, propagation, expected["generated_at"])
+    if actual != expected:
+        raise SystemExit("deterministic reclamation target reconciliation does not match expected fixture")
+
+    mismatch = dict(propagation)
+    mismatch["subject_ref"] = "subject:different-user"
+    try:
+        build_target_set(skap_disclosure, mismatch, expected["generated_at"])
+    except ValueError:
+        pass
+    else:
+        raise SystemExit("cross-subject reconciliation was incorrectly accepted")
+
+    for target in actual["targets"]:
+        if target["evidence_state"] in {"INFERRED_UNVERIFIED", "UNKNOWN"} and target["action_state"] == "ELIGIBLE":
+            raise SystemExit("unverified target was incorrectly promoted to ELIGIBLE")
+
+
 def main():
     inventory = validate("inventory", SAMPLES["inventory"])
     graph = validate("graph", SAMPLES["graph"])
@@ -103,6 +127,7 @@ def main():
     check_skap_disclosure_refs(skap_disclosure)
     check_authority_fail_closed()
     check_unverified_disclosure_fail_closed()
+    check_target_reconciliation(skap_disclosure)
     print("Digital Data Reclamation foundation validation: PASS")
 
 


### PR DESCRIPTION
Continues Digital Data Reclamation implementation by reconciling two discovery origins—authorized SKAP account/disclosure topology and observed Data Propagation Graph state—into a deterministic, evidence-bounded reclamation target set. Adds target-set schema, deterministic builder, paired fixtures, cross-subject refusal, validation coverage, documentation, and canonical handoff updates. Unverified/unknown relationships remain blocked from ELIGIBLE action, and no live deletion/provider execution is claimed.