### PR TITLE
Reconcile reclamation handoff to canonical successors

### DIFF
--- a/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
+++ b/docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY_MIRROR_HANDOFF.md
@@ -1,6 +1,6 @@
 # Digital Data Reclamation and Sovereignty Mirror Handoff
 
-Updated: 2026-09-09
+Updated: 2026-09-10
 
 ## Goal Task ID
 
@@ -11,11 +11,13 @@ COSV: `40000100100000`
 
 ## Scope
 
-This scoped handoff governs the documentation and implementation foundation created from the ERL privacy/derived-data intake. It does not replace `docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md` for ERL-to-KnowledgeVault storage proof.
+This handoff captures the Digital Data Reclamation and Sovereignty implementation foundation created under the parent evidence-comparison goal. The parent established the ERL/KV evidence boundary and deterministic reclamation model; live runtime execution is now decomposed into canonical successor tasks rather than continuing implementation under the capped parent Goal Task ID.
 
-The current parent task remains canonical because it is the registered ACTIVE task that established the ERL/KV evidence boundary. This implementation slice is bounded to schemas, deterministic validation, fail-closed authority semantics, evidence-bounded discovery topology, and deterministic reclamation-target reconciliation; it does not claim a live deletion service.
+This handoff does not replace `docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md` for ERL-to-KnowledgeVault storage proof and does not claim a live universal deletion service.
 
-## Installed architecture and implementation
+## Implemented foundation
+
+Repository implementation includes:
 
 - `docs/DIGITAL_DATA_RECLAMATION_AND_SOVEREIGNTY.md`
 - `docs/SKAP_ACCOUNT_DISCLOSURE_GRAPH.md`
@@ -30,43 +32,56 @@ The current parent task remains canonical because it is the registered ACTIVE ta
 - `scripts/validate_digital_data_reclamation.py`
 - `.github/workflows/validate-digital-data-reclamation.yml`
 
-The Personal Data Inventory models source objects, external appearances, removal state, and five separable authority dimensions. The Data Propagation Graph models source/copy/index/broker/derived/downstream/model nodes. The Derived Data Authority receipt fails closed when no derivation authority exists.
+The Personal Data Inventory separates source objects, external appearances, removal state, and distinct authority dimensions. The Data Propagation Graph models source/copy/index/broker/derived/downstream/model nodes. Derived-data authority fails closed when no derivation authority is present.
 
-The SKAP Account Disclosure Graph extends discovery upstream from known harvesting sites. Every authorized SKAP account can seed an evidence-bounded account-provider topology:
+The SKAP Account Disclosure Graph extends discovery from authorized account topology:
 
-`SKAP account -> account provider -> declared/observed downstream organization -> additional recipient -> broker/search/public surface`
+`SKAP account -> account provider -> evidence-backed downstream organization -> additional recipient -> broker/search/public surface`
 
-This graph distinguishes evidence-backed distribution relationships from unverified inference. A provider privacy disclosure, subprocessor list, regulator/court record, user export, or authentic transfer observation may establish a downstream candidate. It does not by itself prove that a particular user's datum traversed that edge.
+Provider disclosures, subprocessor lists, regulatory/court records, user exports, and authentic observations can establish evidence-backed downstream candidates. They do not, by themselves, prove that a particular user's datum traversed an edge.
 
-The deterministic validator enforces SKAP account/provider referential integrity, organization and edge uniqueness, retained evidence references for evidence-backed edges, and a fail-closed rule preventing `INFERRED_UNVERIFIED` or `UNKNOWN` edges from becoming `PRIMARY` reclamation targets.
+## Deterministic target reconciliation
 
-## Reclamation target reconciliation
+`build_reclamation_target_set.py` combines authorized SKAP topology with observed Data Propagation Graph state into `stegverse.reclamation-target-set/v1`.
 
-`build_reclamation_target_set.py` combines the SKAP disclosure graph with an observed Data Propagation Graph to produce `stegverse.reclamation-target-set/v1`.
+Evidence posture remains fail closed:
 
-Target posture is evidence bounded:
+- authorized account providers may become `PRIMARY / DIRECT / ELIGIBLE`;
+- evidence-backed downstream organizations may become eligible downstream targets;
+- credible third-party reports remain watch posture;
+- inferred/unknown relationships remain `WATCH / BLOCKED_UNVERIFIED`;
+- currently observed or reappeared propagation nodes may become eligible downstream targets;
+- requested/restricted/provider-asserted-deleted nodes remain watch posture;
+- independently verified deleted nodes may become complete posture.
 
-- authorized SKAP account providers -> `PRIMARY / DIRECT / ELIGIBLE`;
-- provider-declared, observed-transfer, and regulator/court downstream edges -> eligible downstream targets unless the source graph deliberately makes them more conservative;
-- credible third-party reports -> watch-only;
-- inferred or unknown downstream edges -> `WATCH / BLOCKED_UNVERIFIED`;
-- currently observed or reappeared propagation nodes -> eligible downstream targets;
-- already requested/restricted/provider-asserted-deleted propagation nodes -> watch posture;
-- independently verified deleted propagation nodes -> complete posture.
+Cross-subject joins are refused. Multiple evidence lanes remain distinct even when they identify the same organization. Target-set membership is an investigation/action candidate surface, not proof of deletion or proof of unobserved data traversal.
 
-The reconciler refuses cross-subject joins and preserves distinct evidence lanes even when multiple lanes identify the same organization. The target set is a governed investigation/action candidate surface, not proof that deletion occurred or that a specific datum traversed any unobserved edge.
+## Validation and merge evidence
 
-The paired reconciliation fixtures and `reclamation-target-set.sample.json` provide deterministic expected output. Repository validation reconstructs and compares that target set, rejects a cross-subject join, and verifies that unverified targets cannot become `ELIGIBLE`.
+PR #146 installed the SKAP Account Disclosure Graph and passed its dedicated and full repository validation before merge at `26208c5c17cd6cc4bc0594f789d9803e9dc5f3f8`.
 
-## Validation evidence
+PR #147 installed deterministic reclamation-target reconciliation. Dedicated run `34435166055` and full Ledger run `34435165897` both completed `success`; PR #147 merged at `c78b2fe4be29dc4e9e15167281b35be8105a922a`.
 
-PR #146 installed the SKAP Account Disclosure Graph and passed both the dedicated Digital Data Reclamation workflow and the full Ledger validation before merge at `26208c5c17cd6cc4bc0594f789d9803e9dc5f3f8`.
+PR #148 reconciled this handoff after those proofs. Its dedicated and full Ledger checks both completed `success`; PR #148 merged at `e0c026f6147f5628b6201ee5de93951816e99a2e`.
 
-PR #147 installed deterministic reclamation-target reconciliation. Before merge, dedicated Digital Data Reclamation workflow run `34435166055` completed `success`, and full Ledger validation run `34435165897` completed `success`, both against head `d68dd5ad6eeb00577c85ff487ede42a1d56c0453`. PR #147 then merged to `main` at `c78b2fe4be29dc4e9e15167281b35be8105a922a`.
+StegVerse-Labs/.github PR #1311 then canonicalized six separable Digital Data Reclamation successor tasks. All three organization-control workflows completed `success`, and #1311 merged at `7c27980b1f885d17177a3dc587dbc917472dd96c`.
 
-These runs validate repository implementation and deterministic evidence boundaries. They do not prove live provider deletion, external network execution, or KnowledgeVault write/readback for generated target sets.
+These are repository/coordination proofs. They do not establish live provider deletion, external account mutation, recurrence detection, or current KnowledgeVault custody for generated reclamation target sets.
 
-## Canonical concepts
+## Canonical successor tasks
+
+Future implementation for this trajectory proceeds under these canonical Goal Task IDs and handoffs:
+
+1. `SS-DATA-RECLAMATION-KV-CUSTODY-001` -> `docs/DATA_RECLAMATION_KV_CUSTODY_MIRROR_HANDOFF.md`
+2. `SS-DATA-RECLAMATION-DISCLOSURE-INGESTION-001` -> `docs/DATA_RECLAMATION_DISCLOSURE_INGESTION_MIRROR_HANDOFF.md`
+3. `SS-DATA-RECLAMATION-INTR-AUTHORITY-BINDING-001` -> `docs/DATA_RECLAMATION_INTR_AUTHORITY_BINDING_MIRROR_HANDOFF.md`
+4. `SS-DATA-RECLAMATION-PROVIDER-EXECUTION-001` -> `docs/DATA_RECLAMATION_PROVIDER_EXECUTION_MIRROR_HANDOFF.md`
+5. `SS-DATA-RECLAMATION-RECURRENCE-MONITOR-001` -> `docs/DATA_RECLAMATION_RECURRENCE_MONITOR_MIRROR_HANDOFF.md`
+6. `SS-DATA-DISCLOSURE-AUTHORITY-ENVELOPE-001` -> `docs/DATA_DISCLOSURE_AUTHORITY_ENVELOPE_MIRROR_HANDOFF.md`
+
+The parent task's separate authentic current-iPhone StegSocials standard preparation/save/readback predicate is not part of reclamation runtime. It is being moved to `SS-EVIDENCE-STANDARD-IPHONE-FLOW-001` with `docs/SS_EVIDENCE_STANDARD_IPHONE_FLOW_MIRROR_HANDOFF.md`, while premium/public social release remains separate under `SS-KV-SKAP-SOCIAL-RELEASE-001`.
+
+## Authority and evidence invariants
 
 Digital ownership separates custody, access, correlation, derivation, and propagation. Technical readability does not automatically confer authority to correlate or derive.
 
@@ -74,41 +89,20 @@ The reclamation lifecycle is:
 
 `discover -> classify -> establish authority -> reconcile targets -> request/execute deletion or restriction -> propagate revocation -> verify -> receipt -> monitor recurrence`
 
-Discovery has two complementary origins:
+KnowledgeVault is the intended authoritative private inventory/continuity surface for account topology, source objects, external appearances, provider-distribution evidence, generated target sets, requests, responses, revocation state, receipts, and recurrence observations.
 
-`known external harvesting/removal targets`
-
-plus
-
-`known SKAP accounts -> account providers -> evidence-backed customer-data distribution graph`
-
-KnowledgeVault is the intended authoritative private inventory/continuity surface for account topology, source objects, external appearances, provider-distribution evidence, generated target sets, requests, responses, revocation state, receipts, and recurrence observations. Graph membership is discovery context, not execution authority; Interlock/InTr remains the governed transition authority.
-
-## Evidence boundary
-
-The architecture refuses universal Internet-erasure claims. A submitted request is not proof of deletion. A provider disclosure relationship is not proof that a specific user's data traversed it. An inferred relationship cannot be promoted to an eligible reclamation target without stronger evidence.
+Graph membership is discovery context, not execution authority. Interlock/InTr remains the governed transition authority. A submitted request is not proof of deletion; a provider relationship is not proof of subject-specific traversal; inferred relationships cannot be promoted to eligible targets without stronger evidence.
 
 ## Observed Google baseline — 2026-09-09
 
-The user supplied current-iPhone screenshots of Google's `Results about you` interface showing result checking and removal-request states such as `In progress` and `Approved`, including visible people-search targets. This is retained only as a bounded comparison point for search-surface removal; it does not establish source-site deletion or full downstream propagation control.
+Current-iPhone screenshots supplied by the user showed Google's `Results about you` interface with result checking and removal-request states including `In progress` and `Approved`. That remains a bounded comparison point for search-surface removal only; it does not prove source-site deletion or downstream propagation control.
 
 ## Current state
 
-`FOUNDATION_IMPLEMENTED / SKAP_DISCLOSURE_GRAPH_VALIDATED / DETERMINISTIC_TARGET_RECONCILIATION_VALIDATED_AND_MERGED / LIVE_RECLAMATION_RUNTIME_NOT_YET_CLAIMED`
+`FOUNDATION_IMPLEMENTED / SKAP_DISCLOSURE_GRAPH_VALIDATED / DETERMINISTIC_TARGET_RECONCILIATION_VALIDATED_AND_MERGED / SIX_RECLAMATION_SUCCESSOR_TASKS_CANONICALIZED / LIVE_RECLAMATION_RUNTIME_NOT_YET_CLAIMED`
 
-No live deletion/reclamation service, provider adapter set, legal-rights router, recurrence monitor, KnowledgeVault target-set writer/readback receipt, or cross-provider verification runtime is claimed yet.
-
-## Remaining implementation decomposition
-
-1. Bind Personal Data Inventory, SKAP account topology, and generated reclamation target sets to concrete KnowledgeVault writer/readback receipts.
-2. Build evidence ingestion that derives disclosure-graph edges from provider policies, subprocessor lists, regulatory records, user exports, and authentic observations.
-3. Bind Derived Data Authority and target execution to Interlock/InTr governed transition evaluation.
-4. Build provider discovery/removal/restriction adapters and verification/proof-class engine.
-5. Build recurrence/reappearance monitoring and legal-rights/jurisdiction routing.
-6. Add prospective disclosure authority envelopes for new StegVerse-originated data.
-
-By Goal Prompt Count 20, genuinely separable implementation lanes must move into new canonical Goal Task IDs rather than extending this evidence-comparison parent indefinitely.
+Goal Prompt Count for parent `SS-EVIDENCE-COMPARISON-001` has reached `20/20`. Do not continue new reclamation implementation under the parent ID. Resolve continuation against the applicable successor task above.
 
 ## Manual work
 
-None for this implementation slice.
+None for this coordination handoff.


### PR DESCRIPTION
Updates the canonical Digital Data Reclamation and Sovereignty handoff after .github PR #1311 merged. Records validated merge evidence, names all six canonical reclamation successor tasks and handoffs, separates the remaining current-iPhone standard-flow predicate, and records the parent 20/20 prompt horizon without claiming live deletion runtime.