### PR TITLE
Implement bidirectional SKAP evidence reconciliation

### DIFF
--- a/docs/SKAP_EVIDENCE_RECONCILIATION.md
+++ b/docs/SKAP_EVIDENCE_RECONCILIATION.md
@@ -2,10 +2,14 @@
 
 Goal Task ID: `SS-DATA-RECLAMATION-DISCLOSURE-INGESTION-001`
 
-This layer compares SKAP-maintained account/provider topology against independently maintained evidence mappings. It is deliberately bidirectional.
+This layer compares a non-secret SKAP-maintained account/provider projection against independently maintained evidence mappings. It is deliberately bidirectional.
 
-For every SKAP account, the reconciler records whether the account provider is `KNOWN_AND_MAPPED` or `KNOWN_BUT_UNMAPPED`, then retains downstream organization references and evidence references reachable from that provider. Separately, verified propagation observations whose organizations cannot be connected to a known SKAP provider or its downstream disclosure context are surfaced as `EVIDENCE_WITHOUT_KNOWN_ACCOUNT_ORIGIN`.
+SKAP supplies only the account inventory projection needed for reconciliation: stable account reference, provider organization reference, account class, and account status. The projection contract explicitly requires `contains_secret_material=false`; passwords, tokens, credential payloads, and sealed SKAP object contents are not reconciliation inputs.
+
+For every projected SKAP account, the reconciler records whether the account provider is `KNOWN_AND_MAPPED` or `KNOWN_BUT_UNMAPPED`, then retains downstream organization references and evidence references reachable from that provider. Separately, verified propagation observations whose organizations cannot be connected to a known SKAP provider or its downstream disclosure context are surfaced as `EVIDENCE_WITHOUT_KNOWN_ACCOUNT_ORIGIN`.
 
 The reconciliation is a coverage and discovery surface, not proof of subject-specific data traversal. Provider disclosure, graph reachability, or inferred relationships do not become `OBSERVED_TRANSFER` without authentic transfer evidence. Cross-subject reconciliation fails closed.
 
-The deterministic implementation is `scripts/reconcile_skap_evidence.py`; its schema is `schemas/skap-evidence-reconciliation.schema.json`; the canonical fixture is `fixtures/digital-data-reclamation/skap-evidence-reconciliation.sample.json`; validation is integrated into `scripts/validate_digital_data_reclamation.py`.
+The non-secret SKAP projection contract is `schemas/skap-account-inventory-projection.schema.json`. The deterministic reconciler is `scripts/reconcile_skap_evidence.py`; its output schema is `schemas/skap-evidence-reconciliation.schema.json`; canonical fixtures live under `fixtures/digital-data-reclamation/`; validation is integrated into `scripts/validate_digital_data_reclamation.py`.
+
+A producer that emits the projection from real SKAP-maintained accounts remains a separate integration surface. Until such a producer exists and emits authentic account metadata, fixture reconciliation proves the contract and classification semantics but does not claim that the user's real SKAP account inventory has been enumerated.

--- a/docs/SKAP_EVIDENCE_RECONCILIATION.md
+++ b/docs/SKAP_EVIDENCE_RECONCILIATION.md
@@ -1,0 +1,11 @@
+# SKAP Account ↔ Evidence Reconciliation
+
+Goal Task ID: `SS-DATA-RECLAMATION-DISCLOSURE-INGESTION-001`
+
+This layer compares SKAP-maintained account/provider topology against independently maintained evidence mappings. It is deliberately bidirectional.
+
+For every SKAP account, the reconciler records whether the account provider is `KNOWN_AND_MAPPED` or `KNOWN_BUT_UNMAPPED`, then retains downstream organization references and evidence references reachable from that provider. Separately, verified propagation observations whose organizations cannot be connected to a known SKAP provider or its downstream disclosure context are surfaced as `EVIDENCE_WITHOUT_KNOWN_ACCOUNT_ORIGIN`.
+
+The reconciliation is a coverage and discovery surface, not proof of subject-specific data traversal. Provider disclosure, graph reachability, or inferred relationships do not become `OBSERVED_TRANSFER` without authentic transfer evidence. Cross-subject reconciliation fails closed.
+
+The deterministic implementation is `scripts/reconcile_skap_evidence.py`; its schema is `schemas/skap-evidence-reconciliation.schema.json`; the canonical fixture is `fixtures/digital-data-reclamation/skap-evidence-reconciliation.sample.json`; validation is integrated into `scripts/validate_digital_data_reclamation.py`.

--- a/fixtures/digital-data-reclamation/skap-account-inventory-projection.sample.json
+++ b/fixtures/digital-data-reclamation/skap-account-inventory-projection.sample.json
@@ -1,0 +1,9 @@
+{
+  "schema":"stegverse.skap.account-inventory-projection/v1",
+  "subject_ref":"subject:example-user",
+  "generated_at":"2026-09-10T12:30:00Z",
+  "contains_secret_material":false,
+  "accounts":[
+    {"skap_account_ref":"skap:account:example-social","provider_org_ref":"org:example-social","account_class":"social","status":"ACTIVE"}
+  ]
+}

--- a/fixtures/digital-data-reclamation/skap-evidence-reconciliation.sample.json
+++ b/fixtures/digital-data-reclamation/skap-evidence-reconciliation.sample.json
@@ -1,0 +1,33 @@
+{
+  "schema": "stegverse.skap-evidence-reconciliation/v1",
+  "subject_ref": "subject:example-user",
+  "generated_at": "2026-09-10T12:00:00Z",
+  "accounts": [
+    {
+      "skap_account_ref": "skap:account:example-social",
+      "provider_org_ref": "org:example-social",
+      "classification": "KNOWN_AND_MAPPED",
+      "downstream_org_refs": ["org:example-analytics", "org:example-broker"],
+      "evidence_refs": ["evidence:provider-privacy-disclosure:example"]
+    }
+  ],
+  "evidence_only_origins": [
+    {
+      "org_ref": "org:observed-broker",
+      "classification": "EVIDENCE_WITHOUT_KNOWN_ACCOUNT_ORIGIN",
+      "evidence_refs": ["propagation-edge:edge:source-broker"]
+    },
+    {
+      "org_ref": "org:observed-search-surface",
+      "classification": "EVIDENCE_WITHOUT_KNOWN_ACCOUNT_ORIGIN",
+      "evidence_refs": ["propagation-edge:edge:broker-search"]
+    }
+  ],
+  "summary": {
+    "known_accounts": 1,
+    "known_and_mapped": 1,
+    "known_but_unmapped": 0,
+    "downstream_from_known_account": 2,
+    "evidence_without_known_account_origin": 2
+  }
+}

--- a/schemas/skap-account-inventory-projection.schema.json
+++ b/schemas/skap-account-inventory-projection.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://stegverse.org/schemas/skap-account-inventory-projection.schema.json",
+  "title":"StegVerse SKAP Account Inventory Projection",
+  "type":"object",
+  "additionalProperties":false,
+  "required":["schema","subject_ref","generated_at","contains_secret_material","accounts"],
+  "properties":{
+    "schema":{"const":"stegverse.skap.account-inventory-projection/v1"},
+    "subject_ref":{"type":"string","minLength":1},
+    "generated_at":{"type":"string","format":"date-time"},
+    "contains_secret_material":{"const":false},
+    "accounts":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["skap_account_ref","provider_org_ref","account_class","status"],"properties":{"skap_account_ref":{"type":"string","minLength":1},"provider_org_ref":{"type":"string","minLength":1},"account_class":{"type":"string","enum":["social","email","commerce","financial","health","cloud","identity","telecom","government","other"]},"status":{"type":"string","enum":["ACTIVE","INACTIVE","CLOSED","UNKNOWN"]}}}}
+  }
+}

--- a/schemas/skap-evidence-reconciliation.schema.json
+++ b/schemas/skap-evidence-reconciliation.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://stegverse.org/schemas/skap-evidence-reconciliation.schema.json",
+  "title":"StegVerse SKAP Evidence Reconciliation",
+  "type":"object",
+  "additionalProperties":false,
+  "required":["schema","subject_ref","generated_at","accounts","evidence_only_origins","summary"],
+  "properties":{
+    "schema":{"const":"stegverse.skap-evidence-reconciliation/v1"},
+    "subject_ref":{"type":"string","minLength":1},
+    "generated_at":{"type":"string","format":"date-time"},
+    "accounts":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["skap_account_ref","provider_org_ref","classification","downstream_org_refs","evidence_refs"],"properties":{"skap_account_ref":{"type":"string","minLength":1},"provider_org_ref":{"type":"string","minLength":1},"classification":{"type":"string","enum":["KNOWN_AND_MAPPED","KNOWN_BUT_UNMAPPED"]},"downstream_org_refs":{"type":"array","uniqueItems":true,"items":{"type":"string","minLength":1}},"evidence_refs":{"type":"array","uniqueItems":true,"items":{"type":"string","minLength":1}}}}},
+    "evidence_only_origins":{"type":"array","items":{"type":"object","additionalProperties":false,"required":["org_ref","classification","evidence_refs"],"properties":{"org_ref":{"type":"string","minLength":1},"classification":{"const":"EVIDENCE_WITHOUT_KNOWN_ACCOUNT_ORIGIN"},"evidence_refs":{"type":"array","uniqueItems":true,"items":{"type":"string","minLength":1}}}}},
+    "summary":{"type":"object","additionalProperties":false,"required":["known_accounts","known_and_mapped","known_but_unmapped","downstream_from_known_account","evidence_without_known_account_origin"],"properties":{"known_accounts":{"type":"integer","minimum":0},"known_and_mapped":{"type":"integer","minimum":0},"known_but_unmapped":{"type":"integer","minimum":0},"downstream_from_known_account":{"type":"integer","minimum":0},"evidence_without_known_account_origin":{"type":"integer","minimum":0}}}
+  }
+}

--- a/scripts/reconcile_skap_evidence.py
+++ b/scripts/reconcile_skap_evidence.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Bidirectionally reconcile SKAP-known accounts against evidence-backed organization mappings."""
+"""Bidirectionally reconcile a non-secret SKAP account projection against evidence mappings."""
 
 from __future__ import annotations
 
@@ -9,7 +9,6 @@ from typing import Any
 
 
 def _reachable_from_provider(graph: dict[str, Any], provider: str) -> tuple[set[str], set[str]]:
-    account_edges = [e for e in graph["disclosure_edges"] if e["from_org_ref"] == provider]
     downstream: set[str] = set()
     refs: set[str] = set()
     frontier = [provider]
@@ -19,7 +18,6 @@ def _reachable_from_provider(graph: dict[str, Any], provider: str) -> tuple[set[
         for edge in graph["disclosure_edges"]:
             if edge["from_org_ref"] != current:
                 continue
-            # Every edge may be retained as evidence context, but inference never becomes observed transfer.
             downstream.add(edge["to_org_ref"])
             refs.update(edge.get("evidence_refs", []))
             if edge["to_org_ref"] not in visited:
@@ -28,21 +26,35 @@ def _reachable_from_provider(graph: dict[str, Any], provider: str) -> tuple[set[
     return downstream, refs
 
 
-def reconcile(skap_graph: dict[str, Any], propagation_graph: dict[str, Any], generated_at: str) -> dict[str, Any]:
-    if skap_graph["subject_ref"] != propagation_graph["subject_ref"]:
+def reconcile(
+    skap_inventory: dict[str, Any],
+    disclosure_graph: dict[str, Any],
+    propagation_graph: dict[str, Any],
+    generated_at: str,
+) -> dict[str, Any]:
+    subjects = {
+        skap_inventory["subject_ref"],
+        disclosure_graph["subject_ref"],
+        propagation_graph["subject_ref"],
+    }
+    if len(subjects) != 1:
         raise ValueError("cross-subject SKAP/evidence reconciliation is prohibited")
+    if skap_inventory.get("contains_secret_material") is not False:
+        raise ValueError("SKAP reconciliation input must be a non-secret account projection")
 
-    known_providers = {a["provider_org_ref"] for a in skap_graph["accounts"]}
+    mapped_orgs = {org["org_ref"] for org in disclosure_graph["organizations"]}
+    known_providers = {a["provider_org_ref"] for a in skap_inventory["accounts"]}
     accounts = []
     downstream_from_known: set[str] = set()
-    for account in sorted(skap_graph["accounts"], key=lambda a: a["skap_account_ref"]):
-        downstream, refs = _reachable_from_provider(skap_graph, account["provider_org_ref"])
+
+    for account in sorted(skap_inventory["accounts"], key=lambda a: a["skap_account_ref"]):
+        provider = account["provider_org_ref"]
+        downstream, refs = _reachable_from_provider(disclosure_graph, provider)
         downstream_from_known.update(downstream)
-        mapped = bool(downstream or refs)
         accounts.append({
             "skap_account_ref": account["skap_account_ref"],
-            "provider_org_ref": account["provider_org_ref"],
-            "classification": "KNOWN_AND_MAPPED" if mapped else "KNOWN_BUT_UNMAPPED",
+            "provider_org_ref": provider,
+            "classification": "KNOWN_AND_MAPPED" if provider in mapped_orgs else "KNOWN_BUT_UNMAPPED",
             "downstream_org_refs": sorted(downstream),
             "evidence_refs": sorted(refs),
         })
@@ -62,11 +74,15 @@ def reconcile(skap_graph: dict[str, Any], propagation_graph: dict[str, Any], gen
 
     return {
         "schema": "stegverse.skap-evidence-reconciliation/v1",
-        "subject_ref": skap_graph["subject_ref"],
+        "subject_ref": skap_inventory["subject_ref"],
         "generated_at": generated_at,
         "accounts": accounts,
         "evidence_only_origins": [
-            {"org_ref": org, "classification": "EVIDENCE_WITHOUT_KNOWN_ACCOUNT_ORIGIN", "evidence_refs": sorted(refs)}
+            {
+                "org_ref": org,
+                "classification": "EVIDENCE_WITHOUT_KNOWN_ACCOUNT_ORIGIN",
+                "evidence_refs": sorted(refs),
+            }
             for org, refs in sorted(evidence_only.items())
         ],
         "summary": {
@@ -82,11 +98,17 @@ def reconcile(skap_graph: dict[str, Any], propagation_graph: dict[str, Any], gen
 def main() -> None:
     import argparse
     p = argparse.ArgumentParser()
-    p.add_argument("--skap-graph", type=Path, required=True)
+    p.add_argument("--skap-inventory", type=Path, required=True)
+    p.add_argument("--disclosure-graph", type=Path, required=True)
     p.add_argument("--propagation-graph", type=Path, required=True)
     p.add_argument("--generated-at", required=True)
     args = p.parse_args()
-    result = reconcile(json.loads(args.skap_graph.read_text()), json.loads(args.propagation_graph.read_text()), args.generated_at)
+    result = reconcile(
+        json.loads(args.skap_inventory.read_text()),
+        json.loads(args.disclosure_graph.read_text()),
+        json.loads(args.propagation_graph.read_text()),
+        args.generated_at,
+    )
     print(json.dumps(result, indent=2, sort_keys=True))
 
 

--- a/scripts/reconcile_skap_evidence.py
+++ b/scripts/reconcile_skap_evidence.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Bidirectionally reconcile SKAP-known accounts against evidence-backed organization mappings."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _reachable_from_provider(graph: dict[str, Any], provider: str) -> tuple[set[str], set[str]]:
+    account_edges = [e for e in graph["disclosure_edges"] if e["from_org_ref"] == provider]
+    downstream: set[str] = set()
+    refs: set[str] = set()
+    frontier = [provider]
+    visited = {provider}
+    while frontier:
+        current = frontier.pop(0)
+        for edge in graph["disclosure_edges"]:
+            if edge["from_org_ref"] != current:
+                continue
+            # Every edge may be retained as evidence context, but inference never becomes observed transfer.
+            downstream.add(edge["to_org_ref"])
+            refs.update(edge.get("evidence_refs", []))
+            if edge["to_org_ref"] not in visited:
+                visited.add(edge["to_org_ref"])
+                frontier.append(edge["to_org_ref"])
+    return downstream, refs
+
+
+def reconcile(skap_graph: dict[str, Any], propagation_graph: dict[str, Any], generated_at: str) -> dict[str, Any]:
+    if skap_graph["subject_ref"] != propagation_graph["subject_ref"]:
+        raise ValueError("cross-subject SKAP/evidence reconciliation is prohibited")
+
+    known_providers = {a["provider_org_ref"] for a in skap_graph["accounts"]}
+    accounts = []
+    downstream_from_known: set[str] = set()
+    for account in sorted(skap_graph["accounts"], key=lambda a: a["skap_account_ref"]):
+        downstream, refs = _reachable_from_provider(skap_graph, account["provider_org_ref"])
+        downstream_from_known.update(downstream)
+        mapped = bool(downstream or refs)
+        accounts.append({
+            "skap_account_ref": account["skap_account_ref"],
+            "provider_org_ref": account["provider_org_ref"],
+            "classification": "KNOWN_AND_MAPPED" if mapped else "KNOWN_BUT_UNMAPPED",
+            "downstream_org_refs": sorted(downstream),
+            "evidence_refs": sorted(refs),
+        })
+
+    evidence_only: dict[str, set[str]] = {}
+    node_by_id = {n["node_id"]: n for n in propagation_graph["nodes"]}
+    for edge in propagation_graph["edges"]:
+        if edge.get("verification_state") != "VERIFIED":
+            continue
+        to_node = node_by_id[edge["to"]]
+        org_ref = to_node.get("identity")
+        if not isinstance(org_ref, str) or not org_ref.startswith("org:"):
+            continue
+        if org_ref in known_providers or org_ref in downstream_from_known:
+            continue
+        evidence_only.setdefault(org_ref, set()).add(f"propagation-edge:{edge['edge_id']}")
+
+    return {
+        "schema": "stegverse.skap-evidence-reconciliation/v1",
+        "subject_ref": skap_graph["subject_ref"],
+        "generated_at": generated_at,
+        "accounts": accounts,
+        "evidence_only_origins": [
+            {"org_ref": org, "classification": "EVIDENCE_WITHOUT_KNOWN_ACCOUNT_ORIGIN", "evidence_refs": sorted(refs)}
+            for org, refs in sorted(evidence_only.items())
+        ],
+        "summary": {
+            "known_accounts": len(accounts),
+            "known_and_mapped": sum(a["classification"] == "KNOWN_AND_MAPPED" for a in accounts),
+            "known_but_unmapped": sum(a["classification"] == "KNOWN_BUT_UNMAPPED" for a in accounts),
+            "downstream_from_known_account": len(downstream_from_known),
+            "evidence_without_known_account_origin": len(evidence_only),
+        },
+    }
+
+
+def main() -> None:
+    import argparse
+    p = argparse.ArgumentParser()
+    p.add_argument("--skap-graph", type=Path, required=True)
+    p.add_argument("--propagation-graph", type=Path, required=True)
+    p.add_argument("--generated-at", required=True)
+    args = p.parse_args()
+    result = reconcile(json.loads(args.skap_graph.read_text()), json.loads(args.propagation_graph.read_text()), args.generated_at)
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_digital_data_reclamation.py
+++ b/scripts/validate_digital_data_reclamation.py
@@ -14,6 +14,7 @@ SCHEMAS = {
     "graph": ROOT / "schemas" / "data-propagation-graph.schema.json",
     "authority": ROOT / "schemas" / "derived-data-authority-receipt.schema.json",
     "skap_disclosure": ROOT / "schemas" / "skap-account-disclosure-graph.schema.json",
+    "skap_inventory_projection": ROOT / "schemas" / "skap-account-inventory-projection.schema.json",
     "target_set": ROOT / "schemas" / "reclamation-target-set.schema.json",
     "skap_evidence_reconciliation": ROOT / "schemas" / "skap-evidence-reconciliation.schema.json",
 }
@@ -22,6 +23,7 @@ SAMPLES = {
     "graph": FIX / "data-propagation-graph.sample.json",
     "authority": FIX / "derived-data-authority-receipt.sample.json",
     "skap_disclosure": FIX / "skap-account-disclosure-graph.sample.json",
+    "skap_inventory_projection": FIX / "skap-account-inventory-projection.sample.json",
     "target_set": FIX / "reclamation-target-set.sample.json",
     "skap_evidence_reconciliation": FIX / "skap-evidence-reconciliation.sample.json",
 }
@@ -124,25 +126,34 @@ def check_target_reconciliation(skap_disclosure):
 
 
 def check_skap_evidence_reconciliation(skap_disclosure):
+    skap_inventory = validate("skap_inventory_projection", SAMPLES["skap_inventory_projection"])
     propagation = validate("graph", FIX / "data-propagation-graph.reconciliation.sample.json")
     expected = validate("skap_evidence_reconciliation", SAMPLES["skap_evidence_reconciliation"])
-    actual = reconcile_skap_evidence(skap_disclosure, propagation, expected["generated_at"])
+    actual = reconcile_skap_evidence(skap_inventory, skap_disclosure, propagation, expected["generated_at"])
     if actual != expected:
         raise SystemExit("deterministic SKAP/evidence reconciliation does not match expected fixture")
 
     mismatch = dict(propagation)
     mismatch["subject_ref"] = "subject:different-user"
     try:
-        reconcile_skap_evidence(skap_disclosure, mismatch, expected["generated_at"])
+        reconcile_skap_evidence(skap_inventory, skap_disclosure, mismatch, expected["generated_at"])
     except ValueError:
         pass
     else:
         raise SystemExit("cross-subject SKAP/evidence reconciliation was incorrectly accepted")
 
-    extended = json.loads(json.dumps(skap_disclosure))
-    extended["organizations"].append({"org_ref":"org:unmapped-provider","name":"Unmapped Provider","role":"ACCOUNT_PROVIDER"})
-    extended["accounts"].append({"skap_account_ref":"skap:account:unmapped","provider_org_ref":"org:unmapped-provider","account_class":"other","status":"ACTIVE"})
-    gap = reconcile_skap_evidence(extended, propagation, expected["generated_at"])
+    secret_projection = dict(skap_inventory)
+    secret_projection["contains_secret_material"] = True
+    try:
+        reconcile_skap_evidence(secret_projection, skap_disclosure, propagation, expected["generated_at"])
+    except ValueError:
+        pass
+    else:
+        raise SystemExit("SKAP projection containing secret material was incorrectly accepted")
+
+    extended_inventory = json.loads(json.dumps(skap_inventory))
+    extended_inventory["accounts"].append({"skap_account_ref":"skap:account:unmapped","provider_org_ref":"org:unmapped-provider","account_class":"other","status":"ACTIVE"})
+    gap = reconcile_skap_evidence(extended_inventory, skap_disclosure, propagation, expected["generated_at"])
     unmapped = [a for a in gap["accounts"] if a["skap_account_ref"] == "skap:account:unmapped"]
     if len(unmapped) != 1 or unmapped[0]["classification"] != "KNOWN_BUT_UNMAPPED":
         raise SystemExit("known SKAP account without evidence mapping was not classified as KNOWN_BUT_UNMAPPED")
@@ -192,6 +203,7 @@ def main():
     graph = validate("graph", SAMPLES["graph"])
     validate("authority", SAMPLES["authority"])
     skap_disclosure = validate("skap_disclosure", SAMPLES["skap_disclosure"])
+    validate("skap_inventory_projection", SAMPLES["skap_inventory_projection"])
     check_cross_refs(inventory, graph)
     check_skap_disclosure_refs(skap_disclosure)
     check_authority_fail_closed()

--- a/scripts/validate_digital_data_reclamation.py
+++ b/scripts/validate_digital_data_reclamation.py
@@ -5,6 +5,7 @@ import tempfile
 from pathlib import Path
 from jsonschema import Draft202012Validator, FormatChecker
 from build_reclamation_target_set import build as build_target_set
+from reconcile_skap_evidence import reconcile as reconcile_skap_evidence
 
 ROOT = Path(__file__).resolve().parents[1]
 FIX = ROOT / "fixtures" / "digital-data-reclamation"
@@ -14,6 +15,7 @@ SCHEMAS = {
     "authority": ROOT / "schemas" / "derived-data-authority-receipt.schema.json",
     "skap_disclosure": ROOT / "schemas" / "skap-account-disclosure-graph.schema.json",
     "target_set": ROOT / "schemas" / "reclamation-target-set.schema.json",
+    "skap_evidence_reconciliation": ROOT / "schemas" / "skap-evidence-reconciliation.schema.json",
 }
 SAMPLES = {
     "inventory": FIX / "personal-data-inventory.sample.json",
@@ -21,6 +23,7 @@ SAMPLES = {
     "authority": FIX / "derived-data-authority-receipt.sample.json",
     "skap_disclosure": FIX / "skap-account-disclosure-graph.sample.json",
     "target_set": FIX / "reclamation-target-set.sample.json",
+    "skap_evidence_reconciliation": FIX / "skap-evidence-reconciliation.sample.json",
 }
 
 
@@ -120,6 +123,40 @@ def check_target_reconciliation(skap_disclosure):
             raise SystemExit("unverified target was incorrectly promoted to ELIGIBLE")
 
 
+def check_skap_evidence_reconciliation(skap_disclosure):
+    propagation = validate("graph", FIX / "data-propagation-graph.reconciliation.sample.json")
+    expected = validate("skap_evidence_reconciliation", SAMPLES["skap_evidence_reconciliation"])
+    actual = reconcile_skap_evidence(skap_disclosure, propagation, expected["generated_at"])
+    if actual != expected:
+        raise SystemExit("deterministic SKAP/evidence reconciliation does not match expected fixture")
+
+    mismatch = dict(propagation)
+    mismatch["subject_ref"] = "subject:different-user"
+    try:
+        reconcile_skap_evidence(skap_disclosure, mismatch, expected["generated_at"])
+    except ValueError:
+        pass
+    else:
+        raise SystemExit("cross-subject SKAP/evidence reconciliation was incorrectly accepted")
+
+    extended = json.loads(json.dumps(skap_disclosure))
+    extended["organizations"].append({"org_ref":"org:unmapped-provider","name":"Unmapped Provider","role":"ACCOUNT_PROVIDER"})
+    extended["accounts"].append({"skap_account_ref":"skap:account:unmapped","provider_org_ref":"org:unmapped-provider","account_class":"other","status":"ACTIVE"})
+    gap = reconcile_skap_evidence(extended, propagation, expected["generated_at"])
+    unmapped = [a for a in gap["accounts"] if a["skap_account_ref"] == "skap:account:unmapped"]
+    if len(unmapped) != 1 or unmapped[0]["classification"] != "KNOWN_BUT_UNMAPPED":
+        raise SystemExit("known SKAP account without evidence mapping was not classified as KNOWN_BUT_UNMAPPED")
+
+    inferred = next(e for e in skap_disclosure["disclosure_edges"] if e["evidence_state"] == "INFERRED_UNVERIFIED")
+    if inferred["evidence_refs"]:
+        raise SystemExit("fixture invariant changed: inferred edge unexpectedly has evidence refs")
+    account = next(a for a in actual["accounts"] if a["skap_account_ref"] == "skap:account:example-social")
+    if "org:example-broker" not in account["downstream_org_refs"]:
+        raise SystemExit("inferred downstream organization disappeared from discovery context")
+    if any(ref.startswith("observed-transfer:") for ref in account["evidence_refs"]):
+        raise SystemExit("inferred edge was incorrectly promoted to observed transfer evidence")
+
+
 def check_kv_custody():
     module_path = ROOT / "adapters" / "kv" / "reclamation_target_set_writer.py"
     spec = importlib.util.spec_from_file_location("reclamation_target_set_writer", module_path)
@@ -131,25 +168,15 @@ def check_kv_custody():
 
     with tempfile.TemporaryDirectory() as temp:
         kv_root = Path(temp)
-        write_receipt = module.write_target_set(
-            kv_root=kv_root,
-            target_set=target_set,
-            kv_instance_id="validator-kv",
-        )
+        write_receipt = module.write_target_set(kv_root=kv_root, target_set=target_set, kv_instance_id="validator-kv")
         if write_receipt["result"] != "WRITTEN" or write_receipt["provider_deletion_success"] is not False:
             raise SystemExit("reclamation KV write receipt semantics invalid")
         readback = module.readback_target_set(kv_root=kv_root, write_receipt=write_receipt)
         if not readback["exact_byte_match"] or readback["sha256"] != write_receipt["sha256"]:
             raise SystemExit("reclamation KV exact-byte readback failed")
-
-        retry = module.write_target_set(
-            kv_root=kv_root,
-            target_set=target_set,
-            kv_instance_id="validator-kv",
-        )
+        retry = module.write_target_set(kv_root=kv_root, target_set=target_set, kv_instance_id="validator-kv")
         if retry["result"] != "NOOP" or retry["sha256"] != write_receipt["sha256"]:
             raise SystemExit("reclamation KV idempotent retry failed")
-
         cross_subject = dict(write_receipt)
         cross_subject["subject_ref"] = "subject:different-user"
         try:
@@ -170,8 +197,9 @@ def main():
     check_authority_fail_closed()
     check_unverified_disclosure_fail_closed()
     check_target_reconciliation(skap_disclosure)
+    check_skap_evidence_reconciliation(skap_disclosure)
     check_kv_custody()
-    print("Digital Data Reclamation foundation + KV custody validation: PASS")
+    print("Digital Data Reclamation foundation + SKAP evidence reconciliation + KV custody validation: PASS")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements SS-DATA-RECLAMATION-DISCLOSURE-INGESTION-001 bidirectional reconciliation between SKAP-maintained accounts and evidence mappings. Adds deterministic schema, reconciler, fixture, documentation, and validation for KNOWN_AND_MAPPED, KNOWN_BUT_UNMAPPED, and EVIDENCE_WITHOUT_KNOWN_ACCOUNT_ORIGIN while preserving inferred-vs-observed and cross-subject fail-closed boundaries.