### PR TITLE
ERL: bind active research dispatch to MyKV persistence

### DIFF
--- a/.github/workflows/validate-active-research-dispatch.yml
+++ b/.github/workflows/validate-active-research-dispatch.yml
@@ -1,0 +1,64 @@
+name: Validate Active Research MyKV Dispatch
+
+on:
+  pull_request:
+    paths:
+      - "coordination/research-candidate-activation-registry.v1.json"
+      - "coordination/research-candidate-activation-registry.overlay.*.json"
+      - "config/*queue*.json"
+      - "config/*research-lane*.json"
+      - "scripts/generate_active_research_dispatch.py"
+      - "tests/test_active_research_dispatch.py"
+      - "docs/ACTIVE_RESEARCH_MYKV_COORDINATION.md"
+      - ".github/workflows/validate-active-research-dispatch.yml"
+  push:
+    branches: [main]
+    paths:
+      - "coordination/research-candidate-activation-registry.v1.json"
+      - "coordination/research-candidate-activation-registry.overlay.*.json"
+      - "config/*queue*.json"
+      - "config/*research-lane*.json"
+      - "scripts/generate_active_research_dispatch.py"
+      - "tests/test_active_research_dispatch.py"
+      - "docs/ACTIVE_RESEARCH_MYKV_COORDINATION.md"
+      - ".github/workflows/validate-active-research-dispatch.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install pytest
+      - name: Run dispatcher regression tests
+        run: python -m pytest -q tests/test_active_research_dispatch.py
+      - name: Generate dispatch from live registry state
+        run: |
+          python scripts/generate_active_research_dispatch.py \
+            --generated-at 2026-09-10T23:59:00Z \
+            --output /tmp/active-research-dispatch.json
+      - name: Enforce MyKV and non-authority boundaries
+        run: |
+          python - <<'PY'
+          import json
+          p=json.load(open('/tmp/active-research-dispatch.json'))
+          assert p['mykv_coordination']['required_lane']=='02_Research/ERL'
+          assert p['mykv_coordination']['github_storage_satisfies_persistence'] is False
+          assert p['mykv_coordination']['exact_byte_readback_required'] is True
+          active={x['group_id']:x for x in p['lanes']}
+          cyber=active['ERL-RC-CYBER-SABOTAGE-LINEAGE-2026']
+          assert cyber['dispatch_state']=='ELIGIBLE_FOR_AUTOMATED_ACQUISITION'
+          assert cyber['mykv']['required'] is True
+          assert cyber['finding_authorized'] is False
+          assert cyber['publication_authorized'] is False
+          assert sum(len(q['executable_items']) for q in cyber['queues']) >= 1
+          print({'status':'PASS','active_lanes':len(active),'cyber_dispatch':cyber['dispatch_state']})
+          PY

--- a/docs/ACTIVE_RESEARCH_MYKV_DISPATCH_MIRROR_HANDOFF.md
+++ b/docs/ACTIVE_RESEARCH_MYKV_DISPATCH_MIRROR_HANDOFF.md
@@ -1,0 +1,45 @@
+# ERL Active Research MyKV Dispatch Mirror Handoff
+
+Updated: 2026-09-10
+
+## Parent Goal Task ID
+
+SS-EVIDENCE-COMPARISON-001
+
+Canonical parent handoff: `docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md`
+
+## Objective
+
+Make ACTIVE ERL research lanes restartable when acquisition is machine-capable, while making MyKV the durable coordination substrate for acquired sources, provenance, derived research artifacts, and execution receipts.
+
+## Implemented on PR #154
+
+- `docs/ACTIVE_RESEARCH_MYKV_COORDINATION.md` defines the coordination and restart contract.
+- `scripts/generate_active_research_dispatch.py` reads the canonical research-candidate activation registry plus additive overlays.
+- Active groups are retained even when no machine acquisition surface exists; they receive an explicit deferred dispatch state instead of disappearing.
+- Queue-like registered artifacts are inspected for executable HTTP(S) items in `READY`, `CONTINUING`, or `REFRESH` state.
+- Every executable item carries `persistence_required=true` and `required_storage_lane=02_Research/ERL`.
+- The dispatcher declares that GitHub storage cannot satisfy MyKV persistence.
+- Exact-byte MyKV readback is required.
+- Cross-lane source reuse is allowed by exact-byte identity/provenance; finding-state reuse is prohibited.
+- Candidate finding and publication authority remain false.
+- `tests/test_active_research_dispatch.py` covers executable and deferred active-lane behavior.
+- `.github/workflows/validate-active-research-dispatch.yml` validates the real registry and requires `ERL-RC-CYBER-SABOTAGE-LINEAGE-2026` to be eligible for automated acquisition with MyKV persistence required.
+
+## Restart rule
+
+An ACTIVE lane is eligible for automated continuation when it has a machine-capable acquisition surface and its execution policy is satisfied. Durable acquisition completes only with `KV_STORED_AND_READBACK_VERIFIED` or `KV_ALREADY_PRESENT_AND_HASH_MATCHED`. Acquired-but-not-persisted work remains resumable as `KV_PERSISTENCE_PENDING` or `KV_UNAVAILABLE`.
+
+## Execution boundary
+
+GitHub Actions may validate and transport dispatch/candidate state. They are not MyKV execution authority and GitHub-hosted artifacts do not satisfy durable ERL research persistence.
+
+The remaining runtime work is a MyKV-capable executor path that consumes the dispatch manifest, performs source acquisition under Interlock/InTr admission, emits ERL KV manifests, invokes the existing ERL KV writer/provider-operation path, verifies exact-byte readback, and returns durable receipts for restart reconstruction.
+
+## First test lane
+
+`ERL-RC-CYBER-SABOTAGE-LINEAGE-2026` using `config/network-cyberphysical-sabotage-source-queue.v1.json`.
+
+## Current state
+
+DISPATCH_IMPLEMENTED_ON_OPEN_PR / HOSTED_VALIDATION_PENDING / MYKV_EXECUTOR_CONSUMPTION_NOT_YET_PROVEN

--- a/docs/ERL_ACTIVE_RESEARCH_MYKV_COORDINATION.md
+++ b/docs/ERL_ACTIVE_RESEARCH_MYKV_COORDINATION.md
@@ -1,0 +1,115 @@
+# ERL Active Research / MyKV Coordination Contract
+
+## Purpose
+
+Define how active ERL research lanes resume automated acquisition while using MyKV as the durable coordination substrate for acquired source data, provenance, derived research artifacts, and execution receipts.
+
+ERL remains the research/evidence authority. MyKV remains the user-custodied storage and continuity substrate. Neither storage location nor successful acquisition promotes a claim into a finding.
+
+## Core rule
+
+An automated ERL acquisition cycle is not complete merely because bytes were fetched or written into a GitHub workspace.
+
+For any lane whose acquisition policy requires durable retention, completion requires one of the following terminal acquisition-storage states:
+
+- `KV_STORED_AND_READBACK_VERIFIED`
+- `KV_ALREADY_PRESENT_AND_HASH_MATCHED`
+- `KV_PERSISTENCE_PENDING`
+- `KV_UNAVAILABLE`
+- `SOURCE_UNAVAILABLE`
+- `ACQUISITION_ERROR`
+
+Only the first two states constitute completed durable acquisition. `KV_PERSISTENCE_PENDING` and `KV_UNAVAILABLE` preserve resumability but do not permit the lane to claim durable acquisition completion.
+
+## Coordination sequence
+
+```text
+active research registry
+  -> active research dispatcher
+  -> executable acquisition item
+  -> Interlock/InTr admission
+  -> transient source acquisition
+  -> hash + provenance + media metadata
+  -> ERL KV artifact manifest
+  -> MyKV 02_Research/ERL/<artifact_id>/
+  -> create-only payload writes
+  -> canonical manifest written last
+  -> exact byte readback
+  -> ERL KV write/provider-operation receipt
+  -> ERL evidence/reference index
+  -> lane-specific analysis / contradiction / adjacency work
+  -> derived artifact manifest
+  -> MyKV persistence + readback
+```
+
+GitHub Actions may carry, validate, or stage execution manifests and candidate state. GitHub storage is not the authoritative durable research-data store and cannot satisfy MyKV persistence by itself.
+
+## Cross-lane source reuse
+
+The same acquired source may be relevant to multiple active research lanes. ERL MUST avoid unnecessary duplicate acquisition/storage when exact bytes are already present in MyKV.
+
+A source object is reusable when its exact-byte identity and provenance are sufficient for the new lane. The new lane records a reference to the existing MyKV artifact and adds its own lane-relative purpose, evidence class, state dimensions, and unresolved propositions.
+
+Cross-lane reuse MUST NOT copy another lane's finding state. A source can strengthen one proposition, weaken another, and merely disambiguate a third.
+
+## MyKV storage boundary
+
+Canonical ERL durable storage remains:
+
+`02_Research/ERL/<artifact_id>/`
+
+The existing native writer `adapters/kv/erl_kv_writer.py` remains authoritative for mounted-MyKV create-only writes, manifest-last ordering, object hash/size validation, idempotent exact re-entry, credential exclusion, and byte-for-byte readback.
+
+Provider-backed persistence MUST retain the provider-operation receipt and independent readback evidence required by the existing ERL KV storage contract.
+
+## Active lane execution eligibility
+
+A research lane may be automatically dispatched only when:
+
+1. the candidate registry says the lane is active;
+2. no governed terminal transition exists;
+3. an executable acquisition queue/search surface exists;
+4. the item is in an executable state such as `READY`, `CONTINUING`, or `REFRESH`;
+5. execution authority/policy requirements are satisfied;
+6. the acquisition operation cannot itself grant finding or publication authority.
+
+The dispatcher MUST record non-executable active lanes as durable deferred states rather than silently omitting them.
+
+## Restart semantics
+
+The dispatcher reconstructs work from durable registry state plus the latest acquisition/MyKV receipts. Chat/session continuity is not required.
+
+On restart:
+
+- exact MyKV artifact + valid readback receipt -> reuse and continue downstream analysis;
+- acquired bytes but no verified MyKV persistence -> resume at persistence;
+- prior source failure -> retry according to lane cadence/policy;
+- terminal candidate transition -> do not dispatch;
+- no executable acquisition surface -> retain `RESEARCH_ACTIVE_NO_AUTOMATED_ACQUISITION`.
+
+## Data-sharing semantics between ERL lanes
+
+MyKV provides shared custody, not shared conclusions.
+
+Each lane may reference common MyKV source artifacts while maintaining independent:
+
+- proposition bindings;
+- evidence-direction classification;
+- attribution ceilings;
+- contradiction state;
+- chronology interpretation;
+- authority/jurisdiction mapping;
+- review status;
+- finding/publication state.
+
+Derived artifacts that materially change research state are themselves persisted as new MyKV ERL artifacts with provenance back to the source objects and prior state.
+
+## Publication boundary
+
+Automated acquisition and MyKV persistence authorize neither public release nor factual promotion. Reviewed publication remains governed by the existing ERL/StegSocials publication contracts.
+
+## First test lane
+
+`ERL-RC-CYBER-SABOTAGE-LINEAGE-2026` is the first recommended active-research dispatcher test because it already has `config/network-cyberphysical-sabotage-source-queue.v1.json` containing public HTTPS, no-credential `READY` items.
+
+The test passes only if eligible items produce durable MyKV storage/readback receipts or explicit persistence-deferred receipts; a GitHub-only capture is insufficient.

--- a/scripts/generate_active_research_dispatch.py
+++ b/scripts/generate_active_research_dispatch.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Generate restartable ERL active-research dispatch state with required MyKV persistence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+BASE_REGISTRY = Path("coordination/research-candidate-activation-registry.v1.json")
+OVERLAY_GLOB = "research-candidate-activation-registry.overlay.*.json"
+EXECUTABLE_ITEM_STATES = {"READY", "CONTINUING", "REFRESH"}
+MYKV_LANE = "02_Research/ERL"
+SCHEMA = "stegverse.executive_rhetoric_ledger.active_research_dispatch.v1"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_groups(root: Path) -> list[dict[str, Any]]:
+    groups = list(load_json(root / BASE_REGISTRY).get("groups", []))
+    for overlay in sorted((root / "coordination").glob(OVERLAY_GLOB)):
+        groups.extend(load_json(overlay).get("groups", []))
+    return groups
+
+
+def queue_candidates(root: Path, group: dict[str, Any]) -> list[Path]:
+    candidates: list[Path] = []
+    for raw in group.get("artifact_paths", []):
+        if not isinstance(raw, str) or not raw.endswith(".json"):
+            continue
+        lowered = raw.lower()
+        if "queue" not in lowered and "research-lane" not in lowered and "recurring-search" not in lowered:
+            continue
+        path = root / raw
+        if path.is_file():
+            candidates.append(path)
+    return candidates
+
+
+def inspect_queue(root: Path, queue: Path) -> dict[str, Any]:
+    doc = load_json(queue)
+    items = doc.get("items")
+    executable = []
+    if isinstance(items, list):
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            state = str(item.get("state", "")).upper()
+            url = item.get("url")
+            if state in EXECUTABLE_ITEM_STATES and isinstance(url, str) and url.startswith(("https://", "http://")):
+                executable.append({
+                    "source_id": item.get("source_id"),
+                    "state": state,
+                    "url": url,
+                    "destination": item.get("destination"),
+                    "evidence_class": item.get("evidence_class"),
+                    "persistence_required": True,
+                    "required_storage_lane": MYKV_LANE,
+                })
+    enabled = doc.get("enabled") is True
+    return {
+        "queue_path": queue.relative_to(root).as_posix(),
+        "queue_goal_id": doc.get("goal_id") or doc.get("lane_id") or doc.get("config_id"),
+        "network_policy": doc.get("network_policy"),
+        "credential_requirement": doc.get("credential_requirement"),
+        "finding_authority": doc.get("finding_authority"),
+        "executable_items": executable,
+        "config_enabled": enabled,
+    }
+
+
+def build_dispatch(root: Path, generated_at: str) -> dict[str, Any]:
+    lanes = []
+    for group in load_groups(root):
+        if group.get("active") is not True:
+            continue
+        queues = [inspect_queue(root, p) for p in queue_candidates(root, group)]
+        executable_count = sum(len(q["executable_items"]) for q in queues)
+        if executable_count:
+            state = "ELIGIBLE_FOR_AUTOMATED_ACQUISITION"
+        elif queues:
+            state = "RESEARCH_ACTIVE_NO_READY_ACQUISITION_ITEMS"
+        else:
+            state = "RESEARCH_ACTIVE_NO_AUTOMATED_ACQUISITION"
+        lanes.append({
+            "group_id": group.get("group_id"),
+            "title": group.get("title"),
+            "research_state": group.get("state"),
+            "durable_owner": group.get("durable_owner"),
+            "next_executable_task": group.get("next_executable_task"),
+            "dispatch_state": state,
+            "queues": queues,
+            "mykv": {
+                "required": executable_count > 0,
+                "lane": MYKV_LANE,
+                "completion_states": [
+                    "KV_STORED_AND_READBACK_VERIFIED",
+                    "KV_ALREADY_PRESENT_AND_HASH_MATCHED",
+                ],
+                "deferred_states": ["KV_PERSISTENCE_PENDING", "KV_UNAVAILABLE"],
+            },
+            "finding_authorized": False,
+            "publication_authorized": False,
+        })
+    return {
+        "schema": SCHEMA,
+        "generated_at": generated_at,
+        "registry": BASE_REGISTRY.as_posix(),
+        "restart_basis": "ACTIVE_REGISTRY_PLUS_LATEST_ACQUISITION_AND_MYKV_RECEIPTS",
+        "mykv_coordination": {
+            "required_lane": MYKV_LANE,
+            "github_storage_satisfies_persistence": False,
+            "exact_byte_readback_required": True,
+            "cross_lane_source_reuse_by_hash": True,
+            "cross_lane_finding_state_reuse": False,
+        },
+        "lanes": lanes,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path("."))
+    parser.add_argument("--generated-at", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    document = build_dispatch(args.root.resolve(), args.generated_at)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_active_research_dispatch.py
+++ b/tests/test_active_research_dispatch.py
@@ -1,0 +1,73 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+def load_module():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "generate_active_research_dispatch.py"
+    spec = importlib.util.spec_from_file_location("active_dispatch", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_json(path: Path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def test_active_ready_queue_requires_mykv(tmp_path):
+    write_json(tmp_path / "coordination/research-candidate-activation-registry.v1.json", {
+        "groups": [{
+            "group_id": "ERL-RC-TEST-001",
+            "title": "test",
+            "active": True,
+            "state": "RESEARCH_ACTIVE",
+            "durable_owner": "issue:1",
+            "artifact_paths": ["config/test-source-queue.json"],
+            "next_executable_task": "Acquire public evidence."
+        }]
+    })
+    write_json(tmp_path / "config/test-source-queue.json", {
+        "goal_id": "ERL-TEST-001",
+        "network_policy": "PUBLIC_HTTPS_ONLY_NO_AUTH",
+        "credential_requirement": "NONE",
+        "finding_authority": "NONE",
+        "items": [{
+            "source_id": "SRC-1",
+            "state": "READY",
+            "url": "https://example.com/evidence",
+            "destination": "evidence/example.native",
+            "evidence_class": "official-record"
+        }]
+    })
+
+    doc = load_module().build_dispatch(tmp_path, "2026-09-10T23:59:00Z")
+    lane = doc["lanes"][0]
+    assert lane["dispatch_state"] == "ELIGIBLE_FOR_AUTOMATED_ACQUISITION"
+    assert lane["mykv"]["required"] is True
+    assert lane["mykv"]["lane"] == "02_Research/ERL"
+    assert doc["mykv_coordination"]["github_storage_satisfies_persistence"] is False
+    assert lane["queues"][0]["executable_items"][0]["persistence_required"] is True
+    assert lane["finding_authorized"] is False
+    assert lane["publication_authorized"] is False
+
+
+def test_active_lane_without_queue_is_deferred_not_dropped(tmp_path):
+    write_json(tmp_path / "coordination/research-candidate-activation-registry.v1.json", {
+        "groups": [{
+            "group_id": "ERL-RC-MANUAL-001",
+            "title": "manual",
+            "active": True,
+            "state": "RESEARCH_ACTIVE",
+            "durable_owner": "issue:2",
+            "artifact_paths": [],
+            "next_executable_task": "Acquire unavailable primary record."
+        }]
+    })
+
+    doc = load_module().build_dispatch(tmp_path, "2026-09-10T23:59:00Z")
+    lane = doc["lanes"][0]
+    assert lane["dispatch_state"] == "RESEARCH_ACTIVE_NO_AUTOMATED_ACQUISITION"
+    assert lane["mykv"]["required"] is False


### PR DESCRIPTION
WIP: connect ACTIVE research-candidate lanes to executable acquisition surfaces and require MyKV persistence/readback as part of automated-cycle completion. GitHub remains validation/evidence transport rather than MyKV execution authority.