### PR TITLE
ERL: consume admitted active research into MyKV

### DIFF
--- a/.github/workflows/validate-active-research-acquisition-consumer.yml
+++ b/.github/workflows/validate-active-research-acquisition-consumer.yml
@@ -1,0 +1,34 @@
+name: Validate Active Research Acquisition Consumer
+
+on:
+  pull_request:
+    paths:
+      - "scripts/consume_active_research_acquisition.py"
+      - "tests/test_active_research_acquisition_consumer.py"
+      - ".github/workflows/validate-active-research-acquisition-consumer.yml"
+      - "docs/ACTIVE_RESEARCH_MYKV_DISPATCH_MIRROR_HANDOFF.md"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/consume_active_research_acquisition.py"
+      - "tests/test_active_research_acquisition_consumer.py"
+      - ".github/workflows/validate-active-research-acquisition-consumer.yml"
+      - "docs/ACTIVE_RESEARCH_MYKV_DISPATCH_MIRROR_HANDOFF.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install pytest
+      - name: Run acquisition consumer tests
+        run: python -m pytest -q tests/test_active_research_acquisition_consumer.py

--- a/docs/ACTIVE_RESEARCH_MYKV_DISPATCH_MIRROR_HANDOFF.md
+++ b/docs/ACTIVE_RESEARCH_MYKV_DISPATCH_MIRROR_HANDOFF.md
@@ -8,23 +8,40 @@ SS-EVIDENCE-COMPARISON-001
 
 Canonical parent handoff: `docs/ERL_KV_STORAGE_MIRROR_HANDOFF.md`
 
+COSV: `40000100100000`
+
 ## Objective
 
 Make ACTIVE ERL research lanes restartable when acquisition is machine-capable, while making MyKV the durable coordination substrate for acquired sources, provenance, derived research artifacts, and execution receipts.
 
-## Implemented on PR #154
+## Dispatcher completion
 
-- `docs/ACTIVE_RESEARCH_MYKV_COORDINATION.md` defines the coordination and restart contract.
-- `scripts/generate_active_research_dispatch.py` reads the canonical research-candidate activation registry plus additive overlays.
-- Active groups are retained even when no machine acquisition surface exists; they receive an explicit deferred dispatch state instead of disappearing.
-- Queue-like registered artifacts are inspected for executable HTTP(S) items in `READY`, `CONTINUING`, or `REFRESH` state.
-- Every executable item carries `persistence_required=true` and `required_storage_lane=02_Research/ERL`.
-- The dispatcher declares that GitHub storage cannot satisfy MyKV persistence.
-- Exact-byte MyKV readback is required.
-- Cross-lane source reuse is allowed by exact-byte identity/provenance; finding-state reuse is prohibited.
-- Candidate finding and publication authority remain false.
-- `tests/test_active_research_dispatch.py` covers executable and deferred active-lane behavior.
-- `.github/workflows/validate-active-research-dispatch.yml` validates the real registry and requires `ERL-RC-CYBER-SABOTAGE-LINEAGE-2026` to be eligible for automated acquisition with MyKV persistence required.
+PR #154 merged at `51ebf09e2412be858243e4925a8dd48f624cf467` after both hosted checks passed on head `d21d48442f9c61456e0d73c7155e9de85084e963`.
+
+The merged dispatcher:
+
+- reads the canonical research-candidate activation registry plus overlays;
+- retains active groups even when no machine acquisition surface exists;
+- exposes executable HTTPS items in `READY`, `CONTINUING`, or `REFRESH` state;
+- requires MyKV persistence under `02_Research/ERL`;
+- rejects GitHub artifact storage as durable MyKV persistence;
+- requires exact-byte MyKV readback;
+- permits exact-byte source reuse across lanes without reusing finding state;
+- carries no finding or publication authority.
+
+## InTr-bound consumer continuation
+
+Branch `erl-active-research-intr-mykv-consumer-2026-09-10` adds the next bounded execution unit:
+
+- `scripts/consume_active_research_acquisition.py` consumes one dispatched acquisition only after a canonical `stegverse.intr.hop_receipt/v1` binds the exact acquisition envelope;
+- the consumer verifies HTTPS source identity against the dispatch allowlist;
+- verified transport receipt may not contain secret plaintext or transfer authority;
+- the consumer emits the existing `stegverse.erl.kv-artifact/v1` source-capture manifest;
+- it delegates create-only materialization and exact-byte readback to `adapters/kv/erl_kv_writer.py`;
+- durable completion becomes `KV_STORED_AND_READBACK_VERIFIED` or `KV_ALREADY_PRESENT_AND_HASH_MATCHED` only after writer readback succeeds;
+- finding and publication authority remain false;
+- regression tests reject an unbound InTr receipt and an attempted authority transfer;
+- `.github/workflows/validate-active-research-acquisition-consumer.yml` provides hosted validation without claiming GitHub is MyKV execution authority.
 
 ## Restart rule
 
@@ -34,7 +51,7 @@ An ACTIVE lane is eligible for automated continuation when it has a machine-capa
 
 GitHub Actions may validate and transport dispatch/candidate state. They are not MyKV execution authority and GitHub-hosted artifacts do not satisfy durable ERL research persistence.
 
-The remaining runtime work is a MyKV-capable executor path that consumes the dispatch manifest, performs source acquisition under Interlock/InTr admission, emits ERL KV manifests, invokes the existing ERL KV writer/provider-operation path, verifies exact-byte readback, and returns durable receipts for restart reconstruction.
+The new consumer proves the repository-side admission-to-writer boundary deterministically. Authentic runtime completion still requires a real acquisition to traverse an actual Interlock/InTr admission surface and a real MyKV/provider target to return exact-byte storage/readback evidence.
 
 ## First test lane
 
@@ -42,4 +59,4 @@ The remaining runtime work is a MyKV-capable executor path that consumes the dis
 
 ## Current state
 
-DISPATCH_IMPLEMENTED_ON_OPEN_PR / HOSTED_VALIDATION_PENDING / MYKV_EXECUTOR_CONSUMPTION_NOT_YET_PROVEN
+DISPATCH_MERGED / INTR_BOUND_MYKV_CONSUMER_IMPLEMENTED_ON_BRANCH / HOSTED_VALIDATION_PENDING / AUTHENTIC_INTERLOCK_INTR_ACQUISITION_TO_MYKV_RECEIPT_NOT_YET_OBSERVED

--- a/scripts/consume_active_research_acquisition.py
+++ b/scripts/consume_active_research_acquisition.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Consume one admitted ERL active-research acquisition into MyKV.
+
+This consumer is intentionally transport-neutral: source acquisition happens before this
+step, but durable completion is impossible unless a canonical InTr hop receipt binds the
+exact acquisition envelope and the existing ERL KV writer completes exact-byte readback.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import mimetypes
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+from urllib.parse import urlparse
+
+from adapters.kv.erl_kv_writer import write_bundle
+
+INTR_SCHEMA = "stegverse.intr.hop_receipt/v1"
+RESULT_SCHEMA = "stegverse.erl.active-research-acquisition-result/v1"
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+
+
+def digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def verify_intr_receipt(receipt: Mapping[str, Any], *, payload_hash: str) -> None:
+    required = {
+        "schema", "receipt_id", "packet_id", "hop_index", "direction", "from_role", "to_role",
+        "operation_hash", "payload_hash", "prior_receipt_hash", "boundary_identity_ref",
+        "boundary_verification", "transition_state", "secret_plaintext_present", "authority_transfer",
+        "recorded_at", "receipt_hash",
+    }
+    if set(receipt) != required:
+        raise ValueError("InTr hop receipt canonical field mismatch")
+    if receipt.get("schema") != INTR_SCHEMA:
+        raise ValueError("unexpected InTr hop receipt schema")
+    if receipt.get("direction") != "FORWARD" or not isinstance(receipt.get("hop_index"), int):
+        raise ValueError("InTr receipt must describe a forward hop")
+    if receipt.get("boundary_verification") != "VERIFIED" or receipt.get("transition_state") != "RECEIVED":
+        raise ValueError("InTr receipt must prove verified receipt at the consumer boundary")
+    if receipt.get("payload_hash") != payload_hash:
+        raise ValueError("InTr receipt does not bind the exact acquisition envelope")
+    if receipt.get("secret_plaintext_present") is not False or receipt.get("authority_transfer") is not False:
+        raise ValueError("InTr acquisition receipt may contain neither secret plaintext nor authority transfer")
+    body = dict(receipt)
+    claimed = body.pop("receipt_hash")
+    if claimed != digest(body):
+        raise ValueError("InTr receipt hash mismatch")
+
+
+def find_item(dispatch: Mapping[str, Any], group_id: str, source_id: str) -> Mapping[str, Any]:
+    for lane in dispatch.get("lanes", []):
+        if lane.get("group_id") != group_id:
+            continue
+        if lane.get("dispatch_state") != "ELIGIBLE_FOR_AUTOMATED_ACQUISITION":
+            raise ValueError("requested research lane is not eligible for automated acquisition")
+        if lane.get("finding_authorized") is not False or lane.get("publication_authorized") is not False:
+            raise ValueError("dispatcher illegally elevated finding/publication authority")
+        for queue in lane.get("queues", []):
+            for item in queue.get("executable_items", []):
+                if item.get("source_id") == source_id:
+                    if item.get("persistence_required") is not True:
+                        raise ValueError("dispatch item does not require MyKV persistence")
+                    if item.get("required_storage_lane") != "02_Research/ERL":
+                        raise ValueError("dispatch item targets the wrong MyKV lane")
+                    return item
+    raise ValueError("dispatch item not found")
+
+
+def consume(*, dispatch: Mapping[str, Any], group_id: str, source_id: str, intr_receipt: Mapping[str, Any],
+            payload: Path, kv_root: Path, kv_instance_id: str, captured_at: str | None = None) -> dict[str, Any]:
+    if dispatch.get("mykv_coordination", {}).get("github_storage_satisfies_persistence") is not False:
+        raise ValueError("dispatch must explicitly reject GitHub storage as MyKV persistence")
+    if dispatch.get("mykv_coordination", {}).get("exact_byte_readback_required") is not True:
+        raise ValueError("dispatch must require exact-byte MyKV readback")
+
+    item = find_item(dispatch, group_id, source_id)
+    url = str(item.get("url", ""))
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise ValueError("active research acquisition consumer requires HTTPS source identity")
+    allowed_hosts = set(item.get("allowed_hosts", []))
+    if parsed.hostname not in allowed_hosts:
+        raise ValueError("source host is not admitted by the dispatch item")
+
+    acquisition_envelope = {
+        "schema": "stegverse.erl.active-research-acquisition-envelope/v1",
+        "group_id": group_id,
+        "source_id": source_id,
+        "source_url": url,
+        "required_storage_lane": "02_Research/ERL",
+        "finding_authorized": False,
+        "publication_authorized": False,
+    }
+    envelope_hash = digest(acquisition_envelope)
+    verify_intr_receipt(intr_receipt, payload_hash=envelope_hash)
+
+    data = payload.read_bytes()
+    raw_sha = hashlib.sha256(data).hexdigest()
+    timestamp = captured_at or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    artifact_id = f"ERL-ACTIVE-{source_id}"
+    filename = payload.name
+    manifest = {
+        "schema": "stegverse.erl.kv-artifact/v1",
+        "artifact_id": artifact_id,
+        "artifact_class": "SOURCE_CAPTURE",
+        "captured_at": timestamp,
+        "source": {"title": source_id, "publisher": parsed.hostname or "unknown", "primary_url": url},
+        "storage": {"lane": "02_Research/ERL", "kv_instance_id": kv_instance_id, "credential_material_present": False},
+        "objects": [{
+            "filename": filename,
+            "sha256": raw_sha,
+            "size_bytes": len(data),
+            "media_type": mimetypes.guess_type(filename)[0] or "application/octet-stream",
+            "role": "acquired-source",
+        }],
+    }
+    kv_receipt = write_bundle(kv_root=kv_root, manifest=manifest, payloads={filename: payload})
+    if kv_receipt.get("readback_verified") is not True:
+        raise ValueError("MyKV exact-byte readback was not verified")
+
+    return {
+        "schema": RESULT_SCHEMA,
+        "group_id": group_id,
+        "source_id": source_id,
+        "state": "KV_STORED_AND_READBACK_VERIFIED" if kv_receipt["result"] == "WRITTEN" else "KV_ALREADY_PRESENT_AND_HASH_MATCHED",
+        "acquisition_envelope_sha256": envelope_hash,
+        "intr_receipt_hash": intr_receipt["receipt_hash"],
+        "artifact_id": artifact_id,
+        "source_sha256": raw_sha,
+        "kv_write_receipt": kv_receipt,
+        "finding_authorized": False,
+        "publication_authorized": False,
+    }
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dispatch", type=Path, required=True)
+    p.add_argument("--group-id", required=True)
+    p.add_argument("--source-id", required=True)
+    p.add_argument("--intr-receipt", type=Path, required=True)
+    p.add_argument("--payload", type=Path, required=True)
+    p.add_argument("--kv-root", type=Path, required=True)
+    p.add_argument("--kv-instance-id", required=True)
+    p.add_argument("--captured-at")
+    p.add_argument("--result", type=Path)
+    args = p.parse_args()
+    result = consume(
+        dispatch=json.loads(args.dispatch.read_text()), group_id=args.group_id, source_id=args.source_id,
+        intr_receipt=json.loads(args.intr_receipt.read_text()), payload=args.payload, kv_root=args.kv_root,
+        kv_instance_id=args.kv_instance_id, captured_at=args.captured_at,
+    )
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.result:
+        args.result.write_text(rendered)
+    print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_active_research_acquisition_consumer.py
+++ b/tests/test_active_research_acquisition_consumer.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.consume_active_research_acquisition import consume, digest
+
+
+def make_dispatch():
+    return {
+        "mykv_coordination": {
+            "github_storage_satisfies_persistence": False,
+            "exact_byte_readback_required": True,
+        },
+        "lanes": [{
+            "group_id": "ERL-RC-CYBER-SABOTAGE-LINEAGE-2026",
+            "dispatch_state": "ELIGIBLE_FOR_AUTOMATED_ACQUISITION",
+            "finding_authorized": False,
+            "publication_authorized": False,
+            "queues": [{
+                "executable_items": [{
+                    "source_id": "ERL-CYBER-WEB-HISTORY-CERN",
+                    "url": "https://web30.web.cern.ch/web-history.html",
+                    "allowed_hosts": ["web30.web.cern.ch", "home.cern"],
+                    "persistence_required": True,
+                    "required_storage_lane": "02_Research/ERL",
+                }]
+            }],
+        }],
+    }
+
+
+def make_receipt(payload_hash: str):
+    body = {
+        "schema": "stegverse.intr.hop_receipt/v1",
+        "receipt_id": "receipt-1",
+        "packet_id": "packet-1",
+        "hop_index": 1,
+        "direction": "FORWARD",
+        "from_role": "ERL_DISPATCHER",
+        "to_role": "ERL_ACQUISITION_EXECUTOR",
+        "operation_hash": "sha256:" + "1" * 64,
+        "payload_hash": payload_hash,
+        "prior_receipt_hash": None,
+        "boundary_identity_ref": "erl-acquisition-executor:test",
+        "boundary_verification": "VERIFIED",
+        "transition_state": "RECEIVED",
+        "secret_plaintext_present": False,
+        "authority_transfer": False,
+        "recorded_at": "2026-09-10T20:00:00Z",
+    }
+    return {**body, "receipt_hash": digest(body)}
+
+
+def envelope_hash():
+    return digest({
+        "schema": "stegverse.erl.active-research-acquisition-envelope/v1",
+        "group_id": "ERL-RC-CYBER-SABOTAGE-LINEAGE-2026",
+        "source_id": "ERL-CYBER-WEB-HISTORY-CERN",
+        "source_url": "https://web30.web.cern.ch/web-history.html",
+        "required_storage_lane": "02_Research/ERL",
+        "finding_authorized": False,
+        "publication_authorized": False,
+    })
+
+
+def test_consumes_admitted_payload_into_kv(tmp_path: Path):
+    payload = tmp_path / "cern.html"
+    payload.write_bytes(b"<html>cern</html>\n")
+    kv = tmp_path / "kv"
+    kv.mkdir()
+    result = consume(
+        dispatch=make_dispatch(),
+        group_id="ERL-RC-CYBER-SABOTAGE-LINEAGE-2026",
+        source_id="ERL-CYBER-WEB-HISTORY-CERN",
+        intr_receipt=make_receipt(envelope_hash()),
+        payload=payload,
+        kv_root=kv,
+        kv_instance_id="MYKV-TEST",
+        captured_at="2026-09-10T20:00:00Z",
+    )
+    assert result["state"] == "KV_STORED_AND_READBACK_VERIFIED"
+    assert result["finding_authorized"] is False
+    assert result["publication_authorized"] is False
+    stored = kv / "02_Research" / "ERL" / result["artifact_id"] / "cern.html"
+    assert stored.read_bytes() == payload.read_bytes()
+    assert result["source_sha256"] == hashlib.sha256(payload.read_bytes()).hexdigest()
+
+
+def test_rejects_receipt_not_bound_to_envelope(tmp_path: Path):
+    payload = tmp_path / "cern.html"
+    payload.write_bytes(b"x")
+    kv = tmp_path / "kv"
+    kv.mkdir()
+    with pytest.raises(ValueError, match="bind"):
+        consume(
+            dispatch=make_dispatch(),
+            group_id="ERL-RC-CYBER-SABOTAGE-LINEAGE-2026",
+            source_id="ERL-CYBER-WEB-HISTORY-CERN",
+            intr_receipt=make_receipt("sha256:" + "0" * 64),
+            payload=payload,
+            kv_root=kv,
+            kv_instance_id="MYKV-TEST",
+            captured_at="2026-09-10T20:00:00Z",
+        )
+
+
+def test_rejects_authority_transfer(tmp_path: Path):
+    payload = tmp_path / "cern.html"
+    payload.write_bytes(b"x")
+    kv = tmp_path / "kv"
+    kv.mkdir()
+    receipt = make_receipt(envelope_hash())
+    receipt["authority_transfer"] = True
+    body = dict(receipt)
+    body.pop("receipt_hash")
+    receipt["receipt_hash"] = digest(body)
+    with pytest.raises(ValueError, match="authority"):
+        consume(
+            dispatch=make_dispatch(),
+            group_id="ERL-RC-CYBER-SABOTAGE-LINEAGE-2026",
+            source_id="ERL-CYBER-WEB-HISTORY-CERN",
+            intr_receipt=receipt,
+            payload=payload,
+            kv_root=kv,
+            kv_instance_id="MYKV-TEST",
+            captured_at="2026-09-10T20:00:00Z",
+        )


### PR DESCRIPTION
Continues SS-EVIDENCE-COMPARISON-001 after merged PR #154. Adds a fail-closed active-research acquisition consumer that requires a canonical InTr hop receipt bound to the exact acquisition envelope, verifies dispatch source/host/MyKV requirements, invokes the existing ERL KV writer for create-only persistence and exact-byte readback, and preserves finding/publication authority as false. Includes regression tests, hosted validation, and an updated active-research MyKV handoff. GitHub remains validation/transport only; authentic Interlock/InTr acquisition-to-real-MyKV execution remains a separate runtime proof boundary.